### PR TITLE
Add Debug Interface Access (DIA) SDK COM wrappers and tests

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,6 +11,7 @@
     <PackageVersion Include="Microsoft.Build" Version="17.14.8" />
     <PackageVersion Include="Microsoft.CodeAnalysis.ResxSourceGenerator" Version="5.0.0-1.25277.114" />
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
+    <PackageVersion Include="Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles" Version="1.0.23" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.300" />
     <PackageVersion Include="Microsoft.Windows.CsWin32" Version="0.3.275" />
     <PackageVersion Include="MinVer" Version="7.0.0" />

--- a/vsinterop.tests/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/DiaSourceTests.cs
+++ b/vsinterop.tests/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/DiaSourceTests.cs
@@ -1,0 +1,153 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using Windows.Win32.Foundation;
+using Windows.Win32.System.Com;
+
+namespace Microsoft.VisualStudio.Debugging.DebugInterfaceAccess;
+
+[TestClass]
+public unsafe class DiaSourceTests
+{
+    private static string TestPdbPath => Path.ChangeExtension(typeof(DiaSourceTests).Assembly.Location, ".pdb");
+
+    [TestMethod]
+    public void CanCreateDiaSourceFactory()
+    {
+        using ComClassFactory factory = Msdia.CreateFactory(CLASSID.DiaSource);
+        Assert.AreEqual(CLASSID.DiaSource, factory.ClassId);
+    }
+
+    [TestMethod]
+    public void CanCreateIDiaDataSource()
+    {
+        using ComClassFactory factory = Msdia.CreateFactory(CLASSID.DiaSource);
+        using var dataSource = factory.CreateInstance<IDiaDataSource>();
+        Assert.IsFalse(dataSource.IsNull);
+    }
+
+    [TestMethod]
+    public void LoadDataFromPdb_NonExistentPath_Fails()
+    {
+        using ComClassFactory factory = Msdia.CreateFactory(CLASSID.DiaSource);
+        using var dataSource = factory.CreateInstance<IDiaDataSource>();
+
+        string missing = Path.Combine(AppContext.BaseDirectory, "this_file_does_not_exist.pdb");
+
+        HRESULT result;
+        fixed (char* path = missing)
+        {
+            result = dataSource.Pointer->loadDataFromPdb(path);
+        }
+
+        Assert.IsTrue(result.Failed, "Loading a missing PDB returns a failure HRESULT.");
+    }
+
+    [TestMethod]
+    public void LoadDataFromPdb_OpenSession_GlobalScopeIsExe()
+    {
+        using ComClassFactory factory = Msdia.CreateFactory(CLASSID.DiaSource);
+        using var dataSource = factory.CreateInstance<IDiaDataSource>();
+
+        LoadTestData(dataSource);
+
+        using ComScope<IDiaSession> session = default;
+        dataSource.Pointer->openSession(session).ThrowOnFailure();
+        Assert.IsFalse(session.IsNull);
+
+        using ComScope<IDiaSymbol> globalScope = default;
+        session.Pointer->get_globalScope(globalScope).ThrowOnFailure();
+        Assert.IsFalse(globalScope.IsNull);
+
+        uint symTag;
+        globalScope.Pointer->get_symTag(&symTag).ThrowOnFailure();
+        Assert.AreEqual((uint)SymTagEnum.SymTagExe, symTag);
+    }
+
+    [TestMethod]
+    public void GlobalScope_HasSymbolName()
+    {
+        using ComClassFactory factory = Msdia.CreateFactory(CLASSID.DiaSource);
+        using var dataSource = factory.CreateInstance<IDiaDataSource>();
+
+        LoadTestData(dataSource);
+
+        using ComScope<IDiaSession> session = default;
+        dataSource.Pointer->openSession(session).ThrowOnFailure();
+
+        using ComScope<IDiaSymbol> globalScope = default;
+        session.Pointer->get_globalScope(globalScope).ThrowOnFailure();
+
+        using BSTR name = default;
+        globalScope.Pointer->get_name(&name).ThrowOnFailure();
+        Assert.IsFalse(name.IsNull, "The global (exe) symbol has a name.");
+    }
+
+    [TestMethod]
+    public void FindChildren_EnumeratesCompilands()
+    {
+        using ComClassFactory factory = Msdia.CreateFactory(CLASSID.DiaSource);
+        using var dataSource = factory.CreateInstance<IDiaDataSource>();
+
+        LoadTestData(dataSource);
+
+        using ComScope<IDiaSession> session = default;
+        dataSource.Pointer->openSession(session).ThrowOnFailure();
+
+        using ComScope<IDiaSymbol> globalScope = default;
+        session.Pointer->get_globalScope(globalScope).ThrowOnFailure();
+
+        using ComScope<IDiaEnumSymbols> compilands = default;
+        globalScope.Pointer->findChildren(
+            SymTagEnum.SymTagCompiland,
+            name: default,
+            compareFlags: 0,
+            compilands).ThrowOnFailure();
+        Assert.IsFalse(compilands.IsNull);
+
+        int count;
+        compilands.Pointer->get_Count(&count).ThrowOnFailure();
+        Assert.IsTrue(count > 0, "The module has at least one compiland.");
+
+        using ComScope<IDiaSymbol> compiland = default;
+        uint fetched;
+        compilands.Pointer->Next(1, compiland, &fetched).ThrowOnFailure();
+        Assert.AreEqual(1u, fetched);
+
+        uint symTag;
+        compiland.Pointer->get_symTag(&symTag).ThrowOnFailure();
+        Assert.AreEqual((uint)SymTagEnum.SymTagCompiland, symTag);
+    }
+
+    [TestMethod]
+    public void GetEnumTables_ReturnsTables()
+    {
+        using ComClassFactory factory = Msdia.CreateFactory(CLASSID.DiaSource);
+        using var dataSource = factory.CreateInstance<IDiaDataSource>();
+
+        LoadTestData(dataSource);
+
+        using ComScope<IDiaSession> session = default;
+        dataSource.Pointer->openSession(session).ThrowOnFailure();
+
+        using ComScope<IDiaEnumTables> tables = default;
+        session.Pointer->getEnumTables(tables).ThrowOnFailure();
+        Assert.IsFalse(tables.IsNull);
+
+        int count;
+        tables.Pointer->get_Count(&count).ThrowOnFailure();
+        Assert.IsTrue(count > 0, "A session exposes at least one table.");
+    }
+
+    private static void LoadTestData(ComScope<IDiaDataSource> dataSource)
+    {
+        string pdbPath = TestPdbPath;
+        Assert.IsTrue(File.Exists(pdbPath), $"Test PDB not found at '{pdbPath}'.");
+
+        fixed (char* path = pdbPath)
+        {
+            dataSource.Pointer->loadDataFromPdb(path).ThrowOnFailure();
+        }
+    }
+}

--- a/vsinterop.tests/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/Msdia.cs
+++ b/vsinterop.tests/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/Msdia.cs
@@ -1,0 +1,45 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Runtime.InteropServices;
+using Windows.Win32.Foundation;
+using Windows.Win32.System.Com;
+using Windows.Win32.System.LibraryLoader;
+
+namespace Microsoft.VisualStudio.Debugging.DebugInterfaceAccess;
+
+/// <summary>
+///  Loads the architecture-appropriate <c>msdia140.dll</c> (supplied by the
+///  Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles package) and creates DIA class factories from it.
+/// </summary>
+internal static class Msdia
+{
+    /// <summary>
+    ///  The full path to the <c>msdia140.dll</c> that matches the current process architecture.
+    /// </summary>
+    internal static string LibraryPath { get; } = Path.Combine(
+        AppContext.BaseDirectory,
+        "Dia",
+        RuntimeInformation.ProcessArchitecture switch
+        {
+            Architecture.X64 => "amd64",
+            Architecture.X86 => "x86",
+            Architecture.Arm64 => "arm64",
+            _ => throw new PlatformNotSupportedException(
+                $"msdia140.dll is not available for {RuntimeInformation.ProcessArchitecture}.")
+        },
+        "msdia140.dll");
+
+    // msdia140.dll has a static dependency on the Visual C++ runtime (msvcp140.dll, vcruntime140*.dll), which
+    // the package places next to it. Loading with LOAD_WITH_ALTERED_SEARCH_PATH makes Windows resolve those
+    // dependencies from the DLL's own directory rather than the application directory.
+    private static readonly Lazy<HMODULE> s_module = new(static () =>
+        HMODULE.LoadModule(LibraryPath, LOAD_LIBRARY_FLAGS.LOAD_WITH_ALTERED_SEARCH_PATH));
+
+    /// <summary>
+    ///  Creates a <see cref="ComClassFactory"/> for the given DIA class, loading <c>msdia140.dll</c> on first use.
+    /// </summary>
+    /// <param name="classId">The CLSID of the DIA coclass, for example <see cref="CLASSID.DiaSource"/>.</param>
+    internal static ComClassFactory CreateFactory(Guid classId) => new(s_module.Value, classId);
+}

--- a/vsinterop.tests/vsinterop.tests.csproj
+++ b/vsinterop.tests/vsinterop.tests.csproj
@@ -23,7 +23,28 @@
     </PackageReference>
     <PackageReference Include="MSTest" />
     <PackageReference Include="AwesomeAssertions" />
+
+    <!--
+      Provides the native msdia140.dll (Debug Interface Access) binaries for each architecture under
+      lib/native/<arch>. We don't want the managed Dia2Lib.dll interop assembly the package also carries,
+      so all assets are excluded; GeneratePathProperty still gives us the restored package location for
+      the copy target below.
+    -->
+    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles" GeneratePathProperty="true" ExcludeAssets="all" />
   </ItemGroup>
+
+  <!--
+    Copy the DIA native binaries (msdia140.dll and its CRT dependencies) for every architecture into a
+    Dia/<arch> folder next to the test assembly. Tests load the architecture-appropriate copy at runtime.
+  -->
+  <Target Name="CopyDiaNativeBinaries" AfterTargets="Build">
+    <ItemGroup>
+      <_DiaNativeFile Include="$(PkgMicrosoft_Diagnostics_Tracing_TraceEvent_SupportFiles)\lib\native\**\*.dll" />
+    </ItemGroup>
+    <Copy SourceFiles="@(_DiaNativeFile)"
+          DestinationFiles="@(_DiaNativeFile->'$(OutDir)Dia\%(RecursiveDir)%(Filename)%(Extension)')"
+          SkipUnchangedFiles="true" />
+  </Target>
 
   <ItemGroup>
     <ProjectReference Include="..\vsinterop\vsinterop.csproj" AdditionalProperties="TargetFramework=$(TargetFramework)" />
@@ -34,11 +55,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <EditorConfigFiles Remove="N:\repos\vsinterop\vsinterop.tests\.editorconfig" />
+    <EditorConfigFiles Remove=".editorconfig" />
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="N:\repos\vsinterop\vsinterop.tests\.editorconfig" />
+    <None Include=".editorconfig" />
   </ItemGroup>
 
 </Project>

--- a/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/CLASSID.cs
+++ b/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/CLASSID.cs
@@ -1,0 +1,44 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace Microsoft.VisualStudio.Debugging.DebugInterfaceAccess;
+
+/// <summary>
+///  Class identifiers (CLSIDs) for the Debug Interface Access (DIA) SDK coclasses exposed by msdia*.dll.
+/// </summary>
+/// <remarks>
+///  <para>
+///   Use these with <c>CoCreateInstance</c> or a class factory (for example, by loading <c>msdia140.dll</c>
+///   directly and calling <c>DllGetClassObject</c>) to create the corresponding DIA objects.
+///  </para>
+/// </remarks>
+public static class CLASSID
+{
+    /// <summary>
+    ///  CLSID of the <c>DiaSource</c> class, which provides an <see cref="IDiaDataSource"/> that allocates from
+    ///  the process heap and returns <c>BSTR</c> values that can be freed with the standard <c>SysFreeString</c>.
+    /// </summary>
+    /// <value>The CLSID <c>{E6756135-1E65-4D17-8576-610761398C3C}</c>.</value>
+    public static Guid DiaSource { get; } = new(0xe6756135, 0x1e65, 0x4d17, 0x85, 0x76, 0x61, 0x07, 0x61, 0x39, 0x8c, 0x3c);
+
+    /// <summary>
+    ///  CLSID of the <c>DiaSourceAlt</c> class, a variant of <c>DiaSource</c> that does not use the system heap.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   A process may create either <c>DiaSourceAlt</c> objects or <c>DiaSource</c> objects, but not both. When
+    ///   using <c>DiaSourceAlt</c>, all returned <c>BSTR</c> values are really <c>LPCOLESTR</c> and must be released
+    ///   with <c>LocalFree</c> rather than the usual <c>BSTR</c> routines.
+    ///  </para>
+    /// </remarks>
+    /// <value>The CLSID <c>{91904831-49CA-4766-B95C-25397E2DD6DC}</c>.</value>
+    public static Guid DiaSourceAlt { get; } = new(0x91904831, 0x49ca, 0x4766, 0xb9, 0x5c, 0x25, 0x39, 0x7e, 0x2d, 0xd6, 0xdc);
+
+    /// <summary>
+    ///  CLSID of the <c>DiaStackWalker</c> class, which provides an <see cref="IDiaStackWalker"/> for performing
+    ///  general stack walks.
+    /// </summary>
+    /// <value>The CLSID <c>{CE4A85DB-5768-475B-A4E1-C0BCA2112A6B}</c>.</value>
+    public static Guid DiaStackWalker { get; } = new(0xce4a85db, 0x5768, 0x475b, 0xa4, 0xe1, 0x0c, 0xbc, 0xa2, 0x11, 0x2a, 0x6b);
+}

--- a/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/CV_CPU_TYPE_e.cs
+++ b/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/CV_CPU_TYPE_e.cs
@@ -1,0 +1,225 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace Microsoft.VisualStudio.Debugging.DebugInterfaceAccess;
+
+/// <summary>
+///  Identifies the processor (CPU) type.
+/// </summary>
+/// <remarks>
+///  <para>
+///   <see href="https://learn.microsoft.com/visualstudio/debugger/debug-interface-access/cv-cpu-type-e">
+///    Official documentation.
+///   </see>
+///  </para>
+/// </remarks>
+public enum CV_CPU_TYPE_e
+{
+    /// <summary>Intel 8080.</summary>
+    CV_CFL_8080 = 0x00,
+
+    /// <summary>Intel 8086.</summary>
+    CV_CFL_8086 = 0x01,
+
+    /// <summary>Intel 80286.</summary>
+    CV_CFL_80286 = 0x02,
+
+    /// <summary>Intel 80386.</summary>
+    CV_CFL_80386 = 0x03,
+
+    /// <summary>Intel 80486.</summary>
+    CV_CFL_80486 = 0x04,
+
+    /// <summary>Intel Pentium.</summary>
+    CV_CFL_PENTIUM = 0x05,
+
+    /// <summary>Intel Pentium II.</summary>
+    CV_CFL_PENTIUMII = 0x06,
+
+    /// <summary>Intel Pentium Pro.</summary>
+    CV_CFL_PENTIUMPRO = CV_CFL_PENTIUMII,
+
+    /// <summary>Intel Pentium III.</summary>
+    CV_CFL_PENTIUMIII = 0x07,
+
+    /// <summary>MIPS.</summary>
+    CV_CFL_MIPS = 0x10,
+
+    /// <summary>MIPS R4000.</summary>
+    CV_CFL_MIPSR4000 = CV_CFL_MIPS,
+
+    /// <summary>MIPS16.</summary>
+    CV_CFL_MIPS16 = 0x11,
+
+    /// <summary>MIPS32.</summary>
+    CV_CFL_MIPS32 = 0x12,
+
+    /// <summary>MIPS64.</summary>
+    CV_CFL_MIPS64 = 0x13,
+
+    /// <summary>MIPS I.</summary>
+    CV_CFL_MIPSI = 0x14,
+
+    /// <summary>MIPS II.</summary>
+    CV_CFL_MIPSII = 0x15,
+
+    /// <summary>MIPS III.</summary>
+    CV_CFL_MIPSIII = 0x16,
+
+    /// <summary>MIPS IV.</summary>
+    CV_CFL_MIPSIV = 0x17,
+
+    /// <summary>MIPS V.</summary>
+    CV_CFL_MIPSV = 0x18,
+
+    /// <summary>Motorola 68000.</summary>
+    CV_CFL_M68000 = 0x20,
+
+    /// <summary>Motorola 68010.</summary>
+    CV_CFL_M68010 = 0x21,
+
+    /// <summary>Motorola 68020.</summary>
+    CV_CFL_M68020 = 0x22,
+
+    /// <summary>Motorola 68030.</summary>
+    CV_CFL_M68030 = 0x23,
+
+    /// <summary>Motorola 68040.</summary>
+    CV_CFL_M68040 = 0x24,
+
+    /// <summary>DEC Alpha.</summary>
+    CV_CFL_ALPHA = 0x30,
+
+    /// <summary>DEC Alpha 21064.</summary>
+    CV_CFL_ALPHA_21064 = 0x30,
+
+    /// <summary>DEC Alpha 21164.</summary>
+    CV_CFL_ALPHA_21164 = 0x31,
+
+    /// <summary>DEC Alpha 21164A.</summary>
+    CV_CFL_ALPHA_21164A = 0x32,
+
+    /// <summary>DEC Alpha 21264.</summary>
+    CV_CFL_ALPHA_21264 = 0x33,
+
+    /// <summary>DEC Alpha 21364.</summary>
+    CV_CFL_ALPHA_21364 = 0x34,
+
+    /// <summary>PowerPC 601.</summary>
+    CV_CFL_PPC601 = 0x40,
+
+    /// <summary>PowerPC 603.</summary>
+    CV_CFL_PPC603 = 0x41,
+
+    /// <summary>PowerPC 604.</summary>
+    CV_CFL_PPC604 = 0x42,
+
+    /// <summary>PowerPC 620.</summary>
+    CV_CFL_PPC620 = 0x43,
+
+    /// <summary>PowerPC with floating point.</summary>
+    CV_CFL_PPCFP = 0x44,
+
+    /// <summary>PowerPC big-endian.</summary>
+    CV_CFL_PPCBE = 0x45,
+
+    /// <summary>Hitachi SH3.</summary>
+    CV_CFL_SH3 = 0x50,
+
+    /// <summary>Hitachi SH3E.</summary>
+    CV_CFL_SH3E = 0x51,
+
+    /// <summary>Hitachi SH3 DSP.</summary>
+    CV_CFL_SH3DSP = 0x52,
+
+    /// <summary>Hitachi SH4.</summary>
+    CV_CFL_SH4 = 0x53,
+
+    /// <summary>Hitachi SH media.</summary>
+    CV_CFL_SHMEDIA = 0x54,
+
+    /// <summary>ARM 3.</summary>
+    CV_CFL_ARM3 = 0x60,
+
+    /// <summary>ARM 4.</summary>
+    CV_CFL_ARM4 = 0x61,
+
+    /// <summary>ARM 4T.</summary>
+    CV_CFL_ARM4T = 0x62,
+
+    /// <summary>ARM 5.</summary>
+    CV_CFL_ARM5 = 0x63,
+
+    /// <summary>ARM 5T.</summary>
+    CV_CFL_ARM5T = 0x64,
+
+    /// <summary>ARM 6.</summary>
+    CV_CFL_ARM6 = 0x65,
+
+    /// <summary>ARM XMAC.</summary>
+    CV_CFL_ARM_XMAC = 0x66,
+
+    /// <summary>ARM WMMX.</summary>
+    CV_CFL_ARM_WMMX = 0x67,
+
+    /// <summary>ARM 7.</summary>
+    CV_CFL_ARM7 = 0x68,
+
+    /// <summary>Omni.</summary>
+    CV_CFL_OMNI = 0x70,
+
+    /// <summary>Intel IA64.</summary>
+    CV_CFL_IA64 = 0x80,
+
+    /// <summary>Intel IA64 (variant 1).</summary>
+    CV_CFL_IA64_1 = 0x80,
+
+    /// <summary>Intel IA64 (variant 2).</summary>
+    CV_CFL_IA64_2 = 0x81,
+
+    /// <summary>Common Language Runtime (managed).</summary>
+    CV_CFL_CEE = 0x90,
+
+    /// <summary>Matsushita AM33.</summary>
+    CV_CFL_AM33 = 0xA0,
+
+    /// <summary>Mitsubishi M32R.</summary>
+    CV_CFL_M32R = 0xB0,
+
+    /// <summary>Infineon TriCore.</summary>
+    CV_CFL_TRICORE = 0xC0,
+
+    /// <summary>x64 (AMD64 / Intel 64).</summary>
+    CV_CFL_X64 = 0xD0,
+
+    /// <summary>AMD64.</summary>
+    CV_CFL_AMD64 = CV_CFL_X64,
+
+    /// <summary>EFI byte code.</summary>
+    CV_CFL_EBC = 0xE0,
+
+    /// <summary>ARM Thumb.</summary>
+    CV_CFL_THUMB = 0xF0,
+
+    /// <summary>ARM (NT).</summary>
+    CV_CFL_ARMNT = 0xF4,
+
+    /// <summary>ARM64.</summary>
+    CV_CFL_ARM64 = 0xF6,
+
+    /// <summary>Hybrid x86 on ARM64.</summary>
+    CV_CFL_HYBRID_X86_ARM64 = 0xF7,
+
+    /// <summary>ARM64EC.</summary>
+    CV_CFL_ARM64EC = 0xF8,
+
+    /// <summary>ARM64X.</summary>
+    CV_CFL_ARM64X = 0xF9,
+
+    /// <summary>Unknown processor type.</summary>
+    CV_CFL_UNKNOWN = 0xFF,
+
+    /// <summary>Direct3D 11 shader.</summary>
+    CV_CFL_D3D11_SHADER = 0x100
+}

--- a/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/DiaAddressMapEntry.cs
+++ b/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/DiaAddressMapEntry.cs
@@ -1,0 +1,26 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace Microsoft.VisualStudio.Debugging.DebugInterfaceAccess;
+
+// Interop structure: the public fields mirror the native memory layout and are read and written
+// directly by callers and passed by pointer to native code, so visible fields are required.
+#pragma warning disable CA1051 // Do not declare visible instance fields
+
+/// <summary>
+///  Describes a single entry in an address map used by <see cref="IDiaAddressMap"/> to translate
+///  between two relative virtual address (RVA) spaces.
+/// </summary>
+public struct DiaAddressMapEntry
+{
+    /// <summary>
+    ///  The source relative virtual address.
+    /// </summary>
+    public uint rva;
+
+    /// <summary>
+    ///  The relative virtual address that <see cref="rva"/> maps to.
+    /// </summary>
+    public uint rvaTo;
+}

--- a/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/DiaTagValue.cs
+++ b/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/DiaTagValue.cs
@@ -1,0 +1,30 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace Microsoft.VisualStudio.Debugging.DebugInterfaceAccess;
+
+// Interop structure: the public fields mirror the native memory layout and are read and written
+// directly by callers and passed by pointer to native code, so visible fields are required.
+#pragma warning disable CA1051 // Do not declare visible instance fields
+
+/// <summary>
+///  Holds a numeric value obtained from a tagged union, which can be 8, 16, 32, 64 or 128 bits in size.
+/// </summary>
+/// <remarks>
+///  <para>
+///   <see cref="valueSizeBytes"/> contains the size, in bytes, of the data stored in <see cref="value"/>.
+///  </para>
+/// </remarks>
+public unsafe struct DiaTagValue
+{
+    /// <summary>
+    ///  The raw value bytes. Up to 16 bytes (128 bits) are valid.
+    /// </summary>
+    public fixed byte value[16];
+
+    /// <summary>
+    ///  The number of valid bytes stored in <see cref="value"/>.
+    /// </summary>
+    public byte valueSizeBytes;
+}

--- a/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaAddressMap.cs
+++ b/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaAddressMap.cs
@@ -1,0 +1,204 @@
+﻿// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Runtime.InteropServices;
+
+// For some reason the XML comment refs for IUnknown can't be resolved on .NET Framework without
+// explicitly using the fully qualified name, which falls afoul of the simplify warning.
+using ComIUnknown = Windows.Win32.System.Com.IUnknown;
+
+namespace Microsoft.VisualStudio.Debugging.DebugInterfaceAccess;
+
+/// <inheritdoc cref="Interface"/>
+public unsafe struct IDiaAddressMap : IComIID
+{
+    /// <inheritdoc cref="IComIID.Guid"/>
+#pragma warning disable IDE1006 // Naming Styles
+    public static readonly Guid IID_Guid = new(0xB62A2E7A, 0x067A, 0x4EA3, 0xB5, 0x98, 0x04, 0xC0, 0x97, 0x17, 0x50, 0x2C);
+#pragma warning restore IDE1006
+
+#if NETFRAMEWORK
+    readonly ref readonly Guid IComIID.Guid => ref IID_Guid;
+#else
+    static ref readonly Guid IComIID.Guid
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get
+        {
+            ReadOnlySpan<byte> data =
+            [
+                0x7A, 0x2E, 0x2A, 0xB6,
+                0x7A, 0x06,
+                0xA3, 0x4E,
+                0xB5, 0x98, 0x04, 0xC0, 0x97, 0x17, 0x50, 0x2C
+            ];
+
+            return ref Unsafe.As<byte, Guid>(ref MemoryMarshal.GetReference(data));
+        }
+    }
+#endif
+
+    private readonly void** _lpVtbl;
+
+    /// <inheritdoc cref="ComIUnknown.QueryInterface(Guid*, void**)"/>
+    public HRESULT QueryInterface(Guid* riid, void** ppvObject)
+    {
+        fixed (IDiaAddressMap* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaAddressMap*, Guid*, void**, HRESULT>)_lpVtbl[0])(pThis, riid, ppvObject);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.AddRef"/>
+    public uint AddRef()
+    {
+        fixed (IDiaAddressMap* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaAddressMap*, uint>)_lpVtbl[1])(pThis);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.Release"/>
+    public uint Release()
+    {
+        fixed (IDiaAddressMap* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaAddressMap*, uint>)_lpVtbl[2])(pThis);
+    }
+
+    /// <inheritdoc cref="Interface.get_addressMapEnabled"/>
+    public HRESULT get_addressMapEnabled(BOOL* pRetVal)
+    {
+        fixed (IDiaAddressMap* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaAddressMap*, BOOL*, HRESULT>)_lpVtbl[3])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.put_addressMapEnabled"/>
+    public HRESULT put_addressMapEnabled(BOOL NewVal)
+    {
+        fixed (IDiaAddressMap* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaAddressMap*, BOOL, HRESULT>)_lpVtbl[4])(pThis, NewVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_relativeVirtualAddressEnabled"/>
+    public HRESULT get_relativeVirtualAddressEnabled(BOOL* pRetVal)
+    {
+        fixed (IDiaAddressMap* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaAddressMap*, BOOL*, HRESULT>)_lpVtbl[5])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.put_relativeVirtualAddressEnabled"/>
+    public HRESULT put_relativeVirtualAddressEnabled(BOOL NewVal)
+    {
+        fixed (IDiaAddressMap* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaAddressMap*, BOOL, HRESULT>)_lpVtbl[6])(pThis, NewVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_imageAlign"/>
+    public HRESULT get_imageAlign(uint* pRetVal)
+    {
+        fixed (IDiaAddressMap* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaAddressMap*, uint*, HRESULT>)_lpVtbl[7])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.put_imageAlign"/>
+    public HRESULT put_imageAlign(uint NewVal)
+    {
+        fixed (IDiaAddressMap* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaAddressMap*, uint, HRESULT>)_lpVtbl[8])(pThis, NewVal);
+    }
+
+    /// <inheritdoc cref="Interface.set_imageHeaders"/>
+    public HRESULT set_imageHeaders(uint cbData, byte* pbData, BOOL originalHeaders)
+    {
+        fixed (IDiaAddressMap* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaAddressMap*, uint, byte*, BOOL, HRESULT>)_lpVtbl[9])(pThis, cbData, pbData, originalHeaders);
+    }
+
+    /// <inheritdoc cref="Interface.set_addressMap"/>
+    public HRESULT set_addressMap(uint cData, DiaAddressMapEntry* pData, BOOL imageToSymbols)
+    {
+        fixed (IDiaAddressMap* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaAddressMap*, uint, DiaAddressMapEntry*, BOOL, HRESULT>)_lpVtbl[10])(pThis, cData, pData, imageToSymbols);
+    }
+
+    /// <summary>
+    ///  Controls how the DIA SDK maps between relative virtual addresses and image offsets.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/visualstudio/debugger/debug-interface-access/idiaaddressmap">
+    ///    Official documentation.
+    ///   </see>
+    ///  </para>
+    /// </remarks>
+    [ComImport]
+    [Guid("B62A2E7A-067A-4EA3-B598-04C09717502C")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    public unsafe interface Interface
+    {
+        /// <summary>
+        ///  Enable address translations.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_addressMapEnabled(BOOL* pRetVal);
+
+        /// <summary>
+        ///  Enable address translations.
+        /// </summary>
+        /// <param name="NewVal">The NewVal value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT put_addressMapEnabled(BOOL NewVal);
+
+        /// <summary>
+        ///  Enable relative virtual address computations.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_relativeVirtualAddressEnabled(BOOL* pRetVal);
+
+        /// <summary>
+        ///  Enable relative virtual address computations.
+        /// </summary>
+        /// <param name="NewVal">The NewVal value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT put_relativeVirtualAddressEnabled(BOOL NewVal);
+
+        /// <summary>
+        ///  Original image alignment.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_imageAlign(uint* pRetVal);
+
+        /// <summary>
+        ///  Original image alignment.
+        /// </summary>
+        /// <param name="NewVal">The NewVal value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT put_imageAlign(uint NewVal);
+
+        /// <summary>
+        ///  Set image headers.
+        /// </summary>
+        /// <param name="cbData">The size, in bytes, of the buffer.</param>
+        /// <param name="pbData">Pointer to a buffer that contains the input data.</param>
+        /// <param name="originalHeaders">The originalHeaders value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT set_imageHeaders(uint cbData, byte* pbData, BOOL originalHeaders);
+
+        /// <summary>
+        ///  Set address map.
+        /// </summary>
+        /// <param name="cData">The cData value.</param>
+        /// <param name="pData">Pointer to a buffer that contains the input data.</param>
+        /// <param name="imageToSymbols">The imageToSymbols value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT set_addressMap(uint cData, DiaAddressMapEntry* pData, BOOL imageToSymbols);
+    }
+}

--- a/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaDataSource.cs
+++ b/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaDataSource.cs
@@ -1,0 +1,216 @@
+﻿// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Runtime.InteropServices;
+
+// For some reason the XML comment refs for IUnknown can't be resolved on .NET Framework without
+// explicitly using the fully qualified name, which falls afoul of the simplify warning.
+using ComIUnknown = Windows.Win32.System.Com.IUnknown;
+
+namespace Microsoft.VisualStudio.Debugging.DebugInterfaceAccess;
+
+/// <inheritdoc cref="Interface"/>
+public unsafe struct IDiaDataSource : IComIID
+{
+    /// <inheritdoc cref="IComIID.Guid"/>
+#pragma warning disable IDE1006 // Naming Styles
+    public static readonly Guid IID_Guid = new(0x79F1BB5F, 0xB66E, 0x48E5, 0xB6, 0xA9, 0x15, 0x45, 0xC3, 0x23, 0xCA, 0x3D);
+#pragma warning restore IDE1006
+
+#if NETFRAMEWORK
+    readonly ref readonly Guid IComIID.Guid => ref IID_Guid;
+#else
+    static ref readonly Guid IComIID.Guid
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get
+        {
+            ReadOnlySpan<byte> data =
+            [
+                0x5F, 0xBB, 0xF1, 0x79,
+                0x6E, 0xB6,
+                0xE5, 0x48,
+                0xB6, 0xA9, 0x15, 0x45, 0xC3, 0x23, 0xCA, 0x3D
+            ];
+
+            return ref Unsafe.As<byte, Guid>(ref MemoryMarshal.GetReference(data));
+        }
+    }
+#endif
+
+    private readonly void** _lpVtbl;
+
+    /// <inheritdoc cref="ComIUnknown.QueryInterface(Guid*, void**)"/>
+    public HRESULT QueryInterface(Guid* riid, void** ppvObject)
+    {
+        fixed (IDiaDataSource* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaDataSource*, Guid*, void**, HRESULT>)_lpVtbl[0])(pThis, riid, ppvObject);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.AddRef"/>
+    public uint AddRef()
+    {
+        fixed (IDiaDataSource* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaDataSource*, uint>)_lpVtbl[1])(pThis);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.Release"/>
+    public uint Release()
+    {
+        fixed (IDiaDataSource* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaDataSource*, uint>)_lpVtbl[2])(pThis);
+    }
+
+    /// <inheritdoc cref="Interface.get_lastError"/>
+    public HRESULT get_lastError(BSTR* pRetVal)
+    {
+        fixed (IDiaDataSource* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaDataSource*, BSTR*, HRESULT>)_lpVtbl[3])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.loadDataFromPdb"/>
+    public HRESULT loadDataFromPdb(PCWSTR pdbPath)
+    {
+        fixed (IDiaDataSource* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaDataSource*, PCWSTR, HRESULT>)_lpVtbl[4])(pThis, pdbPath);
+    }
+
+    /// <inheritdoc cref="Interface.loadAndValidateDataFromPdb"/>
+    public HRESULT loadAndValidateDataFromPdb(PCWSTR pdbPath, Guid* pcsig70, uint sig, uint age)
+    {
+        fixed (IDiaDataSource* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaDataSource*, PCWSTR, Guid*, uint, uint, HRESULT>)_lpVtbl[5])(pThis, pdbPath, pcsig70, sig, age);
+    }
+
+    /// <inheritdoc cref="Interface.loadDataForExe"/>
+    public HRESULT loadDataForExe(PCWSTR executable, PCWSTR searchPath, IUnknown* pCallback)
+    {
+        fixed (IDiaDataSource* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaDataSource*, PCWSTR, PCWSTR, IUnknown*, HRESULT>)_lpVtbl[6])(pThis, executable, searchPath, pCallback);
+    }
+
+    /// <inheritdoc cref="Interface.loadDataFromIStream"/>
+    public HRESULT loadDataFromIStream(IStream* pIStream)
+    {
+        fixed (IDiaDataSource* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaDataSource*, IStream*, HRESULT>)_lpVtbl[7])(pThis, pIStream);
+    }
+
+    /// <inheritdoc cref="Interface.openSession"/>
+    public HRESULT openSession(IDiaSession** ppSession)
+    {
+        fixed (IDiaDataSource* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaDataSource*, IDiaSession**, HRESULT>)_lpVtbl[8])(pThis, ppSession);
+    }
+
+    /// <inheritdoc cref="Interface.loadDataFromCodeViewInfo"/>
+    public HRESULT loadDataFromCodeViewInfo(PCWSTR executable, PCWSTR searchPath, uint cbCvInfo, byte* pbCvInfo, IUnknown* pCallback)
+    {
+        fixed (IDiaDataSource* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaDataSource*, PCWSTR, PCWSTR, uint, byte*, IUnknown*, HRESULT>)_lpVtbl[9])(pThis, executable, searchPath, cbCvInfo, pbCvInfo, pCallback);
+    }
+
+    /// <inheritdoc cref="Interface.loadDataFromMiscInfo"/>
+    public HRESULT loadDataFromMiscInfo(PCWSTR executable, PCWSTR searchPath, uint timeStampExe, uint timeStampDbg, uint sizeOfExe, uint cbMiscInfo, byte* pbMiscInfo, IUnknown* pCallback)
+    {
+        fixed (IDiaDataSource* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaDataSource*, PCWSTR, PCWSTR, uint, uint, uint, uint, byte*, IUnknown*, HRESULT>)_lpVtbl[10])(pThis, executable, searchPath, timeStampExe, timeStampDbg, sizeOfExe, cbMiscInfo, pbMiscInfo, pCallback);
+    }
+
+    /// <summary>
+    ///  Initiates access to a source of debugging symbols.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/visualstudio/debugger/debug-interface-access/idiadatasource">
+    ///    Official documentation.
+    ///   </see>
+    ///  </para>
+    /// </remarks>
+    [ComImport]
+    [Guid("79F1BB5F-B66E-48E5-B6A9-1545C323CA3D")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    public unsafe interface Interface
+    {
+        /// <summary>
+        ///  Text for last load error.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_lastError(BSTR* pRetVal);
+
+        /// <summary>
+        ///  Load data from pdb.
+        /// </summary>
+        /// <param name="pdbPath">The pdbPath value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT loadDataFromPdb(PCWSTR pdbPath);
+
+        /// <summary>
+        ///  Load and validate data from pdb.
+        /// </summary>
+        /// <param name="pdbPath">The pdbPath value.</param>
+        /// <param name="pcsig70">The pcsig70 value.</param>
+        /// <param name="sig">The sig value.</param>
+        /// <param name="age">The age value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT loadAndValidateDataFromPdb(PCWSTR pdbPath, Guid* pcsig70, uint sig, uint age);
+
+        /// <summary>
+        ///  Load data for exe.
+        /// </summary>
+        /// <param name="executable">The executable value.</param>
+        /// <param name="searchPath">The searchPath value.</param>
+        /// <param name="pCallback">The pCallback value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT loadDataForExe(PCWSTR executable, PCWSTR searchPath, IUnknown* pCallback);
+
+        /// <summary>
+        ///  Load data from istream.
+        /// </summary>
+        /// <param name="pIStream">The pIStream value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT loadDataFromIStream(IStream* pIStream);
+
+        /// <summary>
+        ///  Open session.
+        /// </summary>
+        /// <param name="ppSession">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT openSession(IDiaSession** ppSession);
+
+        /// <summary>
+        ///  Load data from code view info.
+        /// </summary>
+        /// <param name="executable">The executable value.</param>
+        /// <param name="searchPath">The searchPath value.</param>
+        /// <param name="cbCvInfo">The size, in bytes, of the buffer.</param>
+        /// <param name="pbCvInfo">Pointer to a buffer that contains the input data.</param>
+        /// <param name="pCallback">The pCallback value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT loadDataFromCodeViewInfo(PCWSTR executable, PCWSTR searchPath, uint cbCvInfo, byte* pbCvInfo, IUnknown* pCallback);
+
+        /// <summary>
+        ///  Load data from misc info.
+        /// </summary>
+        /// <param name="executable">The executable value.</param>
+        /// <param name="searchPath">The searchPath value.</param>
+        /// <param name="timeStampExe">The timeStampExe value.</param>
+        /// <param name="timeStampDbg">The timeStampDbg value.</param>
+        /// <param name="sizeOfExe">The sizeOfExe value.</param>
+        /// <param name="cbMiscInfo">The size, in bytes, of the buffer.</param>
+        /// <param name="pbMiscInfo">Pointer to a buffer that contains the input data.</param>
+        /// <param name="pCallback">The pCallback value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT loadDataFromMiscInfo(PCWSTR executable, PCWSTR searchPath, uint timeStampExe, uint timeStampDbg, uint sizeOfExe, uint cbMiscInfo, byte* pbMiscInfo, IUnknown* pCallback);
+    }
+}

--- a/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaDataSourceEx.cs
+++ b/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaDataSourceEx.cs
@@ -1,0 +1,275 @@
+﻿// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Runtime.InteropServices;
+
+// For some reason the XML comment refs for IUnknown can't be resolved on .NET Framework without
+// explicitly using the fully qualified name, which falls afoul of the simplify warning.
+using ComIUnknown = Windows.Win32.System.Com.IUnknown;
+
+namespace Microsoft.VisualStudio.Debugging.DebugInterfaceAccess;
+
+/// <inheritdoc cref="Interface"/>
+public unsafe struct IDiaDataSourceEx : IComIID
+{
+    /// <inheritdoc cref="IComIID.Guid"/>
+#pragma warning disable IDE1006 // Naming Styles
+    public static readonly Guid IID_Guid = new(0x1A21EB69, 0x962A, 0x4BC4, 0x8B, 0xD3, 0x68, 0x17, 0x97, 0xD3, 0x8B, 0x23);
+#pragma warning restore IDE1006
+
+#if NETFRAMEWORK
+    readonly ref readonly Guid IComIID.Guid => ref IID_Guid;
+#else
+    static ref readonly Guid IComIID.Guid
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get
+        {
+            ReadOnlySpan<byte> data =
+            [
+                0x69, 0xEB, 0x21, 0x1A,
+                0x2A, 0x96,
+                0xC4, 0x4B,
+                0x8B, 0xD3, 0x68, 0x17, 0x97, 0xD3, 0x8B, 0x23
+            ];
+
+            return ref Unsafe.As<byte, Guid>(ref MemoryMarshal.GetReference(data));
+        }
+    }
+#endif
+
+    private readonly void** _lpVtbl;
+
+    /// <inheritdoc cref="ComIUnknown.QueryInterface(Guid*, void**)"/>
+    public HRESULT QueryInterface(Guid* riid, void** ppvObject)
+    {
+        fixed (IDiaDataSourceEx* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaDataSourceEx*, Guid*, void**, HRESULT>)_lpVtbl[0])(pThis, riid, ppvObject);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.AddRef"/>
+    public uint AddRef()
+    {
+        fixed (IDiaDataSourceEx* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaDataSourceEx*, uint>)_lpVtbl[1])(pThis);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.Release"/>
+    public uint Release()
+    {
+        fixed (IDiaDataSourceEx* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaDataSourceEx*, uint>)_lpVtbl[2])(pThis);
+    }
+
+    /// <inheritdoc cref="IDiaDataSource.Interface.get_lastError"/>
+    public HRESULT get_lastError(BSTR* pRetVal)
+    {
+        fixed (IDiaDataSourceEx* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaDataSourceEx*, BSTR*, HRESULT>)_lpVtbl[3])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaDataSource.Interface.loadDataFromPdb"/>
+    public HRESULT loadDataFromPdb(PCWSTR pdbPath)
+    {
+        fixed (IDiaDataSourceEx* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaDataSourceEx*, PCWSTR, HRESULT>)_lpVtbl[4])(pThis, pdbPath);
+    }
+
+    /// <inheritdoc cref="IDiaDataSource.Interface.loadAndValidateDataFromPdb"/>
+    public HRESULT loadAndValidateDataFromPdb(PCWSTR pdbPath, Guid* pcsig70, uint sig, uint age)
+    {
+        fixed (IDiaDataSourceEx* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaDataSourceEx*, PCWSTR, Guid*, uint, uint, HRESULT>)_lpVtbl[5])(pThis, pdbPath, pcsig70, sig, age);
+    }
+
+    /// <inheritdoc cref="IDiaDataSource.Interface.loadDataForExe"/>
+    public HRESULT loadDataForExe(PCWSTR executable, PCWSTR searchPath, IUnknown* pCallback)
+    {
+        fixed (IDiaDataSourceEx* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaDataSourceEx*, PCWSTR, PCWSTR, IUnknown*, HRESULT>)_lpVtbl[6])(pThis, executable, searchPath, pCallback);
+    }
+
+    /// <inheritdoc cref="IDiaDataSource.Interface.loadDataFromIStream"/>
+    public HRESULT loadDataFromIStream(IStream* pIStream)
+    {
+        fixed (IDiaDataSourceEx* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaDataSourceEx*, IStream*, HRESULT>)_lpVtbl[7])(pThis, pIStream);
+    }
+
+    /// <inheritdoc cref="IDiaDataSource.Interface.openSession"/>
+    public HRESULT openSession(IDiaSession** ppSession)
+    {
+        fixed (IDiaDataSourceEx* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaDataSourceEx*, IDiaSession**, HRESULT>)_lpVtbl[8])(pThis, ppSession);
+    }
+
+    /// <inheritdoc cref="IDiaDataSource.Interface.loadDataFromCodeViewInfo"/>
+    public HRESULT loadDataFromCodeViewInfo(PCWSTR executable, PCWSTR searchPath, uint cbCvInfo, byte* pbCvInfo, IUnknown* pCallback)
+    {
+        fixed (IDiaDataSourceEx* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaDataSourceEx*, PCWSTR, PCWSTR, uint, byte*, IUnknown*, HRESULT>)_lpVtbl[9])(pThis, executable, searchPath, cbCvInfo, pbCvInfo, pCallback);
+    }
+
+    /// <inheritdoc cref="IDiaDataSource.Interface.loadDataFromMiscInfo"/>
+    public HRESULT loadDataFromMiscInfo(PCWSTR executable, PCWSTR searchPath, uint timeStampExe, uint timeStampDbg, uint sizeOfExe, uint cbMiscInfo, byte* pbMiscInfo, IUnknown* pCallback)
+    {
+        fixed (IDiaDataSourceEx* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaDataSourceEx*, PCWSTR, PCWSTR, uint, uint, uint, uint, byte*, IUnknown*, HRESULT>)_lpVtbl[10])(pThis, executable, searchPath, timeStampExe, timeStampDbg, sizeOfExe, cbMiscInfo, pbMiscInfo, pCallback);
+    }
+
+    /// <inheritdoc cref="Interface.loadDataFromPdbEx"/>
+    public HRESULT loadDataFromPdbEx(PCWSTR pdbPath, BOOL fPdbPrefetching)
+    {
+        fixed (IDiaDataSourceEx* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaDataSourceEx*, PCWSTR, BOOL, HRESULT>)_lpVtbl[11])(pThis, pdbPath, fPdbPrefetching);
+    }
+
+    /// <inheritdoc cref="Interface.loadAndValidateDataFromPdbEx"/>
+    public HRESULT loadAndValidateDataFromPdbEx(PCWSTR pdbPath, Guid* pcsig70, uint sig, uint age, BOOL fPdbPrefetching)
+    {
+        fixed (IDiaDataSourceEx* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaDataSourceEx*, PCWSTR, Guid*, uint, uint, BOOL, HRESULT>)_lpVtbl[12])(pThis, pdbPath, pcsig70, sig, age, fPdbPrefetching);
+    }
+
+    /// <inheritdoc cref="Interface.loadDataForExeEx"/>
+    public HRESULT loadDataForExeEx(PCWSTR executable, PCWSTR searchPath, IUnknown* pCallback, BOOL fPdbPrefetching)
+    {
+        fixed (IDiaDataSourceEx* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaDataSourceEx*, PCWSTR, PCWSTR, IUnknown*, BOOL, HRESULT>)_lpVtbl[13])(pThis, executable, searchPath, pCallback, fPdbPrefetching);
+    }
+
+    /// <inheritdoc cref="Interface.loadDataFromIStreamEx"/>
+    public HRESULT loadDataFromIStreamEx(IStream* pIStream, BOOL fPdbPrefetching)
+    {
+        fixed (IDiaDataSourceEx* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaDataSourceEx*, IStream*, BOOL, HRESULT>)_lpVtbl[14])(pThis, pIStream, fPdbPrefetching);
+    }
+
+    /// <inheritdoc cref="Interface.getStreamSize"/>
+    public HRESULT getStreamSize(PCWSTR stream, ulong* pcb)
+    {
+        fixed (IDiaDataSourceEx* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaDataSourceEx*, PCWSTR, ulong*, HRESULT>)_lpVtbl[15])(pThis, stream, pcb);
+    }
+
+    /// <inheritdoc cref="Interface.getStreamRawData"/>
+    public HRESULT getStreamRawData(PCWSTR stream, ulong cbOffset, ulong cbRead, ulong* pcbRead, byte* pbData)
+    {
+        fixed (IDiaDataSourceEx* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaDataSourceEx*, PCWSTR, ulong, ulong, ulong*, byte*, HRESULT>)_lpVtbl[16])(pThis, stream, cbOffset, cbRead, pcbRead, pbData);
+    }
+
+    /// <inheritdoc cref="Interface.setPfnMiniPDBErrorCallback2"/>
+    public HRESULT setPfnMiniPDBErrorCallback2(void* pvContext, void* pfn)
+    {
+        fixed (IDiaDataSourceEx* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaDataSourceEx*, void*, void*, HRESULT>)_lpVtbl[17])(pThis, pvContext, pfn);
+    }
+
+    /// <inheritdoc cref="Interface.ValidatePdb"/>
+    public HRESULT ValidatePdb(PCWSTR pdbPath, Guid* pcsig70, uint sig, uint age, BOOL* pfStripped)
+    {
+        fixed (IDiaDataSourceEx* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaDataSourceEx*, PCWSTR, Guid*, uint, uint, BOOL*, HRESULT>)_lpVtbl[18])(pThis, pdbPath, pcsig70, sig, age, pfStripped);
+    }
+
+    /// <summary>
+    ///  Extends IDiaDataSource to allow control of PDB prefetching and raw stream access.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/visualstudio/debugger/debug-interface-access/idiadatasourceex">
+    ///    Official documentation.
+    ///   </see>
+    ///  </para>
+    /// </remarks>
+    [ComImport]
+    [Guid("1A21EB69-962A-4BC4-8BD3-681797D38B23")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    public unsafe interface Interface : IDiaDataSource.Interface
+    {
+        /// <summary>
+        ///  Load data from pdb ex.
+        /// </summary>
+        /// <param name="pdbPath">The pdbPath value.</param>
+        /// <param name="fPdbPrefetching">The fPdbPrefetching value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT loadDataFromPdbEx(PCWSTR pdbPath, BOOL fPdbPrefetching);
+
+        /// <summary>
+        ///  Load and validate data from pdb ex.
+        /// </summary>
+        /// <param name="pdbPath">The pdbPath value.</param>
+        /// <param name="pcsig70">The pcsig70 value.</param>
+        /// <param name="sig">The sig value.</param>
+        /// <param name="age">The age value.</param>
+        /// <param name="fPdbPrefetching">The fPdbPrefetching value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT loadAndValidateDataFromPdbEx(PCWSTR pdbPath, Guid* pcsig70, uint sig, uint age, BOOL fPdbPrefetching);
+
+        /// <summary>
+        ///  Load data for exe ex.
+        /// </summary>
+        /// <param name="executable">The executable value.</param>
+        /// <param name="searchPath">The searchPath value.</param>
+        /// <param name="pCallback">The pCallback value.</param>
+        /// <param name="fPdbPrefetching">The fPdbPrefetching value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT loadDataForExeEx(PCWSTR executable, PCWSTR searchPath, IUnknown* pCallback, BOOL fPdbPrefetching);
+
+        /// <summary>
+        ///  Load data from istream ex.
+        /// </summary>
+        /// <param name="pIStream">The pIStream value.</param>
+        /// <param name="fPdbPrefetching">The fPdbPrefetching value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT loadDataFromIStreamEx(IStream* pIStream, BOOL fPdbPrefetching);
+
+        /// <summary>
+        ///  Get stream size.
+        /// </summary>
+        /// <param name="stream">The stream value.</param>
+        /// <param name="pcb">Pointer to a variable that receives the number of bytes written to the buffer.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT getStreamSize(PCWSTR stream, ulong* pcb);
+
+        /// <summary>
+        ///  Get stream raw data.
+        /// </summary>
+        /// <param name="stream">The stream value.</param>
+        /// <param name="cbOffset">The size, in bytes, of the buffer.</param>
+        /// <param name="cbRead">The size, in bytes, of the buffer.</param>
+        /// <param name="pcbRead">Pointer to a variable that receives the number of bytes written to the buffer.</param>
+        /// <param name="pbData">Pointer to a caller-allocated buffer that receives the data.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT getStreamRawData(PCWSTR stream, ulong cbOffset, ulong cbRead, ulong* pcbRead, byte* pbData);
+
+        /// <summary>
+        ///  Set pfn mini pdberror callback2.
+        /// </summary>
+        /// <param name="pvContext">The pvContext value.</param>
+        /// <param name="pfn">The pfn value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT setPfnMiniPDBErrorCallback2(void* pvContext, void* pfn);
+
+        /// <summary>
+        ///  Validate pdb.
+        /// </summary>
+        /// <param name="pdbPath">The pdbPath value.</param>
+        /// <param name="pcsig70">The pcsig70 value.</param>
+        /// <param name="sig">The sig value.</param>
+        /// <param name="age">The age value.</param>
+        /// <param name="pfStripped">Pointer to a variable that receives the requested value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT ValidatePdb(PCWSTR pdbPath, Guid* pcsig70, uint sig, uint age, BOOL* pfStripped);
+    }
+}

--- a/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaDataSourceEx2.cs
+++ b/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaDataSourceEx2.cs
@@ -1,0 +1,209 @@
+﻿// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Runtime.InteropServices;
+
+// For some reason the XML comment refs for IUnknown can't be resolved on .NET Framework without
+// explicitly using the fully qualified name, which falls afoul of the simplify warning.
+using ComIUnknown = Windows.Win32.System.Com.IUnknown;
+
+namespace Microsoft.VisualStudio.Debugging.DebugInterfaceAccess;
+
+/// <inheritdoc cref="Interface"/>
+public unsafe struct IDiaDataSourceEx2 : IComIID
+{
+    /// <inheritdoc cref="IComIID.Guid"/>
+#pragma warning disable IDE1006 // Naming Styles
+    public static readonly Guid IID_Guid = new(0xD240C8DD, 0x1A0F, 0x456E, 0x80, 0xA6, 0x4F, 0x1D, 0x06, 0xBF, 0x5D, 0xF4);
+#pragma warning restore IDE1006
+
+#if NETFRAMEWORK
+    readonly ref readonly Guid IComIID.Guid => ref IID_Guid;
+#else
+    static ref readonly Guid IComIID.Guid
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get
+        {
+            ReadOnlySpan<byte> data =
+            [
+                0xDD, 0xC8, 0x40, 0xD2,
+                0x0F, 0x1A,
+                0x6E, 0x45,
+                0x80, 0xA6, 0x4F, 0x1D, 0x06, 0xBF, 0x5D, 0xF4
+            ];
+
+            return ref Unsafe.As<byte, Guid>(ref MemoryMarshal.GetReference(data));
+        }
+    }
+#endif
+
+    private readonly void** _lpVtbl;
+
+    /// <inheritdoc cref="ComIUnknown.QueryInterface(Guid*, void**)"/>
+    public HRESULT QueryInterface(Guid* riid, void** ppvObject)
+    {
+        fixed (IDiaDataSourceEx2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaDataSourceEx2*, Guid*, void**, HRESULT>)_lpVtbl[0])(pThis, riid, ppvObject);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.AddRef"/>
+    public uint AddRef()
+    {
+        fixed (IDiaDataSourceEx2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaDataSourceEx2*, uint>)_lpVtbl[1])(pThis);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.Release"/>
+    public uint Release()
+    {
+        fixed (IDiaDataSourceEx2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaDataSourceEx2*, uint>)_lpVtbl[2])(pThis);
+    }
+
+    /// <inheritdoc cref="IDiaDataSource.Interface.get_lastError"/>
+    public HRESULT get_lastError(BSTR* pRetVal)
+    {
+        fixed (IDiaDataSourceEx2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaDataSourceEx2*, BSTR*, HRESULT>)_lpVtbl[3])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaDataSource.Interface.loadDataFromPdb"/>
+    public HRESULT loadDataFromPdb(PCWSTR pdbPath)
+    {
+        fixed (IDiaDataSourceEx2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaDataSourceEx2*, PCWSTR, HRESULT>)_lpVtbl[4])(pThis, pdbPath);
+    }
+
+    /// <inheritdoc cref="IDiaDataSource.Interface.loadAndValidateDataFromPdb"/>
+    public HRESULT loadAndValidateDataFromPdb(PCWSTR pdbPath, Guid* pcsig70, uint sig, uint age)
+    {
+        fixed (IDiaDataSourceEx2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaDataSourceEx2*, PCWSTR, Guid*, uint, uint, HRESULT>)_lpVtbl[5])(pThis, pdbPath, pcsig70, sig, age);
+    }
+
+    /// <inheritdoc cref="IDiaDataSource.Interface.loadDataForExe"/>
+    public HRESULT loadDataForExe(PCWSTR executable, PCWSTR searchPath, IUnknown* pCallback)
+    {
+        fixed (IDiaDataSourceEx2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaDataSourceEx2*, PCWSTR, PCWSTR, IUnknown*, HRESULT>)_lpVtbl[6])(pThis, executable, searchPath, pCallback);
+    }
+
+    /// <inheritdoc cref="IDiaDataSource.Interface.loadDataFromIStream"/>
+    public HRESULT loadDataFromIStream(IStream* pIStream)
+    {
+        fixed (IDiaDataSourceEx2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaDataSourceEx2*, IStream*, HRESULT>)_lpVtbl[7])(pThis, pIStream);
+    }
+
+    /// <inheritdoc cref="IDiaDataSource.Interface.openSession"/>
+    public HRESULT openSession(IDiaSession** ppSession)
+    {
+        fixed (IDiaDataSourceEx2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaDataSourceEx2*, IDiaSession**, HRESULT>)_lpVtbl[8])(pThis, ppSession);
+    }
+
+    /// <inheritdoc cref="IDiaDataSource.Interface.loadDataFromCodeViewInfo"/>
+    public HRESULT loadDataFromCodeViewInfo(PCWSTR executable, PCWSTR searchPath, uint cbCvInfo, byte* pbCvInfo, IUnknown* pCallback)
+    {
+        fixed (IDiaDataSourceEx2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaDataSourceEx2*, PCWSTR, PCWSTR, uint, byte*, IUnknown*, HRESULT>)_lpVtbl[9])(pThis, executable, searchPath, cbCvInfo, pbCvInfo, pCallback);
+    }
+
+    /// <inheritdoc cref="IDiaDataSource.Interface.loadDataFromMiscInfo"/>
+    public HRESULT loadDataFromMiscInfo(PCWSTR executable, PCWSTR searchPath, uint timeStampExe, uint timeStampDbg, uint sizeOfExe, uint cbMiscInfo, byte* pbMiscInfo, IUnknown* pCallback)
+    {
+        fixed (IDiaDataSourceEx2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaDataSourceEx2*, PCWSTR, PCWSTR, uint, uint, uint, uint, byte*, IUnknown*, HRESULT>)_lpVtbl[10])(pThis, executable, searchPath, timeStampExe, timeStampDbg, sizeOfExe, cbMiscInfo, pbMiscInfo, pCallback);
+    }
+
+    /// <inheritdoc cref="IDiaDataSourceEx.Interface.loadDataFromPdbEx"/>
+    public HRESULT loadDataFromPdbEx(PCWSTR pdbPath, BOOL fPdbPrefetching)
+    {
+        fixed (IDiaDataSourceEx2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaDataSourceEx2*, PCWSTR, BOOL, HRESULT>)_lpVtbl[11])(pThis, pdbPath, fPdbPrefetching);
+    }
+
+    /// <inheritdoc cref="IDiaDataSourceEx.Interface.loadAndValidateDataFromPdbEx"/>
+    public HRESULT loadAndValidateDataFromPdbEx(PCWSTR pdbPath, Guid* pcsig70, uint sig, uint age, BOOL fPdbPrefetching)
+    {
+        fixed (IDiaDataSourceEx2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaDataSourceEx2*, PCWSTR, Guid*, uint, uint, BOOL, HRESULT>)_lpVtbl[12])(pThis, pdbPath, pcsig70, sig, age, fPdbPrefetching);
+    }
+
+    /// <inheritdoc cref="IDiaDataSourceEx.Interface.loadDataForExeEx"/>
+    public HRESULT loadDataForExeEx(PCWSTR executable, PCWSTR searchPath, IUnknown* pCallback, BOOL fPdbPrefetching)
+    {
+        fixed (IDiaDataSourceEx2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaDataSourceEx2*, PCWSTR, PCWSTR, IUnknown*, BOOL, HRESULT>)_lpVtbl[13])(pThis, executable, searchPath, pCallback, fPdbPrefetching);
+    }
+
+    /// <inheritdoc cref="IDiaDataSourceEx.Interface.loadDataFromIStreamEx"/>
+    public HRESULT loadDataFromIStreamEx(IStream* pIStream, BOOL fPdbPrefetching)
+    {
+        fixed (IDiaDataSourceEx2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaDataSourceEx2*, IStream*, BOOL, HRESULT>)_lpVtbl[14])(pThis, pIStream, fPdbPrefetching);
+    }
+
+    /// <inheritdoc cref="IDiaDataSourceEx.Interface.getStreamSize"/>
+    public HRESULT getStreamSize(PCWSTR stream, ulong* pcb)
+    {
+        fixed (IDiaDataSourceEx2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaDataSourceEx2*, PCWSTR, ulong*, HRESULT>)_lpVtbl[15])(pThis, stream, pcb);
+    }
+
+    /// <inheritdoc cref="IDiaDataSourceEx.Interface.getStreamRawData"/>
+    public HRESULT getStreamRawData(PCWSTR stream, ulong cbOffset, ulong cbRead, ulong* pcbRead, byte* pbData)
+    {
+        fixed (IDiaDataSourceEx2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaDataSourceEx2*, PCWSTR, ulong, ulong, ulong*, byte*, HRESULT>)_lpVtbl[16])(pThis, stream, cbOffset, cbRead, pcbRead, pbData);
+    }
+
+    /// <inheritdoc cref="IDiaDataSourceEx.Interface.setPfnMiniPDBErrorCallback2"/>
+    public HRESULT setPfnMiniPDBErrorCallback2(void* pvContext, void* pfn)
+    {
+        fixed (IDiaDataSourceEx2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaDataSourceEx2*, void*, void*, HRESULT>)_lpVtbl[17])(pThis, pvContext, pfn);
+    }
+
+    /// <inheritdoc cref="IDiaDataSourceEx.Interface.ValidatePdb"/>
+    public HRESULT ValidatePdb(PCWSTR pdbPath, Guid* pcsig70, uint sig, uint age, BOOL* pfStripped)
+    {
+        fixed (IDiaDataSourceEx2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaDataSourceEx2*, PCWSTR, Guid*, uint, uint, BOOL*, HRESULT>)_lpVtbl[18])(pThis, pdbPath, pcsig70, sig, age, pfStripped);
+    }
+
+    /// <inheritdoc cref="Interface.findNamedStreams"/>
+    public HRESULT findNamedStreams(PCWSTR name, uint compareFlags, IDiaEnumNamedStreams** ppResult)
+    {
+        fixed (IDiaDataSourceEx2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaDataSourceEx2*, PCWSTR, uint, IDiaEnumNamedStreams**, HRESULT>)_lpVtbl[19])(pThis, name, compareFlags, ppResult);
+    }
+
+    /// <summary>
+    ///  Extends IDiaDataSourceEx with additional control over compiler generated PDB error reporting.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/visualstudio/debugger/debug-interface-access/idiadatasourceex2">
+    ///    Official documentation.
+    ///   </see>
+    ///  </para>
+    /// </remarks>
+    [ComImport]
+    [Guid("D240C8DD-1A0F-456E-80A6-4F1D06BF5DF4")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    public unsafe interface Interface : IDiaDataSourceEx.Interface
+    {
+        /// <summary>
+        ///  Find named streams.
+        /// </summary>
+        /// <param name="name">The name value.</param>
+        /// <param name="compareFlags">A combination of name-comparison flags that control how the name is matched.</param>
+        /// <param name="ppResult">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT findNamedStreams(PCWSTR name, uint compareFlags, IDiaEnumNamedStreams** ppResult);
+    }
+}

--- a/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaEnumDebugStreamData.cs
+++ b/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaEnumDebugStreamData.cs
@@ -1,0 +1,206 @@
+﻿// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Runtime.InteropServices;
+
+// For some reason the XML comment refs for IUnknown can't be resolved on .NET Framework without
+// explicitly using the fully qualified name, which falls afoul of the simplify warning.
+using ComIUnknown = Windows.Win32.System.Com.IUnknown;
+
+namespace Microsoft.VisualStudio.Debugging.DebugInterfaceAccess;
+
+/// <inheritdoc cref="Interface"/>
+public unsafe struct IDiaEnumDebugStreamData : IComIID
+{
+    /// <inheritdoc cref="IComIID.Guid"/>
+#pragma warning disable IDE1006 // Naming Styles
+    public static readonly Guid IID_Guid = new(0x486943E8, 0xD187, 0x4A6B, 0xA3, 0xC4, 0x29, 0x12, 0x59, 0xFF, 0xF6, 0x0D);
+#pragma warning restore IDE1006
+
+#if NETFRAMEWORK
+    readonly ref readonly Guid IComIID.Guid => ref IID_Guid;
+#else
+    static ref readonly Guid IComIID.Guid
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get
+        {
+            ReadOnlySpan<byte> data =
+            [
+                0xE8, 0x43, 0x69, 0x48,
+                0x87, 0xD1,
+                0x6B, 0x4A,
+                0xA3, 0xC4, 0x29, 0x12, 0x59, 0xFF, 0xF6, 0x0D
+            ];
+
+            return ref Unsafe.As<byte, Guid>(ref MemoryMarshal.GetReference(data));
+        }
+    }
+#endif
+
+    private readonly void** _lpVtbl;
+
+    /// <inheritdoc cref="ComIUnknown.QueryInterface(Guid*, void**)"/>
+    public HRESULT QueryInterface(Guid* riid, void** ppvObject)
+    {
+        fixed (IDiaEnumDebugStreamData* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumDebugStreamData*, Guid*, void**, HRESULT>)_lpVtbl[0])(pThis, riid, ppvObject);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.AddRef"/>
+    public uint AddRef()
+    {
+        fixed (IDiaEnumDebugStreamData* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumDebugStreamData*, uint>)_lpVtbl[1])(pThis);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.Release"/>
+    public uint Release()
+    {
+        fixed (IDiaEnumDebugStreamData* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumDebugStreamData*, uint>)_lpVtbl[2])(pThis);
+    }
+
+    /// <inheritdoc cref="Interface.get__NewEnum"/>
+    public HRESULT get__NewEnum(IUnknown** pRetVal)
+    {
+        fixed (IDiaEnumDebugStreamData* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumDebugStreamData*, IUnknown**, HRESULT>)_lpVtbl[3])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_Count"/>
+    public HRESULT get_Count(int* pRetVal)
+    {
+        fixed (IDiaEnumDebugStreamData* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumDebugStreamData*, int*, HRESULT>)_lpVtbl[4])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_name"/>
+    public HRESULT get_name(BSTR* pRetVal)
+    {
+        fixed (IDiaEnumDebugStreamData* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumDebugStreamData*, BSTR*, HRESULT>)_lpVtbl[5])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.Item"/>
+    public HRESULT Item(uint index, uint cbData, uint* pcbData, byte* pbData)
+    {
+        fixed (IDiaEnumDebugStreamData* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumDebugStreamData*, uint, uint, uint*, byte*, HRESULT>)_lpVtbl[6])(pThis, index, cbData, pcbData, pbData);
+    }
+
+    /// <inheritdoc cref="Interface.Next"/>
+    public HRESULT Next(uint celt, uint cbData, uint* pcbData, byte* pbData, uint* pceltFetched)
+    {
+        fixed (IDiaEnumDebugStreamData* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumDebugStreamData*, uint, uint, uint*, byte*, uint*, HRESULT>)_lpVtbl[7])(pThis, celt, cbData, pcbData, pbData, pceltFetched);
+    }
+
+    /// <inheritdoc cref="Interface.Skip"/>
+    public HRESULT Skip(uint celt)
+    {
+        fixed (IDiaEnumDebugStreamData* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumDebugStreamData*, uint, HRESULT>)_lpVtbl[8])(pThis, celt);
+    }
+
+    /// <inheritdoc cref="Interface.Reset"/>
+    public HRESULT Reset()
+    {
+        fixed (IDiaEnumDebugStreamData* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumDebugStreamData*, HRESULT>)_lpVtbl[9])(pThis);
+    }
+
+    /// <inheritdoc cref="Interface.Clone"/>
+    public HRESULT Clone(IDiaEnumDebugStreamData** ppenum)
+    {
+        fixed (IDiaEnumDebugStreamData* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumDebugStreamData*, IDiaEnumDebugStreamData**, HRESULT>)_lpVtbl[10])(pThis, ppenum);
+    }
+
+    /// <summary>
+    ///  Enumerates the data contained in a debug data stream.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/visualstudio/debugger/debug-interface-access/idiaenumdebugstreamdata">
+    ///    Official documentation.
+    ///   </see>
+    ///  </para>
+    /// </remarks>
+    [ComImport]
+    [Guid("486943E8-D187-4A6B-A3C4-291259FFF60D")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    public unsafe interface Interface
+    {
+        /// <summary>
+        ///  Retrieves a version of this enumerator as a COM <c>IEnumVARIANT</c> enumerator.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get__NewEnum(IUnknown** pRetVal);
+
+        /// <summary>
+        ///  Number of elements in the stream.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_Count(int* pRetVal);
+
+        /// <summary>
+        ///  Stream name.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_name(BSTR* pRetVal);
+
+        /// <summary>
+        ///  Returns the element for the given index.
+        /// </summary>
+        /// <param name="index">The zero-based index of the item to retrieve.</param>
+        /// <param name="cbData">The size, in bytes, of the buffer.</param>
+        /// <param name="pcbData">Pointer to a variable that receives the number of bytes written to the buffer.</param>
+        /// <param name="pbData">Pointer to a caller-allocated buffer that receives the data.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT Item(uint index, uint cbData, uint* pcbData, byte* pbData);
+
+        /// <summary>
+        ///  Retrieves the next item or items in the enumeration sequence.
+        /// </summary>
+        /// <param name="celt">The number of items to retrieve.</param>
+        /// <param name="cbData">The size, in bytes, of the buffer.</param>
+        /// <param name="pcbData">Pointer to a variable that receives the number of bytes written to the buffer.</param>
+        /// <param name="pbData">Pointer to a caller-allocated buffer that receives the data.</param>
+        /// <param name="pceltFetched">Pointer to a variable that receives the number of items actually retrieved.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT Next(uint celt, uint cbData, uint* pcbData, byte* pbData, uint* pceltFetched);
+
+        /// <summary>
+        ///  Skips a specified number of items in the enumeration sequence.
+        /// </summary>
+        /// <param name="celt">The number of items to retrieve.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT Skip(uint celt);
+
+        /// <summary>
+        ///  Resets the enumeration sequence to the beginning.
+        /// </summary>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT Reset();
+
+        /// <summary>
+        ///  Creates an enumerator that contains the same enumeration state as the current enumerator.
+        /// </summary>
+        /// <param name="ppenum">Pointer to a variable that receives the cloned enumerator.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT Clone(IDiaEnumDebugStreamData** ppenum);
+    }
+}

--- a/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaEnumDebugStreams.cs
+++ b/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaEnumDebugStreams.cs
@@ -1,0 +1,188 @@
+﻿// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Runtime.InteropServices;
+using Windows.Win32.System.Variant;
+
+// For some reason the XML comment refs for IUnknown can't be resolved on .NET Framework without
+// explicitly using the fully qualified name, which falls afoul of the simplify warning.
+using ComIUnknown = Windows.Win32.System.Com.IUnknown;
+
+namespace Microsoft.VisualStudio.Debugging.DebugInterfaceAccess;
+
+/// <inheritdoc cref="Interface"/>
+public unsafe struct IDiaEnumDebugStreams : IComIID
+{
+    /// <inheritdoc cref="IComIID.Guid"/>
+#pragma warning disable IDE1006 // Naming Styles
+    public static readonly Guid IID_Guid = new(0x08CBB41E, 0x47A6, 0x4F87, 0x92, 0xF1, 0x1C, 0x9C, 0x87, 0xCE, 0xD0, 0x44);
+#pragma warning restore IDE1006
+
+#if NETFRAMEWORK
+    readonly ref readonly Guid IComIID.Guid => ref IID_Guid;
+#else
+    static ref readonly Guid IComIID.Guid
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get
+        {
+            ReadOnlySpan<byte> data =
+            [
+                0x1E, 0xB4, 0xCB, 0x08,
+                0xA6, 0x47,
+                0x87, 0x4F,
+                0x92, 0xF1, 0x1C, 0x9C, 0x87, 0xCE, 0xD0, 0x44
+            ];
+
+            return ref Unsafe.As<byte, Guid>(ref MemoryMarshal.GetReference(data));
+        }
+    }
+#endif
+
+    private readonly void** _lpVtbl;
+
+    /// <inheritdoc cref="ComIUnknown.QueryInterface(Guid*, void**)"/>
+    public HRESULT QueryInterface(Guid* riid, void** ppvObject)
+    {
+        fixed (IDiaEnumDebugStreams* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumDebugStreams*, Guid*, void**, HRESULT>)_lpVtbl[0])(pThis, riid, ppvObject);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.AddRef"/>
+    public uint AddRef()
+    {
+        fixed (IDiaEnumDebugStreams* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumDebugStreams*, uint>)_lpVtbl[1])(pThis);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.Release"/>
+    public uint Release()
+    {
+        fixed (IDiaEnumDebugStreams* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumDebugStreams*, uint>)_lpVtbl[2])(pThis);
+    }
+
+    /// <inheritdoc cref="Interface.get__NewEnum"/>
+    public HRESULT get__NewEnum(IUnknown** pRetVal)
+    {
+        fixed (IDiaEnumDebugStreams* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumDebugStreams*, IUnknown**, HRESULT>)_lpVtbl[3])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_Count"/>
+    public HRESULT get_Count(int* pRetVal)
+    {
+        fixed (IDiaEnumDebugStreams* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumDebugStreams*, int*, HRESULT>)_lpVtbl[4])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.Item"/>
+    public HRESULT Item(VARIANT index, IDiaEnumDebugStreamData** stream)
+    {
+        fixed (IDiaEnumDebugStreams* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumDebugStreams*, VARIANT, IDiaEnumDebugStreamData**, HRESULT>)_lpVtbl[5])(pThis, index, stream);
+    }
+
+    /// <inheritdoc cref="Interface.Next"/>
+    public HRESULT Next(uint celt, IDiaEnumDebugStreamData** rgelt, uint* pceltFetched)
+    {
+        fixed (IDiaEnumDebugStreams* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumDebugStreams*, uint, IDiaEnumDebugStreamData**, uint*, HRESULT>)_lpVtbl[6])(pThis, celt, rgelt, pceltFetched);
+    }
+
+    /// <inheritdoc cref="Interface.Skip"/>
+    public HRESULT Skip(uint celt)
+    {
+        fixed (IDiaEnumDebugStreams* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumDebugStreams*, uint, HRESULT>)_lpVtbl[7])(pThis, celt);
+    }
+
+    /// <inheritdoc cref="Interface.Reset"/>
+    public HRESULT Reset()
+    {
+        fixed (IDiaEnumDebugStreams* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumDebugStreams*, HRESULT>)_lpVtbl[8])(pThis);
+    }
+
+    /// <inheritdoc cref="Interface.Clone"/>
+    public HRESULT Clone(IDiaEnumDebugStreams** ppenum)
+    {
+        fixed (IDiaEnumDebugStreams* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumDebugStreams*, IDiaEnumDebugStreams**, HRESULT>)_lpVtbl[9])(pThis, ppenum);
+    }
+
+    /// <summary>
+    ///  Enumerates the various debug streams contained in the data source.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/visualstudio/debugger/debug-interface-access/idiaenumdebugstreams">
+    ///    Official documentation.
+    ///   </see>
+    ///  </para>
+    /// </remarks>
+    [ComImport]
+    [Guid("08CBB41E-47A6-4F87-92F1-1C9C87CED044")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    public unsafe interface Interface
+    {
+        /// <summary>
+        ///  Retrieves a version of this enumerator as a COM <c>IEnumVARIANT</c> enumerator.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get__NewEnum(IUnknown** pRetVal);
+
+        /// <summary>
+        ///  Number of streams.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_Count(int* pRetVal);
+
+        /// <summary>
+        ///  Returns the stream for the given index.
+        /// </summary>
+        /// <param name="index">The zero-based index of the item to retrieve.</param>
+        /// <param name="stream">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT Item(VARIANT index, IDiaEnumDebugStreamData** stream);
+
+        /// <summary>
+        ///  Retrieves the next item or items in the enumeration sequence.
+        /// </summary>
+        /// <param name="celt">The number of items to retrieve.</param>
+        /// <param name="rgelt">Pointer to a variable that receives the requested object.</param>
+        /// <param name="pceltFetched">Pointer to a variable that receives the number of items actually retrieved.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT Next(uint celt, IDiaEnumDebugStreamData** rgelt, uint* pceltFetched);
+
+        /// <summary>
+        ///  Skips a specified number of items in the enumeration sequence.
+        /// </summary>
+        /// <param name="celt">The number of items to retrieve.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT Skip(uint celt);
+
+        /// <summary>
+        ///  Resets the enumeration sequence to the beginning.
+        /// </summary>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT Reset();
+
+        /// <summary>
+        ///  Creates an enumerator that contains the same enumeration state as the current enumerator.
+        /// </summary>
+        /// <param name="ppenum">Pointer to a variable that receives the cloned enumerator.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT Clone(IDiaEnumDebugStreams** ppenum);
+    }
+}

--- a/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaEnumFrameData.cs
+++ b/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaEnumFrameData.cs
@@ -1,0 +1,219 @@
+﻿// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Runtime.InteropServices;
+
+// For some reason the XML comment refs for IUnknown can't be resolved on .NET Framework without
+// explicitly using the fully qualified name, which falls afoul of the simplify warning.
+using ComIUnknown = Windows.Win32.System.Com.IUnknown;
+
+namespace Microsoft.VisualStudio.Debugging.DebugInterfaceAccess;
+
+/// <inheritdoc cref="Interface"/>
+public unsafe struct IDiaEnumFrameData : IComIID
+{
+    /// <inheritdoc cref="IComIID.Guid"/>
+#pragma warning disable IDE1006 // Naming Styles
+    public static readonly Guid IID_Guid = new(0x9FC77A4B, 0x3C1C, 0x44ED, 0xA7, 0x98, 0x6C, 0x1D, 0xEE, 0xA5, 0x3E, 0x1F);
+#pragma warning restore IDE1006
+
+#if NETFRAMEWORK
+    readonly ref readonly Guid IComIID.Guid => ref IID_Guid;
+#else
+    static ref readonly Guid IComIID.Guid
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get
+        {
+            ReadOnlySpan<byte> data =
+            [
+                0x4B, 0x7A, 0xC7, 0x9F,
+                0x1C, 0x3C,
+                0xED, 0x44,
+                0xA7, 0x98, 0x6C, 0x1D, 0xEE, 0xA5, 0x3E, 0x1F
+            ];
+
+            return ref Unsafe.As<byte, Guid>(ref MemoryMarshal.GetReference(data));
+        }
+    }
+#endif
+
+    private readonly void** _lpVtbl;
+
+    /// <inheritdoc cref="ComIUnknown.QueryInterface(Guid*, void**)"/>
+    public HRESULT QueryInterface(Guid* riid, void** ppvObject)
+    {
+        fixed (IDiaEnumFrameData* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumFrameData*, Guid*, void**, HRESULT>)_lpVtbl[0])(pThis, riid, ppvObject);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.AddRef"/>
+    public uint AddRef()
+    {
+        fixed (IDiaEnumFrameData* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumFrameData*, uint>)_lpVtbl[1])(pThis);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.Release"/>
+    public uint Release()
+    {
+        fixed (IDiaEnumFrameData* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumFrameData*, uint>)_lpVtbl[2])(pThis);
+    }
+
+    /// <inheritdoc cref="Interface.get__NewEnum"/>
+    public HRESULT get__NewEnum(IUnknown** pRetVal)
+    {
+        fixed (IDiaEnumFrameData* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumFrameData*, IUnknown**, HRESULT>)_lpVtbl[3])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_Count"/>
+    public HRESULT get_Count(int* pRetVal)
+    {
+        fixed (IDiaEnumFrameData* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumFrameData*, int*, HRESULT>)_lpVtbl[4])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.Item"/>
+    public HRESULT Item(uint index, IDiaFrameData** frame)
+    {
+        fixed (IDiaEnumFrameData* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumFrameData*, uint, IDiaFrameData**, HRESULT>)_lpVtbl[5])(pThis, index, frame);
+    }
+
+    /// <inheritdoc cref="Interface.Next"/>
+    public HRESULT Next(uint celt, IDiaFrameData** rgelt, uint* pceltFetched)
+    {
+        fixed (IDiaEnumFrameData* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumFrameData*, uint, IDiaFrameData**, uint*, HRESULT>)_lpVtbl[6])(pThis, celt, rgelt, pceltFetched);
+    }
+
+    /// <inheritdoc cref="Interface.Skip"/>
+    public HRESULT Skip(uint celt)
+    {
+        fixed (IDiaEnumFrameData* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumFrameData*, uint, HRESULT>)_lpVtbl[7])(pThis, celt);
+    }
+
+    /// <inheritdoc cref="Interface.Reset"/>
+    public HRESULT Reset()
+    {
+        fixed (IDiaEnumFrameData* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumFrameData*, HRESULT>)_lpVtbl[8])(pThis);
+    }
+
+    /// <inheritdoc cref="Interface.Clone"/>
+    public HRESULT Clone(IDiaEnumFrameData** ppenum)
+    {
+        fixed (IDiaEnumFrameData* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumFrameData*, IDiaEnumFrameData**, HRESULT>)_lpVtbl[9])(pThis, ppenum);
+    }
+
+    /// <inheritdoc cref="Interface.frameByRVA"/>
+    public HRESULT frameByRVA(uint relativeVirtualAddress, IDiaFrameData** frame)
+    {
+        fixed (IDiaEnumFrameData* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumFrameData*, uint, IDiaFrameData**, HRESULT>)_lpVtbl[10])(pThis, relativeVirtualAddress, frame);
+    }
+
+    /// <inheritdoc cref="Interface.frameByVA"/>
+    public HRESULT frameByVA(ulong virtualAddress, IDiaFrameData** frame)
+    {
+        fixed (IDiaEnumFrameData* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumFrameData*, ulong, IDiaFrameData**, HRESULT>)_lpVtbl[11])(pThis, virtualAddress, frame);
+    }
+
+    /// <summary>
+    ///  Enumerates the various frame data elements contained in the data source.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/visualstudio/debugger/debug-interface-access/idiaenumframedata">
+    ///    Official documentation.
+    ///   </see>
+    ///  </para>
+    /// </remarks>
+    [ComImport]
+    [Guid("9FC77A4B-3C1C-44ED-A798-6C1DEEA53E1F")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    public unsafe interface Interface
+    {
+        /// <summary>
+        ///  Retrieves a version of this enumerator as a COM <c>IEnumVARIANT</c> enumerator.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get__NewEnum(IUnknown** pRetVal);
+
+        /// <summary>
+        ///  Number of frames.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_Count(int* pRetVal);
+
+        /// <summary>
+        ///  Returns the frame for the given index.
+        /// </summary>
+        /// <param name="index">The zero-based index of the item to retrieve.</param>
+        /// <param name="frame">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT Item(uint index, IDiaFrameData** frame);
+
+        /// <summary>
+        ///  Retrieves the next item or items in the enumeration sequence.
+        /// </summary>
+        /// <param name="celt">The number of items to retrieve.</param>
+        /// <param name="rgelt">Pointer to a variable that receives the requested object.</param>
+        /// <param name="pceltFetched">Pointer to a variable that receives the number of items actually retrieved.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT Next(uint celt, IDiaFrameData** rgelt, uint* pceltFetched);
+
+        /// <summary>
+        ///  Skips a specified number of items in the enumeration sequence.
+        /// </summary>
+        /// <param name="celt">The number of items to retrieve.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT Skip(uint celt);
+
+        /// <summary>
+        ///  Resets the enumeration sequence to the beginning.
+        /// </summary>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT Reset();
+
+        /// <summary>
+        ///  Creates an enumerator that contains the same enumeration state as the current enumerator.
+        /// </summary>
+        /// <param name="ppenum">Pointer to a variable that receives the cloned enumerator.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT Clone(IDiaEnumFrameData** ppenum);
+
+        /// <summary>
+        ///  Returns the frame for the given relative virtual address.
+        /// </summary>
+        /// <param name="relativeVirtualAddress">The relativeVirtualAddress value.</param>
+        /// <param name="frame">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT frameByRVA(uint relativeVirtualAddress, IDiaFrameData** frame);
+
+        /// <summary>
+        ///  Returns the frame for the given virtual address.
+        /// </summary>
+        /// <param name="virtualAddress">The virtualAddress value.</param>
+        /// <param name="frame">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT frameByVA(ulong virtualAddress, IDiaFrameData** frame);
+    }
+}

--- a/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaEnumInjectedSources.cs
+++ b/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaEnumInjectedSources.cs
@@ -1,0 +1,187 @@
+﻿// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Runtime.InteropServices;
+
+// For some reason the XML comment refs for IUnknown can't be resolved on .NET Framework without
+// explicitly using the fully qualified name, which falls afoul of the simplify warning.
+using ComIUnknown = Windows.Win32.System.Com.IUnknown;
+
+namespace Microsoft.VisualStudio.Debugging.DebugInterfaceAccess;
+
+/// <inheritdoc cref="Interface"/>
+public unsafe struct IDiaEnumInjectedSources : IComIID
+{
+    /// <inheritdoc cref="IComIID.Guid"/>
+#pragma warning disable IDE1006 // Naming Styles
+    public static readonly Guid IID_Guid = new(0xD5612573, 0x6925, 0x4468, 0x88, 0x83, 0x98, 0xCD, 0xEC, 0x8C, 0x38, 0x4A);
+#pragma warning restore IDE1006
+
+#if NETFRAMEWORK
+    readonly ref readonly Guid IComIID.Guid => ref IID_Guid;
+#else
+    static ref readonly Guid IComIID.Guid
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get
+        {
+            ReadOnlySpan<byte> data =
+            [
+                0x73, 0x25, 0x61, 0xD5,
+                0x25, 0x69,
+                0x68, 0x44,
+                0x88, 0x83, 0x98, 0xCD, 0xEC, 0x8C, 0x38, 0x4A
+            ];
+
+            return ref Unsafe.As<byte, Guid>(ref MemoryMarshal.GetReference(data));
+        }
+    }
+#endif
+
+    private readonly void** _lpVtbl;
+
+    /// <inheritdoc cref="ComIUnknown.QueryInterface(Guid*, void**)"/>
+    public HRESULT QueryInterface(Guid* riid, void** ppvObject)
+    {
+        fixed (IDiaEnumInjectedSources* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumInjectedSources*, Guid*, void**, HRESULT>)_lpVtbl[0])(pThis, riid, ppvObject);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.AddRef"/>
+    public uint AddRef()
+    {
+        fixed (IDiaEnumInjectedSources* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumInjectedSources*, uint>)_lpVtbl[1])(pThis);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.Release"/>
+    public uint Release()
+    {
+        fixed (IDiaEnumInjectedSources* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumInjectedSources*, uint>)_lpVtbl[2])(pThis);
+    }
+
+    /// <inheritdoc cref="Interface.get__NewEnum"/>
+    public HRESULT get__NewEnum(IUnknown** pRetVal)
+    {
+        fixed (IDiaEnumInjectedSources* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumInjectedSources*, IUnknown**, HRESULT>)_lpVtbl[3])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_Count"/>
+    public HRESULT get_Count(int* pRetVal)
+    {
+        fixed (IDiaEnumInjectedSources* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumInjectedSources*, int*, HRESULT>)_lpVtbl[4])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.Item"/>
+    public HRESULT Item(uint index, IDiaInjectedSource** injectedSource)
+    {
+        fixed (IDiaEnumInjectedSources* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumInjectedSources*, uint, IDiaInjectedSource**, HRESULT>)_lpVtbl[5])(pThis, index, injectedSource);
+    }
+
+    /// <inheritdoc cref="Interface.Next"/>
+    public HRESULT Next(uint celt, IDiaInjectedSource** rgelt, uint* pceltFetched)
+    {
+        fixed (IDiaEnumInjectedSources* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumInjectedSources*, uint, IDiaInjectedSource**, uint*, HRESULT>)_lpVtbl[6])(pThis, celt, rgelt, pceltFetched);
+    }
+
+    /// <inheritdoc cref="Interface.Skip"/>
+    public HRESULT Skip(uint celt)
+    {
+        fixed (IDiaEnumInjectedSources* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumInjectedSources*, uint, HRESULT>)_lpVtbl[7])(pThis, celt);
+    }
+
+    /// <inheritdoc cref="Interface.Reset"/>
+    public HRESULT Reset()
+    {
+        fixed (IDiaEnumInjectedSources* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumInjectedSources*, HRESULT>)_lpVtbl[8])(pThis);
+    }
+
+    /// <inheritdoc cref="Interface.Clone"/>
+    public HRESULT Clone(IDiaEnumInjectedSources** ppenum)
+    {
+        fixed (IDiaEnumInjectedSources* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumInjectedSources*, IDiaEnumInjectedSources**, HRESULT>)_lpVtbl[9])(pThis, ppenum);
+    }
+
+    /// <summary>
+    ///  Enumerates the various injected sources contained in the data source.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/visualstudio/debugger/debug-interface-access/idiaenuminjectedsources">
+    ///    Official documentation.
+    ///   </see>
+    ///  </para>
+    /// </remarks>
+    [ComImport]
+    [Guid("D5612573-6925-4468-8883-98CDEC8C384A")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    public unsafe interface Interface
+    {
+        /// <summary>
+        ///  Retrieves a version of this enumerator as a COM <c>IEnumVARIANT</c> enumerator.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get__NewEnum(IUnknown** pRetVal);
+
+        /// <summary>
+        ///  Number of injected source files.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_Count(int* pRetVal);
+
+        /// <summary>
+        ///  Returns the injected source for the given index.
+        /// </summary>
+        /// <param name="index">The zero-based index of the item to retrieve.</param>
+        /// <param name="injectedSource">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT Item(uint index, IDiaInjectedSource** injectedSource);
+
+        /// <summary>
+        ///  Retrieves the next item or items in the enumeration sequence.
+        /// </summary>
+        /// <param name="celt">The number of items to retrieve.</param>
+        /// <param name="rgelt">Pointer to a variable that receives the requested object.</param>
+        /// <param name="pceltFetched">Pointer to a variable that receives the number of items actually retrieved.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT Next(uint celt, IDiaInjectedSource** rgelt, uint* pceltFetched);
+
+        /// <summary>
+        ///  Skips a specified number of items in the enumeration sequence.
+        /// </summary>
+        /// <param name="celt">The number of items to retrieve.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT Skip(uint celt);
+
+        /// <summary>
+        ///  Resets the enumeration sequence to the beginning.
+        /// </summary>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT Reset();
+
+        /// <summary>
+        ///  Creates an enumerator that contains the same enumeration state as the current enumerator.
+        /// </summary>
+        /// <param name="ppenum">Pointer to a variable that receives the cloned enumerator.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT Clone(IDiaEnumInjectedSources** ppenum);
+    }
+}

--- a/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaEnumInputAssemblyFiles.cs
+++ b/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaEnumInputAssemblyFiles.cs
@@ -1,0 +1,187 @@
+﻿// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Runtime.InteropServices;
+
+// For some reason the XML comment refs for IUnknown can't be resolved on .NET Framework without
+// explicitly using the fully qualified name, which falls afoul of the simplify warning.
+using ComIUnknown = Windows.Win32.System.Com.IUnknown;
+
+namespace Microsoft.VisualStudio.Debugging.DebugInterfaceAccess;
+
+/// <inheritdoc cref="Interface"/>
+public unsafe struct IDiaEnumInputAssemblyFiles : IComIID
+{
+    /// <inheritdoc cref="IComIID.Guid"/>
+#pragma warning disable IDE1006 // Naming Styles
+    public static readonly Guid IID_Guid = new(0x1C7FF653, 0x51F7, 0x457E, 0x84, 0x19, 0xB2, 0x0F, 0x57, 0xEF, 0x7E, 0x4D);
+#pragma warning restore IDE1006
+
+#if NETFRAMEWORK
+    readonly ref readonly Guid IComIID.Guid => ref IID_Guid;
+#else
+    static ref readonly Guid IComIID.Guid
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get
+        {
+            ReadOnlySpan<byte> data =
+            [
+                0x53, 0xF6, 0x7F, 0x1C,
+                0xF7, 0x51,
+                0x7E, 0x45,
+                0x84, 0x19, 0xB2, 0x0F, 0x57, 0xEF, 0x7E, 0x4D
+            ];
+
+            return ref Unsafe.As<byte, Guid>(ref MemoryMarshal.GetReference(data));
+        }
+    }
+#endif
+
+    private readonly void** _lpVtbl;
+
+    /// <inheritdoc cref="ComIUnknown.QueryInterface(Guid*, void**)"/>
+    public HRESULT QueryInterface(Guid* riid, void** ppvObject)
+    {
+        fixed (IDiaEnumInputAssemblyFiles* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumInputAssemblyFiles*, Guid*, void**, HRESULT>)_lpVtbl[0])(pThis, riid, ppvObject);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.AddRef"/>
+    public uint AddRef()
+    {
+        fixed (IDiaEnumInputAssemblyFiles* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumInputAssemblyFiles*, uint>)_lpVtbl[1])(pThis);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.Release"/>
+    public uint Release()
+    {
+        fixed (IDiaEnumInputAssemblyFiles* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumInputAssemblyFiles*, uint>)_lpVtbl[2])(pThis);
+    }
+
+    /// <inheritdoc cref="Interface.get__NewEnum"/>
+    public HRESULT get__NewEnum(IUnknown** pRetVal)
+    {
+        fixed (IDiaEnumInputAssemblyFiles* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumInputAssemblyFiles*, IUnknown**, HRESULT>)_lpVtbl[3])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_Count"/>
+    public HRESULT get_Count(int* pRetVal)
+    {
+        fixed (IDiaEnumInputAssemblyFiles* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumInputAssemblyFiles*, int*, HRESULT>)_lpVtbl[4])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.Item"/>
+    public HRESULT Item(uint index, IDiaInputAssemblyFile** file)
+    {
+        fixed (IDiaEnumInputAssemblyFiles* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumInputAssemblyFiles*, uint, IDiaInputAssemblyFile**, HRESULT>)_lpVtbl[5])(pThis, index, file);
+    }
+
+    /// <inheritdoc cref="Interface.Next"/>
+    public HRESULT Next(uint celt, IDiaInputAssemblyFile** rgelt, uint* pceltFetched)
+    {
+        fixed (IDiaEnumInputAssemblyFiles* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumInputAssemblyFiles*, uint, IDiaInputAssemblyFile**, uint*, HRESULT>)_lpVtbl[6])(pThis, celt, rgelt, pceltFetched);
+    }
+
+    /// <inheritdoc cref="Interface.Skip"/>
+    public HRESULT Skip(uint celt)
+    {
+        fixed (IDiaEnumInputAssemblyFiles* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumInputAssemblyFiles*, uint, HRESULT>)_lpVtbl[7])(pThis, celt);
+    }
+
+    /// <inheritdoc cref="Interface.Reset"/>
+    public HRESULT Reset()
+    {
+        fixed (IDiaEnumInputAssemblyFiles* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumInputAssemblyFiles*, HRESULT>)_lpVtbl[8])(pThis);
+    }
+
+    /// <inheritdoc cref="Interface.Clone"/>
+    public HRESULT Clone(IDiaEnumInputAssemblyFiles** ppenum)
+    {
+        fixed (IDiaEnumInputAssemblyFiles* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumInputAssemblyFiles*, IDiaEnumInputAssemblyFiles**, HRESULT>)_lpVtbl[9])(pThis, ppenum);
+    }
+
+    /// <summary>
+    ///  Enumerates the various input assembly files contained in the data source.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/visualstudio/debugger/debug-interface-access/idiaenuminputassemblyfiles">
+    ///    Official documentation.
+    ///   </see>
+    ///  </para>
+    /// </remarks>
+    [ComImport]
+    [Guid("1C7FF653-51F7-457E-8419-B20F57EF7E4D")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    public unsafe interface Interface
+    {
+        /// <summary>
+        ///  Retrieves a version of this enumerator as a COM <c>IEnumVARIANT</c> enumerator.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get__NewEnum(IUnknown** pRetVal);
+
+        /// <summary>
+        ///  Number of input assembly files.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_Count(int* pRetVal);
+
+        /// <summary>
+        ///  Returns the source file for the given index.
+        /// </summary>
+        /// <param name="index">The zero-based index of the item to retrieve.</param>
+        /// <param name="file">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT Item(uint index, IDiaInputAssemblyFile** file);
+
+        /// <summary>
+        ///  Retrieves the next item or items in the enumeration sequence.
+        /// </summary>
+        /// <param name="celt">The number of items to retrieve.</param>
+        /// <param name="rgelt">Pointer to a variable that receives the requested object.</param>
+        /// <param name="pceltFetched">Pointer to a variable that receives the number of items actually retrieved.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT Next(uint celt, IDiaInputAssemblyFile** rgelt, uint* pceltFetched);
+
+        /// <summary>
+        ///  Skips a specified number of items in the enumeration sequence.
+        /// </summary>
+        /// <param name="celt">The number of items to retrieve.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT Skip(uint celt);
+
+        /// <summary>
+        ///  Resets the enumeration sequence to the beginning.
+        /// </summary>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT Reset();
+
+        /// <summary>
+        ///  Creates an enumerator that contains the same enumeration state as the current enumerator.
+        /// </summary>
+        /// <param name="ppenum">Pointer to a variable that receives the cloned enumerator.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT Clone(IDiaEnumInputAssemblyFiles** ppenum);
+    }
+}

--- a/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaEnumLineNumbers.cs
+++ b/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaEnumLineNumbers.cs
@@ -1,0 +1,187 @@
+﻿// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Runtime.InteropServices;
+
+// For some reason the XML comment refs for IUnknown can't be resolved on .NET Framework without
+// explicitly using the fully qualified name, which falls afoul of the simplify warning.
+using ComIUnknown = Windows.Win32.System.Com.IUnknown;
+
+namespace Microsoft.VisualStudio.Debugging.DebugInterfaceAccess;
+
+/// <inheritdoc cref="Interface"/>
+public unsafe struct IDiaEnumLineNumbers : IComIID
+{
+    /// <inheritdoc cref="IComIID.Guid"/>
+#pragma warning disable IDE1006 // Naming Styles
+    public static readonly Guid IID_Guid = new(0xFE30E878, 0x54AC, 0x44F1, 0x81, 0xBA, 0x39, 0xDE, 0x94, 0x0F, 0x60, 0x52);
+#pragma warning restore IDE1006
+
+#if NETFRAMEWORK
+    readonly ref readonly Guid IComIID.Guid => ref IID_Guid;
+#else
+    static ref readonly Guid IComIID.Guid
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get
+        {
+            ReadOnlySpan<byte> data =
+            [
+                0x78, 0xE8, 0x30, 0xFE,
+                0xAC, 0x54,
+                0xF1, 0x44,
+                0x81, 0xBA, 0x39, 0xDE, 0x94, 0x0F, 0x60, 0x52
+            ];
+
+            return ref Unsafe.As<byte, Guid>(ref MemoryMarshal.GetReference(data));
+        }
+    }
+#endif
+
+    private readonly void** _lpVtbl;
+
+    /// <inheritdoc cref="ComIUnknown.QueryInterface(Guid*, void**)"/>
+    public HRESULT QueryInterface(Guid* riid, void** ppvObject)
+    {
+        fixed (IDiaEnumLineNumbers* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumLineNumbers*, Guid*, void**, HRESULT>)_lpVtbl[0])(pThis, riid, ppvObject);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.AddRef"/>
+    public uint AddRef()
+    {
+        fixed (IDiaEnumLineNumbers* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumLineNumbers*, uint>)_lpVtbl[1])(pThis);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.Release"/>
+    public uint Release()
+    {
+        fixed (IDiaEnumLineNumbers* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumLineNumbers*, uint>)_lpVtbl[2])(pThis);
+    }
+
+    /// <inheritdoc cref="Interface.get__NewEnum"/>
+    public HRESULT get__NewEnum(IUnknown** pRetVal)
+    {
+        fixed (IDiaEnumLineNumbers* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumLineNumbers*, IUnknown**, HRESULT>)_lpVtbl[3])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_Count"/>
+    public HRESULT get_Count(int* pRetVal)
+    {
+        fixed (IDiaEnumLineNumbers* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumLineNumbers*, int*, HRESULT>)_lpVtbl[4])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.Item"/>
+    public HRESULT Item(uint index, IDiaLineNumber** lineNumber)
+    {
+        fixed (IDiaEnumLineNumbers* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumLineNumbers*, uint, IDiaLineNumber**, HRESULT>)_lpVtbl[5])(pThis, index, lineNumber);
+    }
+
+    /// <inheritdoc cref="Interface.Next"/>
+    public HRESULT Next(uint celt, IDiaLineNumber** rgelt, uint* pceltFetched)
+    {
+        fixed (IDiaEnumLineNumbers* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumLineNumbers*, uint, IDiaLineNumber**, uint*, HRESULT>)_lpVtbl[6])(pThis, celt, rgelt, pceltFetched);
+    }
+
+    /// <inheritdoc cref="Interface.Skip"/>
+    public HRESULT Skip(uint celt)
+    {
+        fixed (IDiaEnumLineNumbers* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumLineNumbers*, uint, HRESULT>)_lpVtbl[7])(pThis, celt);
+    }
+
+    /// <inheritdoc cref="Interface.Reset"/>
+    public HRESULT Reset()
+    {
+        fixed (IDiaEnumLineNumbers* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumLineNumbers*, HRESULT>)_lpVtbl[8])(pThis);
+    }
+
+    /// <inheritdoc cref="Interface.Clone"/>
+    public HRESULT Clone(IDiaEnumLineNumbers** ppenum)
+    {
+        fixed (IDiaEnumLineNumbers* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumLineNumbers*, IDiaEnumLineNumbers**, HRESULT>)_lpVtbl[9])(pThis, ppenum);
+    }
+
+    /// <summary>
+    ///  Enumerates the various line numbers contained in the data source.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/visualstudio/debugger/debug-interface-access/idiaenumlinenumbers">
+    ///    Official documentation.
+    ///   </see>
+    ///  </para>
+    /// </remarks>
+    [ComImport]
+    [Guid("FE30E878-54AC-44F1-81BA-39DE940F6052")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    public unsafe interface Interface
+    {
+        /// <summary>
+        ///  Retrieves a version of this enumerator as a COM <c>IEnumVARIANT</c> enumerator.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get__NewEnum(IUnknown** pRetVal);
+
+        /// <summary>
+        ///  Number of line numbers.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_Count(int* pRetVal);
+
+        /// <summary>
+        ///  Returns the line number for the given index.
+        /// </summary>
+        /// <param name="index">The zero-based index of the item to retrieve.</param>
+        /// <param name="lineNumber">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT Item(uint index, IDiaLineNumber** lineNumber);
+
+        /// <summary>
+        ///  Retrieves the next item or items in the enumeration sequence.
+        /// </summary>
+        /// <param name="celt">The number of items to retrieve.</param>
+        /// <param name="rgelt">Pointer to a variable that receives the requested object.</param>
+        /// <param name="pceltFetched">Pointer to a variable that receives the number of items actually retrieved.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT Next(uint celt, IDiaLineNumber** rgelt, uint* pceltFetched);
+
+        /// <summary>
+        ///  Skips a specified number of items in the enumeration sequence.
+        /// </summary>
+        /// <param name="celt">The number of items to retrieve.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT Skip(uint celt);
+
+        /// <summary>
+        ///  Resets the enumeration sequence to the beginning.
+        /// </summary>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT Reset();
+
+        /// <summary>
+        ///  Creates an enumerator that contains the same enumeration state as the current enumerator.
+        /// </summary>
+        /// <param name="ppenum">Pointer to a variable that receives the cloned enumerator.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT Clone(IDiaEnumLineNumbers** ppenum);
+    }
+}

--- a/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaEnumNamedStreams.cs
+++ b/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaEnumNamedStreams.cs
@@ -1,0 +1,169 @@
+﻿// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Runtime.InteropServices;
+
+// For some reason the XML comment refs for IUnknown can't be resolved on .NET Framework without
+// explicitly using the fully qualified name, which falls afoul of the simplify warning.
+using ComIUnknown = Windows.Win32.System.Com.IUnknown;
+
+namespace Microsoft.VisualStudio.Debugging.DebugInterfaceAccess;
+
+/// <inheritdoc cref="Interface"/>
+public unsafe struct IDiaEnumNamedStreams : IComIID
+{
+    /// <inheritdoc cref="IComIID.Guid"/>
+#pragma warning disable IDE1006 // Naming Styles
+    public static readonly Guid IID_Guid = new(0x2B01F5E0, 0x98DB, 0x4824, 0xA9, 0xA0, 0x51, 0x92, 0x83, 0x3B, 0xEF, 0x47);
+#pragma warning restore IDE1006
+
+#if NETFRAMEWORK
+    readonly ref readonly Guid IComIID.Guid => ref IID_Guid;
+#else
+    static ref readonly Guid IComIID.Guid
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get
+        {
+            ReadOnlySpan<byte> data =
+            [
+                0xE0, 0xF5, 0x01, 0x2B,
+                0xDB, 0x98,
+                0x24, 0x48,
+                0xA9, 0xA0, 0x51, 0x92, 0x83, 0x3B, 0xEF, 0x47
+            ];
+
+            return ref Unsafe.As<byte, Guid>(ref MemoryMarshal.GetReference(data));
+        }
+    }
+#endif
+
+    private readonly void** _lpVtbl;
+
+    /// <inheritdoc cref="ComIUnknown.QueryInterface(Guid*, void**)"/>
+    public HRESULT QueryInterface(Guid* riid, void** ppvObject)
+    {
+        fixed (IDiaEnumNamedStreams* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumNamedStreams*, Guid*, void**, HRESULT>)_lpVtbl[0])(pThis, riid, ppvObject);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.AddRef"/>
+    public uint AddRef()
+    {
+        fixed (IDiaEnumNamedStreams* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumNamedStreams*, uint>)_lpVtbl[1])(pThis);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.Release"/>
+    public uint Release()
+    {
+        fixed (IDiaEnumNamedStreams* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumNamedStreams*, uint>)_lpVtbl[2])(pThis);
+    }
+
+    /// <inheritdoc cref="Interface.get__NewEnum"/>
+    public HRESULT get__NewEnum(IUnknown** pRetVal)
+    {
+        fixed (IDiaEnumNamedStreams* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumNamedStreams*, IUnknown**, HRESULT>)_lpVtbl[3])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_Count"/>
+    public HRESULT get_Count(int* pRetVal)
+    {
+        fixed (IDiaEnumNamedStreams* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumNamedStreams*, int*, HRESULT>)_lpVtbl[4])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.Next"/>
+    public HRESULT Next(BSTR* pName)
+    {
+        fixed (IDiaEnumNamedStreams* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumNamedStreams*, BSTR*, HRESULT>)_lpVtbl[5])(pThis, pName);
+    }
+
+    /// <inheritdoc cref="Interface.Skip"/>
+    public HRESULT Skip(uint celt)
+    {
+        fixed (IDiaEnumNamedStreams* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumNamedStreams*, uint, HRESULT>)_lpVtbl[6])(pThis, celt);
+    }
+
+    /// <inheritdoc cref="Interface.Reset"/>
+    public HRESULT Reset()
+    {
+        fixed (IDiaEnumNamedStreams* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumNamedStreams*, HRESULT>)_lpVtbl[7])(pThis);
+    }
+
+    /// <inheritdoc cref="Interface.Clone"/>
+    public HRESULT Clone(IDiaEnumNamedStreams** ppenum)
+    {
+        fixed (IDiaEnumNamedStreams* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumNamedStreams*, IDiaEnumNamedStreams**, HRESULT>)_lpVtbl[8])(pThis, ppenum);
+    }
+
+    /// <summary>
+    ///  Enumerates the various named streams contained in the data source.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/visualstudio/debugger/debug-interface-access/idiaenumnamedstreams">
+    ///    Official documentation.
+    ///   </see>
+    ///  </para>
+    /// </remarks>
+    [ComImport]
+    [Guid("2B01F5E0-98DB-4824-A9A0-5192833BEF47")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    public unsafe interface Interface
+    {
+        /// <summary>
+        ///  Retrieves a version of this enumerator as a COM <c>IEnumVARIANT</c> enumerator.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get__NewEnum(IUnknown** pRetVal);
+
+        /// <summary>
+        ///  Number of named streams.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_Count(int* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the next item or items in the enumeration sequence.
+        /// </summary>
+        /// <param name="pName">Pointer to a variable that receives the requested value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT Next(BSTR* pName);
+
+        /// <summary>
+        ///  Skips a specified number of items in the enumeration sequence.
+        /// </summary>
+        /// <param name="celt">The number of items to retrieve.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT Skip(uint celt);
+
+        /// <summary>
+        ///  Resets the enumeration sequence to the beginning.
+        /// </summary>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT Reset();
+
+        /// <summary>
+        ///  Creates an enumerator that contains the same enumeration state as the current enumerator.
+        /// </summary>
+        /// <param name="ppenum">Pointer to a variable that receives the cloned enumerator.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT Clone(IDiaEnumNamedStreams** ppenum);
+    }
+}

--- a/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaEnumSectionContribs.cs
+++ b/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaEnumSectionContribs.cs
@@ -1,0 +1,187 @@
+﻿// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Runtime.InteropServices;
+
+// For some reason the XML comment refs for IUnknown can't be resolved on .NET Framework without
+// explicitly using the fully qualified name, which falls afoul of the simplify warning.
+using ComIUnknown = Windows.Win32.System.Com.IUnknown;
+
+namespace Microsoft.VisualStudio.Debugging.DebugInterfaceAccess;
+
+/// <inheritdoc cref="Interface"/>
+public unsafe struct IDiaEnumSectionContribs : IComIID
+{
+    /// <inheritdoc cref="IComIID.Guid"/>
+#pragma warning disable IDE1006 // Naming Styles
+    public static readonly Guid IID_Guid = new(0x1994DEB2, 0x2C82, 0x4B1D, 0xA5, 0x7F, 0xAF, 0xF4, 0x24, 0xD5, 0x4A, 0x68);
+#pragma warning restore IDE1006
+
+#if NETFRAMEWORK
+    readonly ref readonly Guid IComIID.Guid => ref IID_Guid;
+#else
+    static ref readonly Guid IComIID.Guid
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get
+        {
+            ReadOnlySpan<byte> data =
+            [
+                0xB2, 0xDE, 0x94, 0x19,
+                0x82, 0x2C,
+                0x1D, 0x4B,
+                0xA5, 0x7F, 0xAF, 0xF4, 0x24, 0xD5, 0x4A, 0x68
+            ];
+
+            return ref Unsafe.As<byte, Guid>(ref MemoryMarshal.GetReference(data));
+        }
+    }
+#endif
+
+    private readonly void** _lpVtbl;
+
+    /// <inheritdoc cref="ComIUnknown.QueryInterface(Guid*, void**)"/>
+    public HRESULT QueryInterface(Guid* riid, void** ppvObject)
+    {
+        fixed (IDiaEnumSectionContribs* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumSectionContribs*, Guid*, void**, HRESULT>)_lpVtbl[0])(pThis, riid, ppvObject);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.AddRef"/>
+    public uint AddRef()
+    {
+        fixed (IDiaEnumSectionContribs* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumSectionContribs*, uint>)_lpVtbl[1])(pThis);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.Release"/>
+    public uint Release()
+    {
+        fixed (IDiaEnumSectionContribs* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumSectionContribs*, uint>)_lpVtbl[2])(pThis);
+    }
+
+    /// <inheritdoc cref="Interface.get__NewEnum"/>
+    public HRESULT get__NewEnum(IUnknown** pRetVal)
+    {
+        fixed (IDiaEnumSectionContribs* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumSectionContribs*, IUnknown**, HRESULT>)_lpVtbl[3])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_Count"/>
+    public HRESULT get_Count(int* pRetVal)
+    {
+        fixed (IDiaEnumSectionContribs* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumSectionContribs*, int*, HRESULT>)_lpVtbl[4])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.Item"/>
+    public HRESULT Item(uint index, IDiaSectionContrib** section)
+    {
+        fixed (IDiaEnumSectionContribs* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumSectionContribs*, uint, IDiaSectionContrib**, HRESULT>)_lpVtbl[5])(pThis, index, section);
+    }
+
+    /// <inheritdoc cref="Interface.Next"/>
+    public HRESULT Next(uint celt, IDiaSectionContrib** rgelt, uint* pceltFetched)
+    {
+        fixed (IDiaEnumSectionContribs* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumSectionContribs*, uint, IDiaSectionContrib**, uint*, HRESULT>)_lpVtbl[6])(pThis, celt, rgelt, pceltFetched);
+    }
+
+    /// <inheritdoc cref="Interface.Skip"/>
+    public HRESULT Skip(uint celt)
+    {
+        fixed (IDiaEnumSectionContribs* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumSectionContribs*, uint, HRESULT>)_lpVtbl[7])(pThis, celt);
+    }
+
+    /// <inheritdoc cref="Interface.Reset"/>
+    public HRESULT Reset()
+    {
+        fixed (IDiaEnumSectionContribs* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumSectionContribs*, HRESULT>)_lpVtbl[8])(pThis);
+    }
+
+    /// <inheritdoc cref="Interface.Clone"/>
+    public HRESULT Clone(IDiaEnumSectionContribs** ppenum)
+    {
+        fixed (IDiaEnumSectionContribs* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumSectionContribs*, IDiaEnumSectionContribs**, HRESULT>)_lpVtbl[9])(pThis, ppenum);
+    }
+
+    /// <summary>
+    ///  Enumerates the various section contributions contained in the data source.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/visualstudio/debugger/debug-interface-access/idiaenumsectioncontribs">
+    ///    Official documentation.
+    ///   </see>
+    ///  </para>
+    /// </remarks>
+    [ComImport]
+    [Guid("1994DEB2-2C82-4B1D-A57F-AFF424D54A68")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    public unsafe interface Interface
+    {
+        /// <summary>
+        ///  Retrieves a version of this enumerator as a COM <c>IEnumVARIANT</c> enumerator.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get__NewEnum(IUnknown** pRetVal);
+
+        /// <summary>
+        ///  Number of section contributions.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_Count(int* pRetVal);
+
+        /// <summary>
+        ///  Returns the section contribution for the given index.
+        /// </summary>
+        /// <param name="index">The zero-based index of the item to retrieve.</param>
+        /// <param name="section">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT Item(uint index, IDiaSectionContrib** section);
+
+        /// <summary>
+        ///  Retrieves the next item or items in the enumeration sequence.
+        /// </summary>
+        /// <param name="celt">The number of items to retrieve.</param>
+        /// <param name="rgelt">Pointer to a variable that receives the requested object.</param>
+        /// <param name="pceltFetched">Pointer to a variable that receives the number of items actually retrieved.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT Next(uint celt, IDiaSectionContrib** rgelt, uint* pceltFetched);
+
+        /// <summary>
+        ///  Skips a specified number of items in the enumeration sequence.
+        /// </summary>
+        /// <param name="celt">The number of items to retrieve.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT Skip(uint celt);
+
+        /// <summary>
+        ///  Resets the enumeration sequence to the beginning.
+        /// </summary>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT Reset();
+
+        /// <summary>
+        ///  Creates an enumerator that contains the same enumeration state as the current enumerator.
+        /// </summary>
+        /// <param name="ppenum">Pointer to a variable that receives the cloned enumerator.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT Clone(IDiaEnumSectionContribs** ppenum);
+    }
+}

--- a/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaEnumSegments.cs
+++ b/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaEnumSegments.cs
@@ -1,0 +1,187 @@
+﻿// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Runtime.InteropServices;
+
+// For some reason the XML comment refs for IUnknown can't be resolved on .NET Framework without
+// explicitly using the fully qualified name, which falls afoul of the simplify warning.
+using ComIUnknown = Windows.Win32.System.Com.IUnknown;
+
+namespace Microsoft.VisualStudio.Debugging.DebugInterfaceAccess;
+
+/// <inheritdoc cref="Interface"/>
+public unsafe struct IDiaEnumSegments : IComIID
+{
+    /// <inheritdoc cref="IComIID.Guid"/>
+#pragma warning disable IDE1006 // Naming Styles
+    public static readonly Guid IID_Guid = new(0xE8368CA9, 0x01D1, 0x419D, 0xAC, 0x0C, 0xE3, 0x12, 0x35, 0xDB, 0xDA, 0x9F);
+#pragma warning restore IDE1006
+
+#if NETFRAMEWORK
+    readonly ref readonly Guid IComIID.Guid => ref IID_Guid;
+#else
+    static ref readonly Guid IComIID.Guid
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get
+        {
+            ReadOnlySpan<byte> data =
+            [
+                0xA9, 0x8C, 0x36, 0xE8,
+                0xD1, 0x01,
+                0x9D, 0x41,
+                0xAC, 0x0C, 0xE3, 0x12, 0x35, 0xDB, 0xDA, 0x9F
+            ];
+
+            return ref Unsafe.As<byte, Guid>(ref MemoryMarshal.GetReference(data));
+        }
+    }
+#endif
+
+    private readonly void** _lpVtbl;
+
+    /// <inheritdoc cref="ComIUnknown.QueryInterface(Guid*, void**)"/>
+    public HRESULT QueryInterface(Guid* riid, void** ppvObject)
+    {
+        fixed (IDiaEnumSegments* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumSegments*, Guid*, void**, HRESULT>)_lpVtbl[0])(pThis, riid, ppvObject);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.AddRef"/>
+    public uint AddRef()
+    {
+        fixed (IDiaEnumSegments* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumSegments*, uint>)_lpVtbl[1])(pThis);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.Release"/>
+    public uint Release()
+    {
+        fixed (IDiaEnumSegments* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumSegments*, uint>)_lpVtbl[2])(pThis);
+    }
+
+    /// <inheritdoc cref="Interface.get__NewEnum"/>
+    public HRESULT get__NewEnum(IUnknown** pRetVal)
+    {
+        fixed (IDiaEnumSegments* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumSegments*, IUnknown**, HRESULT>)_lpVtbl[3])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_Count"/>
+    public HRESULT get_Count(int* pRetVal)
+    {
+        fixed (IDiaEnumSegments* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumSegments*, int*, HRESULT>)_lpVtbl[4])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.Item"/>
+    public HRESULT Item(uint index, IDiaSegment** segment)
+    {
+        fixed (IDiaEnumSegments* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumSegments*, uint, IDiaSegment**, HRESULT>)_lpVtbl[5])(pThis, index, segment);
+    }
+
+    /// <inheritdoc cref="Interface.Next"/>
+    public HRESULT Next(uint celt, IDiaSegment** rgelt, uint* pceltFetched)
+    {
+        fixed (IDiaEnumSegments* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumSegments*, uint, IDiaSegment**, uint*, HRESULT>)_lpVtbl[6])(pThis, celt, rgelt, pceltFetched);
+    }
+
+    /// <inheritdoc cref="Interface.Skip"/>
+    public HRESULT Skip(uint celt)
+    {
+        fixed (IDiaEnumSegments* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumSegments*, uint, HRESULT>)_lpVtbl[7])(pThis, celt);
+    }
+
+    /// <inheritdoc cref="Interface.Reset"/>
+    public HRESULT Reset()
+    {
+        fixed (IDiaEnumSegments* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumSegments*, HRESULT>)_lpVtbl[8])(pThis);
+    }
+
+    /// <inheritdoc cref="Interface.Clone"/>
+    public HRESULT Clone(IDiaEnumSegments** ppenum)
+    {
+        fixed (IDiaEnumSegments* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumSegments*, IDiaEnumSegments**, HRESULT>)_lpVtbl[9])(pThis, ppenum);
+    }
+
+    /// <summary>
+    ///  Enumerates the various segments contained in the data source.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/visualstudio/debugger/debug-interface-access/idiaenumsegments">
+    ///    Official documentation.
+    ///   </see>
+    ///  </para>
+    /// </remarks>
+    [ComImport]
+    [Guid("E8368CA9-01D1-419D-AC0C-E31235DBDA9F")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    public unsafe interface Interface
+    {
+        /// <summary>
+        ///  Retrieves a version of this enumerator as a COM <c>IEnumVARIANT</c> enumerator.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get__NewEnum(IUnknown** pRetVal);
+
+        /// <summary>
+        ///  Number of segments.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_Count(int* pRetVal);
+
+        /// <summary>
+        ///  Returns the segment for the given index.
+        /// </summary>
+        /// <param name="index">The zero-based index of the item to retrieve.</param>
+        /// <param name="segment">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT Item(uint index, IDiaSegment** segment);
+
+        /// <summary>
+        ///  Retrieves the next item or items in the enumeration sequence.
+        /// </summary>
+        /// <param name="celt">The number of items to retrieve.</param>
+        /// <param name="rgelt">Pointer to a variable that receives the requested object.</param>
+        /// <param name="pceltFetched">Pointer to a variable that receives the number of items actually retrieved.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT Next(uint celt, IDiaSegment** rgelt, uint* pceltFetched);
+
+        /// <summary>
+        ///  Skips a specified number of items in the enumeration sequence.
+        /// </summary>
+        /// <param name="celt">The number of items to retrieve.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT Skip(uint celt);
+
+        /// <summary>
+        ///  Resets the enumeration sequence to the beginning.
+        /// </summary>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT Reset();
+
+        /// <summary>
+        ///  Creates an enumerator that contains the same enumeration state as the current enumerator.
+        /// </summary>
+        /// <param name="ppenum">Pointer to a variable that receives the cloned enumerator.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT Clone(IDiaEnumSegments** ppenum);
+    }
+}

--- a/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaEnumSourceFiles.cs
+++ b/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaEnumSourceFiles.cs
@@ -1,0 +1,187 @@
+﻿// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Runtime.InteropServices;
+
+// For some reason the XML comment refs for IUnknown can't be resolved on .NET Framework without
+// explicitly using the fully qualified name, which falls afoul of the simplify warning.
+using ComIUnknown = Windows.Win32.System.Com.IUnknown;
+
+namespace Microsoft.VisualStudio.Debugging.DebugInterfaceAccess;
+
+/// <inheritdoc cref="Interface"/>
+public unsafe struct IDiaEnumSourceFiles : IComIID
+{
+    /// <inheritdoc cref="IComIID.Guid"/>
+#pragma warning disable IDE1006 // Naming Styles
+    public static readonly Guid IID_Guid = new(0x10F3DBD9, 0x664F, 0x4469, 0xB8, 0x08, 0x94, 0x71, 0xC7, 0xA5, 0x05, 0x38);
+#pragma warning restore IDE1006
+
+#if NETFRAMEWORK
+    readonly ref readonly Guid IComIID.Guid => ref IID_Guid;
+#else
+    static ref readonly Guid IComIID.Guid
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get
+        {
+            ReadOnlySpan<byte> data =
+            [
+                0xD9, 0xDB, 0xF3, 0x10,
+                0x4F, 0x66,
+                0x69, 0x44,
+                0xB8, 0x08, 0x94, 0x71, 0xC7, 0xA5, 0x05, 0x38
+            ];
+
+            return ref Unsafe.As<byte, Guid>(ref MemoryMarshal.GetReference(data));
+        }
+    }
+#endif
+
+    private readonly void** _lpVtbl;
+
+    /// <inheritdoc cref="ComIUnknown.QueryInterface(Guid*, void**)"/>
+    public HRESULT QueryInterface(Guid* riid, void** ppvObject)
+    {
+        fixed (IDiaEnumSourceFiles* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumSourceFiles*, Guid*, void**, HRESULT>)_lpVtbl[0])(pThis, riid, ppvObject);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.AddRef"/>
+    public uint AddRef()
+    {
+        fixed (IDiaEnumSourceFiles* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumSourceFiles*, uint>)_lpVtbl[1])(pThis);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.Release"/>
+    public uint Release()
+    {
+        fixed (IDiaEnumSourceFiles* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumSourceFiles*, uint>)_lpVtbl[2])(pThis);
+    }
+
+    /// <inheritdoc cref="Interface.get__NewEnum"/>
+    public HRESULT get__NewEnum(IUnknown** pRetVal)
+    {
+        fixed (IDiaEnumSourceFiles* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumSourceFiles*, IUnknown**, HRESULT>)_lpVtbl[3])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_Count"/>
+    public HRESULT get_Count(int* pRetVal)
+    {
+        fixed (IDiaEnumSourceFiles* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumSourceFiles*, int*, HRESULT>)_lpVtbl[4])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.Item"/>
+    public HRESULT Item(uint index, IDiaSourceFile** sourceFile)
+    {
+        fixed (IDiaEnumSourceFiles* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumSourceFiles*, uint, IDiaSourceFile**, HRESULT>)_lpVtbl[5])(pThis, index, sourceFile);
+    }
+
+    /// <inheritdoc cref="Interface.Next"/>
+    public HRESULT Next(uint celt, IDiaSourceFile** rgelt, uint* pceltFetched)
+    {
+        fixed (IDiaEnumSourceFiles* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumSourceFiles*, uint, IDiaSourceFile**, uint*, HRESULT>)_lpVtbl[6])(pThis, celt, rgelt, pceltFetched);
+    }
+
+    /// <inheritdoc cref="Interface.Skip"/>
+    public HRESULT Skip(uint celt)
+    {
+        fixed (IDiaEnumSourceFiles* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumSourceFiles*, uint, HRESULT>)_lpVtbl[7])(pThis, celt);
+    }
+
+    /// <inheritdoc cref="Interface.Reset"/>
+    public HRESULT Reset()
+    {
+        fixed (IDiaEnumSourceFiles* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumSourceFiles*, HRESULT>)_lpVtbl[8])(pThis);
+    }
+
+    /// <inheritdoc cref="Interface.Clone"/>
+    public HRESULT Clone(IDiaEnumSourceFiles** ppenum)
+    {
+        fixed (IDiaEnumSourceFiles* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumSourceFiles*, IDiaEnumSourceFiles**, HRESULT>)_lpVtbl[9])(pThis, ppenum);
+    }
+
+    /// <summary>
+    ///  Enumerates the various source files contained in the data source.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/visualstudio/debugger/debug-interface-access/idiaenumsourcefiles">
+    ///    Official documentation.
+    ///   </see>
+    ///  </para>
+    /// </remarks>
+    [ComImport]
+    [Guid("10F3DBD9-664F-4469-B808-9471C7A50538")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    public unsafe interface Interface
+    {
+        /// <summary>
+        ///  Retrieves a version of this enumerator as a COM <c>IEnumVARIANT</c> enumerator.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get__NewEnum(IUnknown** pRetVal);
+
+        /// <summary>
+        ///  Number of source files.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_Count(int* pRetVal);
+
+        /// <summary>
+        ///  Returns the source file for the given index.
+        /// </summary>
+        /// <param name="index">The zero-based index of the item to retrieve.</param>
+        /// <param name="sourceFile">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT Item(uint index, IDiaSourceFile** sourceFile);
+
+        /// <summary>
+        ///  Retrieves the next item or items in the enumeration sequence.
+        /// </summary>
+        /// <param name="celt">The number of items to retrieve.</param>
+        /// <param name="rgelt">Pointer to a variable that receives the requested object.</param>
+        /// <param name="pceltFetched">Pointer to a variable that receives the number of items actually retrieved.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT Next(uint celt, IDiaSourceFile** rgelt, uint* pceltFetched);
+
+        /// <summary>
+        ///  Skips a specified number of items in the enumeration sequence.
+        /// </summary>
+        /// <param name="celt">The number of items to retrieve.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT Skip(uint celt);
+
+        /// <summary>
+        ///  Resets the enumeration sequence to the beginning.
+        /// </summary>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT Reset();
+
+        /// <summary>
+        ///  Creates an enumerator that contains the same enumeration state as the current enumerator.
+        /// </summary>
+        /// <param name="ppenum">Pointer to a variable that receives the cloned enumerator.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT Clone(IDiaEnumSourceFiles** ppenum);
+    }
+}

--- a/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaEnumSourceLink.cs
+++ b/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaEnumSourceLink.cs
@@ -1,0 +1,171 @@
+﻿// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Runtime.InteropServices;
+
+// For some reason the XML comment refs for IUnknown can't be resolved on .NET Framework without
+// explicitly using the fully qualified name, which falls afoul of the simplify warning.
+using ComIUnknown = Windows.Win32.System.Com.IUnknown;
+
+namespace Microsoft.VisualStudio.Debugging.DebugInterfaceAccess;
+
+/// <inheritdoc cref="Interface"/>
+public unsafe struct IDiaEnumSourceLink : IComIID
+{
+    /// <inheritdoc cref="IComIID.Guid"/>
+#pragma warning disable IDE1006 // Naming Styles
+    public static readonly Guid IID_Guid = new(0x45CD1EB3, 0x5C6C, 0x43E3, 0xB2, 0x0A, 0xA4, 0xD8, 0x03, 0x5D, 0xE4, 0xE2);
+#pragma warning restore IDE1006
+
+#if NETFRAMEWORK
+    readonly ref readonly Guid IComIID.Guid => ref IID_Guid;
+#else
+    static ref readonly Guid IComIID.Guid
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get
+        {
+            ReadOnlySpan<byte> data =
+            [
+                0xB3, 0x1E, 0xCD, 0x45,
+                0x6C, 0x5C,
+                0xE3, 0x43,
+                0xB2, 0x0A, 0xA4, 0xD8, 0x03, 0x5D, 0xE4, 0xE2
+            ];
+
+            return ref Unsafe.As<byte, Guid>(ref MemoryMarshal.GetReference(data));
+        }
+    }
+#endif
+
+    private readonly void** _lpVtbl;
+
+    /// <inheritdoc cref="ComIUnknown.QueryInterface(Guid*, void**)"/>
+    public HRESULT QueryInterface(Guid* riid, void** ppvObject)
+    {
+        fixed (IDiaEnumSourceLink* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumSourceLink*, Guid*, void**, HRESULT>)_lpVtbl[0])(pThis, riid, ppvObject);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.AddRef"/>
+    public uint AddRef()
+    {
+        fixed (IDiaEnumSourceLink* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumSourceLink*, uint>)_lpVtbl[1])(pThis);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.Release"/>
+    public uint Release()
+    {
+        fixed (IDiaEnumSourceLink* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumSourceLink*, uint>)_lpVtbl[2])(pThis);
+    }
+
+    /// <inheritdoc cref="Interface.Count"/>
+    public HRESULT Count(uint* pCnt)
+    {
+        fixed (IDiaEnumSourceLink* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumSourceLink*, uint*, HRESULT>)_lpVtbl[3])(pThis, pCnt);
+    }
+
+    /// <inheritdoc cref="Interface.SizeOfNext"/>
+    public HRESULT SizeOfNext(uint* pcb)
+    {
+        fixed (IDiaEnumSourceLink* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumSourceLink*, uint*, HRESULT>)_lpVtbl[4])(pThis, pcb);
+    }
+
+    /// <inheritdoc cref="Interface.Next"/>
+    public HRESULT Next(uint cb, uint* pcb, byte* pb)
+    {
+        fixed (IDiaEnumSourceLink* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumSourceLink*, uint, uint*, byte*, HRESULT>)_lpVtbl[5])(pThis, cb, pcb, pb);
+    }
+
+    /// <inheritdoc cref="Interface.Skip"/>
+    public HRESULT Skip(uint cnt)
+    {
+        fixed (IDiaEnumSourceLink* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumSourceLink*, uint, HRESULT>)_lpVtbl[6])(pThis, cnt);
+    }
+
+    /// <inheritdoc cref="Interface.Reset"/>
+    public HRESULT Reset()
+    {
+        fixed (IDiaEnumSourceLink* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumSourceLink*, HRESULT>)_lpVtbl[7])(pThis);
+    }
+
+    /// <inheritdoc cref="Interface.Clone"/>
+    public HRESULT Clone(IDiaEnumSourceLink** ppenum)
+    {
+        fixed (IDiaEnumSourceLink* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumSourceLink*, IDiaEnumSourceLink**, HRESULT>)_lpVtbl[8])(pThis, ppenum);
+    }
+
+    /// <summary>
+    ///  Enumerates source link key and value pairs.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/visualstudio/debugger/debug-interface-access/idiaenumsourcelink">
+    ///    Official documentation.
+    ///   </see>
+    ///  </para>
+    /// </remarks>
+    [ComImport]
+    [Guid("45CD1EB3-5C6C-43E3-B20A-A4D8035DE4E2")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    public unsafe interface Interface
+    {
+        /// <summary>
+        ///  Count.
+        /// </summary>
+        /// <param name="pCnt">Pointer to a variable that receives the requested value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT Count(uint* pCnt);
+
+        /// <summary>
+        ///  Size of next.
+        /// </summary>
+        /// <param name="pcb">Pointer to a variable that receives the number of bytes written to the buffer.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT SizeOfNext(uint* pcb);
+
+        /// <summary>
+        ///  Retrieves the next item or items in the enumeration sequence.
+        /// </summary>
+        /// <param name="cb">The size, in bytes, of the buffer.</param>
+        /// <param name="pcb">Pointer to a variable that receives the number of bytes written to the buffer.</param>
+        /// <param name="pb">Pointer to a caller-allocated buffer that receives the data.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT Next(uint cb, uint* pcb, byte* pb);
+
+        /// <summary>
+        ///  Skips a specified number of items in the enumeration sequence.
+        /// </summary>
+        /// <param name="cnt">The cnt value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT Skip(uint cnt);
+
+        /// <summary>
+        ///  Resets the enumeration sequence to the beginning.
+        /// </summary>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT Reset();
+
+        /// <summary>
+        ///  Creates an enumerator that contains the same enumeration state as the current enumerator.
+        /// </summary>
+        /// <param name="ppenum">Pointer to a variable that receives the cloned enumerator.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT Clone(IDiaEnumSourceLink** ppenum);
+    }
+}

--- a/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaEnumSourceLink2.cs
+++ b/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaEnumSourceLink2.cs
@@ -1,0 +1,154 @@
+﻿// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Runtime.InteropServices;
+
+// For some reason the XML comment refs for IUnknown can't be resolved on .NET Framework without
+// explicitly using the fully qualified name, which falls afoul of the simplify warning.
+using ComIUnknown = Windows.Win32.System.Com.IUnknown;
+
+namespace Microsoft.VisualStudio.Debugging.DebugInterfaceAccess;
+
+/// <inheritdoc cref="Interface"/>
+public unsafe struct IDiaEnumSourceLink2 : IComIID
+{
+    /// <inheritdoc cref="IComIID.Guid"/>
+#pragma warning disable IDE1006 // Naming Styles
+    public static readonly Guid IID_Guid = new(0x136D8151, 0xADE7, 0x4704, 0xAF, 0x13, 0x32, 0x40, 0x80, 0x76, 0x2E, 0x8F);
+#pragma warning restore IDE1006
+
+#if NETFRAMEWORK
+    readonly ref readonly Guid IComIID.Guid => ref IID_Guid;
+#else
+    static ref readonly Guid IComIID.Guid
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get
+        {
+            ReadOnlySpan<byte> data =
+            [
+                0x51, 0x81, 0x6D, 0x13,
+                0xE7, 0xAD,
+                0x04, 0x47,
+                0xAF, 0x13, 0x32, 0x40, 0x80, 0x76, 0x2E, 0x8F
+            ];
+
+            return ref Unsafe.As<byte, Guid>(ref MemoryMarshal.GetReference(data));
+        }
+    }
+#endif
+
+    private readonly void** _lpVtbl;
+
+    /// <inheritdoc cref="ComIUnknown.QueryInterface(Guid*, void**)"/>
+    public HRESULT QueryInterface(Guid* riid, void** ppvObject)
+    {
+        fixed (IDiaEnumSourceLink2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumSourceLink2*, Guid*, void**, HRESULT>)_lpVtbl[0])(pThis, riid, ppvObject);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.AddRef"/>
+    public uint AddRef()
+    {
+        fixed (IDiaEnumSourceLink2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumSourceLink2*, uint>)_lpVtbl[1])(pThis);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.Release"/>
+    public uint Release()
+    {
+        fixed (IDiaEnumSourceLink2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumSourceLink2*, uint>)_lpVtbl[2])(pThis);
+    }
+
+    /// <inheritdoc cref="IDiaEnumSourceLink.Interface.Count"/>
+    public HRESULT Count(uint* pCnt)
+    {
+        fixed (IDiaEnumSourceLink2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumSourceLink2*, uint*, HRESULT>)_lpVtbl[3])(pThis, pCnt);
+    }
+
+    /// <inheritdoc cref="IDiaEnumSourceLink.Interface.SizeOfNext"/>
+    public HRESULT SizeOfNext(uint* pcb)
+    {
+        fixed (IDiaEnumSourceLink2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumSourceLink2*, uint*, HRESULT>)_lpVtbl[4])(pThis, pcb);
+    }
+
+    /// <inheritdoc cref="IDiaEnumSourceLink.Interface.Next"/>
+    public HRESULT Next(uint cb, uint* pcb, byte* pb)
+    {
+        fixed (IDiaEnumSourceLink2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumSourceLink2*, uint, uint*, byte*, HRESULT>)_lpVtbl[5])(pThis, cb, pcb, pb);
+    }
+
+    /// <inheritdoc cref="IDiaEnumSourceLink.Interface.Skip"/>
+    public HRESULT Skip(uint cnt)
+    {
+        fixed (IDiaEnumSourceLink2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumSourceLink2*, uint, HRESULT>)_lpVtbl[6])(pThis, cnt);
+    }
+
+    /// <inheritdoc cref="IDiaEnumSourceLink.Interface.Reset"/>
+    public HRESULT Reset()
+    {
+        fixed (IDiaEnumSourceLink2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumSourceLink2*, HRESULT>)_lpVtbl[7])(pThis);
+    }
+
+    /// <inheritdoc cref="IDiaEnumSourceLink.Interface.Clone"/>
+    public HRESULT Clone(IDiaEnumSourceLink** ppenum)
+    {
+        fixed (IDiaEnumSourceLink2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumSourceLink2*, IDiaEnumSourceLink**, HRESULT>)_lpVtbl[8])(pThis, ppenum);
+    }
+
+    /// <inheritdoc cref="Interface.SizeOfNext2"/>
+    public HRESULT SizeOfNext2(ulong* pcb)
+    {
+        fixed (IDiaEnumSourceLink2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumSourceLink2*, ulong*, HRESULT>)_lpVtbl[9])(pThis, pcb);
+    }
+
+    /// <inheritdoc cref="Interface.Next2"/>
+    public HRESULT Next2(ulong cb, ulong* pcb, byte* pb)
+    {
+        fixed (IDiaEnumSourceLink2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumSourceLink2*, ulong, ulong*, byte*, HRESULT>)_lpVtbl[10])(pThis, cb, pcb, pb);
+    }
+
+    /// <summary>
+    ///  Extends IDiaEnumSourceLink with support for larger source link streams.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/visualstudio/debugger/debug-interface-access/idiaenumsourcelink2">
+    ///    Official documentation.
+    ///   </see>
+    ///  </para>
+    /// </remarks>
+    [ComImport]
+    [Guid("136D8151-ADE7-4704-AF13-324080762E8F")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    public unsafe interface Interface : IDiaEnumSourceLink.Interface
+    {
+        /// <summary>
+        ///  Size of next2.
+        /// </summary>
+        /// <param name="pcb">Pointer to a variable that receives the number of bytes written to the buffer.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT SizeOfNext2(ulong* pcb);
+
+        /// <summary>
+        ///  Next2.
+        /// </summary>
+        /// <param name="cb">The size, in bytes, of the buffer.</param>
+        /// <param name="pcb">Pointer to a variable that receives the number of bytes written to the buffer.</param>
+        /// <param name="pb">Pointer to a caller-allocated buffer that receives the data.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT Next2(ulong cb, ulong* pcb, byte* pb);
+    }
+}

--- a/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaEnumStackFrames.cs
+++ b/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaEnumStackFrames.cs
@@ -1,0 +1,111 @@
+﻿// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Runtime.InteropServices;
+
+// For some reason the XML comment refs for IUnknown can't be resolved on .NET Framework without
+// explicitly using the fully qualified name, which falls afoul of the simplify warning.
+using ComIUnknown = Windows.Win32.System.Com.IUnknown;
+
+namespace Microsoft.VisualStudio.Debugging.DebugInterfaceAccess;
+
+/// <inheritdoc cref="Interface"/>
+public unsafe struct IDiaEnumStackFrames : IComIID
+{
+    /// <inheritdoc cref="IComIID.Guid"/>
+#pragma warning disable IDE1006 // Naming Styles
+    public static readonly Guid IID_Guid = new(0xEC9D461D, 0xCE74, 0x4711, 0xA0, 0x20, 0x7D, 0x8F, 0x9A, 0x1D, 0xD2, 0x55);
+#pragma warning restore IDE1006
+
+#if NETFRAMEWORK
+    readonly ref readonly Guid IComIID.Guid => ref IID_Guid;
+#else
+    static ref readonly Guid IComIID.Guid
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get
+        {
+            ReadOnlySpan<byte> data =
+            [
+                0x1D, 0x46, 0x9D, 0xEC,
+                0x74, 0xCE,
+                0x11, 0x47,
+                0xA0, 0x20, 0x7D, 0x8F, 0x9A, 0x1D, 0xD2, 0x55
+            ];
+
+            return ref Unsafe.As<byte, Guid>(ref MemoryMarshal.GetReference(data));
+        }
+    }
+#endif
+
+    private readonly void** _lpVtbl;
+
+    /// <inheritdoc cref="ComIUnknown.QueryInterface(Guid*, void**)"/>
+    public HRESULT QueryInterface(Guid* riid, void** ppvObject)
+    {
+        fixed (IDiaEnumStackFrames* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumStackFrames*, Guid*, void**, HRESULT>)_lpVtbl[0])(pThis, riid, ppvObject);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.AddRef"/>
+    public uint AddRef()
+    {
+        fixed (IDiaEnumStackFrames* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumStackFrames*, uint>)_lpVtbl[1])(pThis);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.Release"/>
+    public uint Release()
+    {
+        fixed (IDiaEnumStackFrames* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumStackFrames*, uint>)_lpVtbl[2])(pThis);
+    }
+
+    /// <inheritdoc cref="Interface.Next"/>
+    public HRESULT Next(uint celt, IDiaStackFrame** rgelt, uint* pceltFetched)
+    {
+        fixed (IDiaEnumStackFrames* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumStackFrames*, uint, IDiaStackFrame**, uint*, HRESULT>)_lpVtbl[3])(pThis, celt, rgelt, pceltFetched);
+    }
+
+    /// <inheritdoc cref="Interface.Reset"/>
+    public HRESULT Reset()
+    {
+        fixed (IDiaEnumStackFrames* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumStackFrames*, HRESULT>)_lpVtbl[4])(pThis);
+    }
+
+    /// <summary>
+    ///  Enumerates the various stack frames available in a particular context.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/visualstudio/debugger/debug-interface-access/idiaenumstackframes">
+    ///    Official documentation.
+    ///   </see>
+    ///  </para>
+    /// </remarks>
+    [ComImport]
+    [Guid("EC9D461D-CE74-4711-A020-7D8F9A1DD255")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    public unsafe interface Interface
+    {
+        /// <summary>
+        ///  Retrieves the next item or items in the enumeration sequence.
+        /// </summary>
+        /// <param name="celt">The number of items to retrieve.</param>
+        /// <param name="rgelt">Pointer to a variable that receives the requested object.</param>
+        /// <param name="pceltFetched">Pointer to a variable that receives the number of items actually retrieved.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT Next(uint celt, IDiaStackFrame** rgelt, uint* pceltFetched);
+
+        /// <summary>
+        ///  Resets the enumeration sequence to the beginning.
+        /// </summary>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT Reset();
+    }
+}

--- a/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaEnumSymbols.cs
+++ b/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaEnumSymbols.cs
@@ -1,0 +1,187 @@
+﻿// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Runtime.InteropServices;
+
+// For some reason the XML comment refs for IUnknown can't be resolved on .NET Framework without
+// explicitly using the fully qualified name, which falls afoul of the simplify warning.
+using ComIUnknown = Windows.Win32.System.Com.IUnknown;
+
+namespace Microsoft.VisualStudio.Debugging.DebugInterfaceAccess;
+
+/// <inheritdoc cref="Interface"/>
+public unsafe struct IDiaEnumSymbols : IComIID
+{
+    /// <inheritdoc cref="IComIID.Guid"/>
+#pragma warning disable IDE1006 // Naming Styles
+    public static readonly Guid IID_Guid = new(0xCAB72C48, 0x443B, 0x48F5, 0x9B, 0x0B, 0x42, 0xF0, 0x82, 0x0A, 0xB2, 0x9A);
+#pragma warning restore IDE1006
+
+#if NETFRAMEWORK
+    readonly ref readonly Guid IComIID.Guid => ref IID_Guid;
+#else
+    static ref readonly Guid IComIID.Guid
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get
+        {
+            ReadOnlySpan<byte> data =
+            [
+                0x48, 0x2C, 0xB7, 0xCA,
+                0x3B, 0x44,
+                0xF5, 0x48,
+                0x9B, 0x0B, 0x42, 0xF0, 0x82, 0x0A, 0xB2, 0x9A
+            ];
+
+            return ref Unsafe.As<byte, Guid>(ref MemoryMarshal.GetReference(data));
+        }
+    }
+#endif
+
+    private readonly void** _lpVtbl;
+
+    /// <inheritdoc cref="ComIUnknown.QueryInterface(Guid*, void**)"/>
+    public HRESULT QueryInterface(Guid* riid, void** ppvObject)
+    {
+        fixed (IDiaEnumSymbols* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumSymbols*, Guid*, void**, HRESULT>)_lpVtbl[0])(pThis, riid, ppvObject);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.AddRef"/>
+    public uint AddRef()
+    {
+        fixed (IDiaEnumSymbols* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumSymbols*, uint>)_lpVtbl[1])(pThis);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.Release"/>
+    public uint Release()
+    {
+        fixed (IDiaEnumSymbols* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumSymbols*, uint>)_lpVtbl[2])(pThis);
+    }
+
+    /// <inheritdoc cref="Interface.get__NewEnum"/>
+    public HRESULT get__NewEnum(IUnknown** pRetVal)
+    {
+        fixed (IDiaEnumSymbols* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumSymbols*, IUnknown**, HRESULT>)_lpVtbl[3])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_Count"/>
+    public HRESULT get_Count(int* pRetVal)
+    {
+        fixed (IDiaEnumSymbols* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumSymbols*, int*, HRESULT>)_lpVtbl[4])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.Item"/>
+    public HRESULT Item(uint index, IDiaSymbol** symbol)
+    {
+        fixed (IDiaEnumSymbols* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumSymbols*, uint, IDiaSymbol**, HRESULT>)_lpVtbl[5])(pThis, index, symbol);
+    }
+
+    /// <inheritdoc cref="Interface.Next"/>
+    public HRESULT Next(uint celt, IDiaSymbol** rgelt, uint* pceltFetched)
+    {
+        fixed (IDiaEnumSymbols* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumSymbols*, uint, IDiaSymbol**, uint*, HRESULT>)_lpVtbl[6])(pThis, celt, rgelt, pceltFetched);
+    }
+
+    /// <inheritdoc cref="Interface.Skip"/>
+    public HRESULT Skip(uint celt)
+    {
+        fixed (IDiaEnumSymbols* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumSymbols*, uint, HRESULT>)_lpVtbl[7])(pThis, celt);
+    }
+
+    /// <inheritdoc cref="Interface.Reset"/>
+    public HRESULT Reset()
+    {
+        fixed (IDiaEnumSymbols* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumSymbols*, HRESULT>)_lpVtbl[8])(pThis);
+    }
+
+    /// <inheritdoc cref="Interface.Clone"/>
+    public HRESULT Clone(IDiaEnumSymbols** ppenum)
+    {
+        fixed (IDiaEnumSymbols* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumSymbols*, IDiaEnumSymbols**, HRESULT>)_lpVtbl[9])(pThis, ppenum);
+    }
+
+    /// <summary>
+    ///  Enumerates the various symbols contained in the data source.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/visualstudio/debugger/debug-interface-access/idiaenumsymbols">
+    ///    Official documentation.
+    ///   </see>
+    ///  </para>
+    /// </remarks>
+    [ComImport]
+    [Guid("CAB72C48-443B-48F5-9B0B-42F0820AB29A")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    public unsafe interface Interface
+    {
+        /// <summary>
+        ///  Retrieves a version of this enumerator as a COM <c>IEnumVARIANT</c> enumerator.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get__NewEnum(IUnknown** pRetVal);
+
+        /// <summary>
+        ///  Number of symbols.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_Count(int* pRetVal);
+
+        /// <summary>
+        ///  Returns the symbol for the given index.
+        /// </summary>
+        /// <param name="index">The zero-based index of the item to retrieve.</param>
+        /// <param name="symbol">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT Item(uint index, IDiaSymbol** symbol);
+
+        /// <summary>
+        ///  Retrieves the next item or items in the enumeration sequence.
+        /// </summary>
+        /// <param name="celt">The number of items to retrieve.</param>
+        /// <param name="rgelt">Pointer to a variable that receives the requested object.</param>
+        /// <param name="pceltFetched">Pointer to a variable that receives the number of items actually retrieved.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT Next(uint celt, IDiaSymbol** rgelt, uint* pceltFetched);
+
+        /// <summary>
+        ///  Skips a specified number of items in the enumeration sequence.
+        /// </summary>
+        /// <param name="celt">The number of items to retrieve.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT Skip(uint celt);
+
+        /// <summary>
+        ///  Resets the enumeration sequence to the beginning.
+        /// </summary>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT Reset();
+
+        /// <summary>
+        ///  Creates an enumerator that contains the same enumeration state as the current enumerator.
+        /// </summary>
+        /// <param name="ppenum">Pointer to a variable that receives the cloned enumerator.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT Clone(IDiaEnumSymbols** ppenum);
+    }
+}

--- a/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaEnumSymbolsByAddr.cs
+++ b/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaEnumSymbolsByAddr.cs
@@ -1,0 +1,178 @@
+﻿// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Runtime.InteropServices;
+
+// For some reason the XML comment refs for IUnknown can't be resolved on .NET Framework without
+// explicitly using the fully qualified name, which falls afoul of the simplify warning.
+using ComIUnknown = Windows.Win32.System.Com.IUnknown;
+
+namespace Microsoft.VisualStudio.Debugging.DebugInterfaceAccess;
+
+/// <inheritdoc cref="Interface"/>
+public unsafe struct IDiaEnumSymbolsByAddr : IComIID
+{
+    /// <inheritdoc cref="IComIID.Guid"/>
+#pragma warning disable IDE1006 // Naming Styles
+    public static readonly Guid IID_Guid = new(0x624B7D9C, 0x24EA, 0x4421, 0x9D, 0x06, 0x3B, 0x57, 0x74, 0x71, 0xC1, 0xFA);
+#pragma warning restore IDE1006
+
+#if NETFRAMEWORK
+    readonly ref readonly Guid IComIID.Guid => ref IID_Guid;
+#else
+    static ref readonly Guid IComIID.Guid
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get
+        {
+            ReadOnlySpan<byte> data =
+            [
+                0x9C, 0x7D, 0x4B, 0x62,
+                0xEA, 0x24,
+                0x21, 0x44,
+                0x9D, 0x06, 0x3B, 0x57, 0x74, 0x71, 0xC1, 0xFA
+            ];
+
+            return ref Unsafe.As<byte, Guid>(ref MemoryMarshal.GetReference(data));
+        }
+    }
+#endif
+
+    private readonly void** _lpVtbl;
+
+    /// <inheritdoc cref="ComIUnknown.QueryInterface(Guid*, void**)"/>
+    public HRESULT QueryInterface(Guid* riid, void** ppvObject)
+    {
+        fixed (IDiaEnumSymbolsByAddr* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumSymbolsByAddr*, Guid*, void**, HRESULT>)_lpVtbl[0])(pThis, riid, ppvObject);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.AddRef"/>
+    public uint AddRef()
+    {
+        fixed (IDiaEnumSymbolsByAddr* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumSymbolsByAddr*, uint>)_lpVtbl[1])(pThis);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.Release"/>
+    public uint Release()
+    {
+        fixed (IDiaEnumSymbolsByAddr* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumSymbolsByAddr*, uint>)_lpVtbl[2])(pThis);
+    }
+
+    /// <inheritdoc cref="Interface.symbolByAddr"/>
+    public HRESULT symbolByAddr(uint isect, uint offset, IDiaSymbol** ppSymbol)
+    {
+        fixed (IDiaEnumSymbolsByAddr* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumSymbolsByAddr*, uint, uint, IDiaSymbol**, HRESULT>)_lpVtbl[3])(pThis, isect, offset, ppSymbol);
+    }
+
+    /// <inheritdoc cref="Interface.symbolByRVA"/>
+    public HRESULT symbolByRVA(uint relativeVirtualAddress, IDiaSymbol** ppSymbol)
+    {
+        fixed (IDiaEnumSymbolsByAddr* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumSymbolsByAddr*, uint, IDiaSymbol**, HRESULT>)_lpVtbl[4])(pThis, relativeVirtualAddress, ppSymbol);
+    }
+
+    /// <inheritdoc cref="Interface.symbolByVA"/>
+    public HRESULT symbolByVA(ulong virtualAddress, IDiaSymbol** ppSymbol)
+    {
+        fixed (IDiaEnumSymbolsByAddr* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumSymbolsByAddr*, ulong, IDiaSymbol**, HRESULT>)_lpVtbl[5])(pThis, virtualAddress, ppSymbol);
+    }
+
+    /// <inheritdoc cref="Interface.Next"/>
+    public HRESULT Next(uint celt, IDiaSymbol** rgelt, uint* pceltFetched)
+    {
+        fixed (IDiaEnumSymbolsByAddr* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumSymbolsByAddr*, uint, IDiaSymbol**, uint*, HRESULT>)_lpVtbl[6])(pThis, celt, rgelt, pceltFetched);
+    }
+
+    /// <inheritdoc cref="Interface.Prev"/>
+    public HRESULT Prev(uint celt, IDiaSymbol** rgelt, uint* pceltFetched)
+    {
+        fixed (IDiaEnumSymbolsByAddr* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumSymbolsByAddr*, uint, IDiaSymbol**, uint*, HRESULT>)_lpVtbl[7])(pThis, celt, rgelt, pceltFetched);
+    }
+
+    /// <inheritdoc cref="Interface.Clone"/>
+    public HRESULT Clone(IDiaEnumSymbolsByAddr** ppenum)
+    {
+        fixed (IDiaEnumSymbolsByAddr* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumSymbolsByAddr*, IDiaEnumSymbolsByAddr**, HRESULT>)_lpVtbl[8])(pThis, ppenum);
+    }
+
+    /// <summary>
+    ///  Enumerates by address the various symbols contained in the data source.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/visualstudio/debugger/debug-interface-access/idiaenumsymbolsbyaddr">
+    ///    Official documentation.
+    ///   </see>
+    ///  </para>
+    /// </remarks>
+    [ComImport]
+    [Guid("624B7D9C-24EA-4421-9D06-3B577471C1FA")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    public unsafe interface Interface
+    {
+        /// <summary>
+        ///  Returns the symbol for the given address.
+        /// </summary>
+        /// <param name="isect">The section index component of the address.</param>
+        /// <param name="offset">The offset component of the address within the section.</param>
+        /// <param name="ppSymbol">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT symbolByAddr(uint isect, uint offset, IDiaSymbol** ppSymbol);
+
+        /// <summary>
+        ///  Returns the symbol for the given relative virtual address.
+        /// </summary>
+        /// <param name="relativeVirtualAddress">The relativeVirtualAddress value.</param>
+        /// <param name="ppSymbol">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT symbolByRVA(uint relativeVirtualAddress, IDiaSymbol** ppSymbol);
+
+        /// <summary>
+        ///  Returns the symbol for the given virtual address.
+        /// </summary>
+        /// <param name="virtualAddress">The virtualAddress value.</param>
+        /// <param name="ppSymbol">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT symbolByVA(ulong virtualAddress, IDiaSymbol** ppSymbol);
+
+        /// <summary>
+        ///  Retrieves the next item or items in the enumeration sequence.
+        /// </summary>
+        /// <param name="celt">The number of items to retrieve.</param>
+        /// <param name="rgelt">Pointer to a variable that receives the requested object.</param>
+        /// <param name="pceltFetched">Pointer to a variable that receives the number of items actually retrieved.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT Next(uint celt, IDiaSymbol** rgelt, uint* pceltFetched);
+
+        /// <summary>
+        ///  Prev.
+        /// </summary>
+        /// <param name="celt">The number of items to retrieve.</param>
+        /// <param name="rgelt">Pointer to a variable that receives the requested object.</param>
+        /// <param name="pceltFetched">Pointer to a variable that receives the number of items actually retrieved.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT Prev(uint celt, IDiaSymbol** rgelt, uint* pceltFetched);
+
+        /// <summary>
+        ///  Creates an enumerator that contains the same enumeration state as the current enumerator.
+        /// </summary>
+        /// <param name="ppenum">Pointer to a variable that receives the cloned enumerator.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT Clone(IDiaEnumSymbolsByAddr** ppenum);
+    }
+}

--- a/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaEnumSymbolsByAddr2.cs
+++ b/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaEnumSymbolsByAddr2.cs
@@ -1,0 +1,210 @@
+﻿// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Runtime.InteropServices;
+
+// For some reason the XML comment refs for IUnknown can't be resolved on .NET Framework without
+// explicitly using the fully qualified name, which falls afoul of the simplify warning.
+using ComIUnknown = Windows.Win32.System.Com.IUnknown;
+
+namespace Microsoft.VisualStudio.Debugging.DebugInterfaceAccess;
+
+/// <inheritdoc cref="Interface"/>
+public unsafe struct IDiaEnumSymbolsByAddr2 : IComIID
+{
+    /// <inheritdoc cref="IComIID.Guid"/>
+#pragma warning disable IDE1006 // Naming Styles
+    public static readonly Guid IID_Guid = new(0x1E45BD02, 0xBE45, 0x4D71, 0xBA, 0x32, 0x0E, 0x57, 0x6C, 0xFC, 0xD5, 0x9F);
+#pragma warning restore IDE1006
+
+#if NETFRAMEWORK
+    readonly ref readonly Guid IComIID.Guid => ref IID_Guid;
+#else
+    static ref readonly Guid IComIID.Guid
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get
+        {
+            ReadOnlySpan<byte> data =
+            [
+                0x02, 0xBD, 0x45, 0x1E,
+                0x45, 0xBE,
+                0x71, 0x4D,
+                0xBA, 0x32, 0x0E, 0x57, 0x6C, 0xFC, 0xD5, 0x9F
+            ];
+
+            return ref Unsafe.As<byte, Guid>(ref MemoryMarshal.GetReference(data));
+        }
+    }
+#endif
+
+    private readonly void** _lpVtbl;
+
+    /// <inheritdoc cref="ComIUnknown.QueryInterface(Guid*, void**)"/>
+    public HRESULT QueryInterface(Guid* riid, void** ppvObject)
+    {
+        fixed (IDiaEnumSymbolsByAddr2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumSymbolsByAddr2*, Guid*, void**, HRESULT>)_lpVtbl[0])(pThis, riid, ppvObject);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.AddRef"/>
+    public uint AddRef()
+    {
+        fixed (IDiaEnumSymbolsByAddr2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumSymbolsByAddr2*, uint>)_lpVtbl[1])(pThis);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.Release"/>
+    public uint Release()
+    {
+        fixed (IDiaEnumSymbolsByAddr2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumSymbolsByAddr2*, uint>)_lpVtbl[2])(pThis);
+    }
+
+    /// <inheritdoc cref="IDiaEnumSymbolsByAddr.Interface.symbolByAddr"/>
+    public HRESULT symbolByAddr(uint isect, uint offset, IDiaSymbol** ppSymbol)
+    {
+        fixed (IDiaEnumSymbolsByAddr2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumSymbolsByAddr2*, uint, uint, IDiaSymbol**, HRESULT>)_lpVtbl[3])(pThis, isect, offset, ppSymbol);
+    }
+
+    /// <inheritdoc cref="IDiaEnumSymbolsByAddr.Interface.symbolByRVA"/>
+    public HRESULT symbolByRVA(uint relativeVirtualAddress, IDiaSymbol** ppSymbol)
+    {
+        fixed (IDiaEnumSymbolsByAddr2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumSymbolsByAddr2*, uint, IDiaSymbol**, HRESULT>)_lpVtbl[4])(pThis, relativeVirtualAddress, ppSymbol);
+    }
+
+    /// <inheritdoc cref="IDiaEnumSymbolsByAddr.Interface.symbolByVA"/>
+    public HRESULT symbolByVA(ulong virtualAddress, IDiaSymbol** ppSymbol)
+    {
+        fixed (IDiaEnumSymbolsByAddr2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumSymbolsByAddr2*, ulong, IDiaSymbol**, HRESULT>)_lpVtbl[5])(pThis, virtualAddress, ppSymbol);
+    }
+
+    /// <inheritdoc cref="IDiaEnumSymbolsByAddr.Interface.Next"/>
+    public HRESULT Next(uint celt, IDiaSymbol** rgelt, uint* pceltFetched)
+    {
+        fixed (IDiaEnumSymbolsByAddr2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumSymbolsByAddr2*, uint, IDiaSymbol**, uint*, HRESULT>)_lpVtbl[6])(pThis, celt, rgelt, pceltFetched);
+    }
+
+    /// <inheritdoc cref="IDiaEnumSymbolsByAddr.Interface.Prev"/>
+    public HRESULT Prev(uint celt, IDiaSymbol** rgelt, uint* pceltFetched)
+    {
+        fixed (IDiaEnumSymbolsByAddr2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumSymbolsByAddr2*, uint, IDiaSymbol**, uint*, HRESULT>)_lpVtbl[7])(pThis, celt, rgelt, pceltFetched);
+    }
+
+    /// <inheritdoc cref="IDiaEnumSymbolsByAddr.Interface.Clone"/>
+    public HRESULT Clone(IDiaEnumSymbolsByAddr** ppenum)
+    {
+        fixed (IDiaEnumSymbolsByAddr2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumSymbolsByAddr2*, IDiaEnumSymbolsByAddr**, HRESULT>)_lpVtbl[8])(pThis, ppenum);
+    }
+
+    /// <inheritdoc cref="Interface.symbolByAddrEx"/>
+    public HRESULT symbolByAddrEx(BOOL fPromoteBlockSym, uint isect, uint offset, IDiaSymbol** ppSymbol)
+    {
+        fixed (IDiaEnumSymbolsByAddr2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumSymbolsByAddr2*, BOOL, uint, uint, IDiaSymbol**, HRESULT>)_lpVtbl[9])(pThis, fPromoteBlockSym, isect, offset, ppSymbol);
+    }
+
+    /// <inheritdoc cref="Interface.symbolByRVAEx"/>
+    public HRESULT symbolByRVAEx(BOOL fPromoteBlockSym, uint relativeVirtualAddress, IDiaSymbol** ppSymbol)
+    {
+        fixed (IDiaEnumSymbolsByAddr2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumSymbolsByAddr2*, BOOL, uint, IDiaSymbol**, HRESULT>)_lpVtbl[10])(pThis, fPromoteBlockSym, relativeVirtualAddress, ppSymbol);
+    }
+
+    /// <inheritdoc cref="Interface.symbolByVAEx"/>
+    public HRESULT symbolByVAEx(BOOL fPromoteBlockSym, ulong virtualAddress, IDiaSymbol** ppSymbol)
+    {
+        fixed (IDiaEnumSymbolsByAddr2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumSymbolsByAddr2*, BOOL, ulong, IDiaSymbol**, HRESULT>)_lpVtbl[11])(pThis, fPromoteBlockSym, virtualAddress, ppSymbol);
+    }
+
+    /// <inheritdoc cref="Interface.NextEx"/>
+    public HRESULT NextEx(BOOL fPromoteBlockSym, uint celt, IDiaSymbol** rgelt, uint* pceltFetched)
+    {
+        fixed (IDiaEnumSymbolsByAddr2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumSymbolsByAddr2*, BOOL, uint, IDiaSymbol**, uint*, HRESULT>)_lpVtbl[12])(pThis, fPromoteBlockSym, celt, rgelt, pceltFetched);
+    }
+
+    /// <inheritdoc cref="Interface.PrevEx"/>
+    public HRESULT PrevEx(BOOL fPromoteBlockSym, uint celt, IDiaSymbol** rgelt, uint* pceltFetched)
+    {
+        fixed (IDiaEnumSymbolsByAddr2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumSymbolsByAddr2*, BOOL, uint, IDiaSymbol**, uint*, HRESULT>)_lpVtbl[13])(pThis, fPromoteBlockSym, celt, rgelt, pceltFetched);
+    }
+
+    /// <summary>
+    ///  Extends IDiaEnumSymbolsByAddr with enumeration that can optionally promote block symbols.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/visualstudio/debugger/debug-interface-access/idiaenumsymbolsbyaddr2">
+    ///    Official documentation.
+    ///   </see>
+    ///  </para>
+    /// </remarks>
+    [ComImport]
+    [Guid("1E45BD02-BE45-4D71-BA32-0E576CFCD59F")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    public unsafe interface Interface : IDiaEnumSymbolsByAddr.Interface
+    {
+        /// <summary>
+        ///  Symbol by addr ex.
+        /// </summary>
+        /// <param name="fPromoteBlockSym">The fPromoteBlockSym value.</param>
+        /// <param name="isect">The section index component of the address.</param>
+        /// <param name="offset">The offset component of the address within the section.</param>
+        /// <param name="ppSymbol">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT symbolByAddrEx(BOOL fPromoteBlockSym, uint isect, uint offset, IDiaSymbol** ppSymbol);
+
+        /// <summary>
+        ///  Symbol by rvaex.
+        /// </summary>
+        /// <param name="fPromoteBlockSym">The fPromoteBlockSym value.</param>
+        /// <param name="relativeVirtualAddress">The relativeVirtualAddress value.</param>
+        /// <param name="ppSymbol">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT symbolByRVAEx(BOOL fPromoteBlockSym, uint relativeVirtualAddress, IDiaSymbol** ppSymbol);
+
+        /// <summary>
+        ///  Symbol by vaex.
+        /// </summary>
+        /// <param name="fPromoteBlockSym">The fPromoteBlockSym value.</param>
+        /// <param name="virtualAddress">The virtualAddress value.</param>
+        /// <param name="ppSymbol">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT symbolByVAEx(BOOL fPromoteBlockSym, ulong virtualAddress, IDiaSymbol** ppSymbol);
+
+        /// <summary>
+        ///  Next ex.
+        /// </summary>
+        /// <param name="fPromoteBlockSym">The fPromoteBlockSym value.</param>
+        /// <param name="celt">The number of items to retrieve.</param>
+        /// <param name="rgelt">Pointer to a variable that receives the requested object.</param>
+        /// <param name="pceltFetched">Pointer to a variable that receives the number of items actually retrieved.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT NextEx(BOOL fPromoteBlockSym, uint celt, IDiaSymbol** rgelt, uint* pceltFetched);
+
+        /// <summary>
+        ///  Prev ex.
+        /// </summary>
+        /// <param name="fPromoteBlockSym">The fPromoteBlockSym value.</param>
+        /// <param name="celt">The number of items to retrieve.</param>
+        /// <param name="rgelt">Pointer to a variable that receives the requested object.</param>
+        /// <param name="pceltFetched">Pointer to a variable that receives the number of items actually retrieved.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT PrevEx(BOOL fPromoteBlockSym, uint celt, IDiaSymbol** rgelt, uint* pceltFetched);
+    }
+}

--- a/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaEnumTables.cs
+++ b/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaEnumTables.cs
@@ -1,0 +1,188 @@
+﻿// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Runtime.InteropServices;
+using Windows.Win32.System.Variant;
+
+// For some reason the XML comment refs for IUnknown can't be resolved on .NET Framework without
+// explicitly using the fully qualified name, which falls afoul of the simplify warning.
+using ComIUnknown = Windows.Win32.System.Com.IUnknown;
+
+namespace Microsoft.VisualStudio.Debugging.DebugInterfaceAccess;
+
+/// <inheritdoc cref="Interface"/>
+public unsafe struct IDiaEnumTables : IComIID
+{
+    /// <inheritdoc cref="IComIID.Guid"/>
+#pragma warning disable IDE1006 // Naming Styles
+    public static readonly Guid IID_Guid = new(0xC65C2B0A, 0x1150, 0x4D7A, 0xAF, 0xCC, 0xE0, 0x5B, 0xF3, 0xDE, 0xE8, 0x1E);
+#pragma warning restore IDE1006
+
+#if NETFRAMEWORK
+    readonly ref readonly Guid IComIID.Guid => ref IID_Guid;
+#else
+    static ref readonly Guid IComIID.Guid
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get
+        {
+            ReadOnlySpan<byte> data =
+            [
+                0x0A, 0x2B, 0x5C, 0xC6,
+                0x50, 0x11,
+                0x7A, 0x4D,
+                0xAF, 0xCC, 0xE0, 0x5B, 0xF3, 0xDE, 0xE8, 0x1E
+            ];
+
+            return ref Unsafe.As<byte, Guid>(ref MemoryMarshal.GetReference(data));
+        }
+    }
+#endif
+
+    private readonly void** _lpVtbl;
+
+    /// <inheritdoc cref="ComIUnknown.QueryInterface(Guid*, void**)"/>
+    public HRESULT QueryInterface(Guid* riid, void** ppvObject)
+    {
+        fixed (IDiaEnumTables* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumTables*, Guid*, void**, HRESULT>)_lpVtbl[0])(pThis, riid, ppvObject);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.AddRef"/>
+    public uint AddRef()
+    {
+        fixed (IDiaEnumTables* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumTables*, uint>)_lpVtbl[1])(pThis);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.Release"/>
+    public uint Release()
+    {
+        fixed (IDiaEnumTables* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumTables*, uint>)_lpVtbl[2])(pThis);
+    }
+
+    /// <inheritdoc cref="Interface.get__NewEnum"/>
+    public HRESULT get__NewEnum(IUnknown** pRetVal)
+    {
+        fixed (IDiaEnumTables* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumTables*, IUnknown**, HRESULT>)_lpVtbl[3])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_Count"/>
+    public HRESULT get_Count(int* pRetVal)
+    {
+        fixed (IDiaEnumTables* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumTables*, int*, HRESULT>)_lpVtbl[4])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.Item"/>
+    public HRESULT Item(VARIANT index, IDiaTable** table)
+    {
+        fixed (IDiaEnumTables* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumTables*, VARIANT, IDiaTable**, HRESULT>)_lpVtbl[5])(pThis, index, table);
+    }
+
+    /// <inheritdoc cref="Interface.Next"/>
+    public HRESULT Next(uint celt, IDiaTable** rgelt, uint* pceltFetched)
+    {
+        fixed (IDiaEnumTables* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumTables*, uint, IDiaTable**, uint*, HRESULT>)_lpVtbl[6])(pThis, celt, rgelt, pceltFetched);
+    }
+
+    /// <inheritdoc cref="Interface.Skip"/>
+    public HRESULT Skip(uint celt)
+    {
+        fixed (IDiaEnumTables* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumTables*, uint, HRESULT>)_lpVtbl[7])(pThis, celt);
+    }
+
+    /// <inheritdoc cref="Interface.Reset"/>
+    public HRESULT Reset()
+    {
+        fixed (IDiaEnumTables* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumTables*, HRESULT>)_lpVtbl[8])(pThis);
+    }
+
+    /// <inheritdoc cref="Interface.Clone"/>
+    public HRESULT Clone(IDiaEnumTables** ppenum)
+    {
+        fixed (IDiaEnumTables* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaEnumTables*, IDiaEnumTables**, HRESULT>)_lpVtbl[9])(pThis, ppenum);
+    }
+
+    /// <summary>
+    ///  Enumerates the various tables contained in the data source.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/visualstudio/debugger/debug-interface-access/idiaenumtables">
+    ///    Official documentation.
+    ///   </see>
+    ///  </para>
+    /// </remarks>
+    [ComImport]
+    [Guid("C65C2B0A-1150-4D7A-AFCC-E05BF3DEE81E")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    public unsafe interface Interface
+    {
+        /// <summary>
+        ///  Retrieves a version of this enumerator as a COM <c>IEnumVARIANT</c> enumerator.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get__NewEnum(IUnknown** pRetVal);
+
+        /// <summary>
+        ///  Number of tables.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_Count(int* pRetVal);
+
+        /// <summary>
+        ///  Returns the table for the given index or name.
+        /// </summary>
+        /// <param name="index">The zero-based index of the item to retrieve.</param>
+        /// <param name="table">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT Item(VARIANT index, IDiaTable** table);
+
+        /// <summary>
+        ///  Retrieves the next item or items in the enumeration sequence.
+        /// </summary>
+        /// <param name="celt">The number of items to retrieve.</param>
+        /// <param name="rgelt">The rgelt value.</param>
+        /// <param name="pceltFetched">Pointer to a variable that receives the number of items actually retrieved.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT Next(uint celt, IDiaTable** rgelt, uint* pceltFetched);
+
+        /// <summary>
+        ///  Skips a specified number of items in the enumeration sequence.
+        /// </summary>
+        /// <param name="celt">The number of items to retrieve.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT Skip(uint celt);
+
+        /// <summary>
+        ///  Resets the enumeration sequence to the beginning.
+        /// </summary>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT Reset();
+
+        /// <summary>
+        ///  Creates an enumerator that contains the same enumeration state as the current enumerator.
+        /// </summary>
+        /// <param name="ppenum">Pointer to a variable that receives the cloned enumerator.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT Clone(IDiaEnumTables** ppenum);
+    }
+}

--- a/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaFrameData.cs
+++ b/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaFrameData.cs
@@ -1,0 +1,350 @@
+﻿// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Runtime.InteropServices;
+
+// For some reason the XML comment refs for IUnknown can't be resolved on .NET Framework without
+// explicitly using the fully qualified name, which falls afoul of the simplify warning.
+using ComIUnknown = Windows.Win32.System.Com.IUnknown;
+
+namespace Microsoft.VisualStudio.Debugging.DebugInterfaceAccess;
+
+/// <inheritdoc cref="Interface"/>
+public unsafe struct IDiaFrameData : IComIID
+{
+    /// <inheritdoc cref="IComIID.Guid"/>
+#pragma warning disable IDE1006 // Naming Styles
+    public static readonly Guid IID_Guid = new(0xA39184B7, 0x6A36, 0x42DE, 0x8E, 0xEC, 0x7D, 0xF9, 0xF3, 0xF5, 0x9F, 0x33);
+#pragma warning restore IDE1006
+
+#if NETFRAMEWORK
+    readonly ref readonly Guid IComIID.Guid => ref IID_Guid;
+#else
+    static ref readonly Guid IComIID.Guid
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get
+        {
+            ReadOnlySpan<byte> data =
+            [
+                0xB7, 0x84, 0x91, 0xA3,
+                0x36, 0x6A,
+                0xDE, 0x42,
+                0x8E, 0xEC, 0x7D, 0xF9, 0xF3, 0xF5, 0x9F, 0x33
+            ];
+
+            return ref Unsafe.As<byte, Guid>(ref MemoryMarshal.GetReference(data));
+        }
+    }
+#endif
+
+    private readonly void** _lpVtbl;
+
+    /// <inheritdoc cref="ComIUnknown.QueryInterface(Guid*, void**)"/>
+    public HRESULT QueryInterface(Guid* riid, void** ppvObject)
+    {
+        fixed (IDiaFrameData* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaFrameData*, Guid*, void**, HRESULT>)_lpVtbl[0])(pThis, riid, ppvObject);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.AddRef"/>
+    public uint AddRef()
+    {
+        fixed (IDiaFrameData* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaFrameData*, uint>)_lpVtbl[1])(pThis);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.Release"/>
+    public uint Release()
+    {
+        fixed (IDiaFrameData* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaFrameData*, uint>)_lpVtbl[2])(pThis);
+    }
+
+    /// <inheritdoc cref="Interface.get_addressSection"/>
+    public HRESULT get_addressSection(uint* pRetVal)
+    {
+        fixed (IDiaFrameData* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaFrameData*, uint*, HRESULT>)_lpVtbl[3])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_addressOffset"/>
+    public HRESULT get_addressOffset(uint* pRetVal)
+    {
+        fixed (IDiaFrameData* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaFrameData*, uint*, HRESULT>)_lpVtbl[4])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_relativeVirtualAddress"/>
+    public HRESULT get_relativeVirtualAddress(uint* pRetVal)
+    {
+        fixed (IDiaFrameData* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaFrameData*, uint*, HRESULT>)_lpVtbl[5])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_virtualAddress"/>
+    public HRESULT get_virtualAddress(ulong* pRetVal)
+    {
+        fixed (IDiaFrameData* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaFrameData*, ulong*, HRESULT>)_lpVtbl[6])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_lengthBlock"/>
+    public HRESULT get_lengthBlock(uint* pRetVal)
+    {
+        fixed (IDiaFrameData* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaFrameData*, uint*, HRESULT>)_lpVtbl[7])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_lengthLocals"/>
+    public HRESULT get_lengthLocals(uint* pRetVal)
+    {
+        fixed (IDiaFrameData* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaFrameData*, uint*, HRESULT>)_lpVtbl[8])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_lengthParams"/>
+    public HRESULT get_lengthParams(uint* pRetVal)
+    {
+        fixed (IDiaFrameData* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaFrameData*, uint*, HRESULT>)_lpVtbl[9])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_maxStack"/>
+    public HRESULT get_maxStack(uint* pRetVal)
+    {
+        fixed (IDiaFrameData* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaFrameData*, uint*, HRESULT>)_lpVtbl[10])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_lengthProlog"/>
+    public HRESULT get_lengthProlog(uint* pRetVal)
+    {
+        fixed (IDiaFrameData* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaFrameData*, uint*, HRESULT>)_lpVtbl[11])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_lengthSavedRegisters"/>
+    public HRESULT get_lengthSavedRegisters(uint* pRetVal)
+    {
+        fixed (IDiaFrameData* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaFrameData*, uint*, HRESULT>)_lpVtbl[12])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_program"/>
+    public HRESULT get_program(BSTR* pRetVal)
+    {
+        fixed (IDiaFrameData* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaFrameData*, BSTR*, HRESULT>)_lpVtbl[13])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_systemExceptionHandling"/>
+    public HRESULT get_systemExceptionHandling(BOOL* pRetVal)
+    {
+        fixed (IDiaFrameData* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaFrameData*, BOOL*, HRESULT>)_lpVtbl[14])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_cplusplusExceptionHandling"/>
+    public HRESULT get_cplusplusExceptionHandling(BOOL* pRetVal)
+    {
+        fixed (IDiaFrameData* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaFrameData*, BOOL*, HRESULT>)_lpVtbl[15])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_functionStart"/>
+    public HRESULT get_functionStart(BOOL* pRetVal)
+    {
+        fixed (IDiaFrameData* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaFrameData*, BOOL*, HRESULT>)_lpVtbl[16])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_allocatesBasePointer"/>
+    public HRESULT get_allocatesBasePointer(BOOL* pRetVal)
+    {
+        fixed (IDiaFrameData* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaFrameData*, BOOL*, HRESULT>)_lpVtbl[17])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_type"/>
+    public HRESULT get_type(uint* pRetVal)
+    {
+        fixed (IDiaFrameData* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaFrameData*, uint*, HRESULT>)_lpVtbl[18])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_functionParent"/>
+    public HRESULT get_functionParent(IDiaFrameData** pRetVal)
+    {
+        fixed (IDiaFrameData* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaFrameData*, IDiaFrameData**, HRESULT>)_lpVtbl[19])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.execute"/>
+    public HRESULT execute(IDiaStackWalkFrame* frame)
+    {
+        fixed (IDiaFrameData* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaFrameData*, IDiaStackWalkFrame*, HRESULT>)_lpVtbl[20])(pThis, frame);
+    }
+
+    /// <summary>
+    ///  Represents stack frame data.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/visualstudio/debugger/debug-interface-access/idiaframedata">
+    ///    Official documentation.
+    ///   </see>
+    ///  </para>
+    /// </remarks>
+    [ComImport]
+    [Guid("A39184B7-6A36-42DE-8EEC-7DF9F3F59F33")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    public unsafe interface Interface
+    {
+        /// <summary>
+        ///  Retrieves the address section.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_addressSection(uint* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the address offset.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_addressOffset(uint* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the relative virtual address.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_relativeVirtualAddress(uint* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the virtual address.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_virtualAddress(ulong* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the length block.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_lengthBlock(uint* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the length locals.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_lengthLocals(uint* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the length params.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_lengthParams(uint* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the max stack.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_maxStack(uint* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the length prolog.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_lengthProlog(uint* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the length saved registers.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_lengthSavedRegisters(uint* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the program.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_program(BSTR* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the system exception handling.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_systemExceptionHandling(BOOL* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the cplusplus exception handling.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_cplusplusExceptionHandling(BOOL* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the function start.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_functionStart(BOOL* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the allocates base pointer.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_allocatesBasePointer(BOOL* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the type.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_type(uint* pRetVal);
+
+        /// <summary>
+        ///  Frame data for enclosing function.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_functionParent(IDiaFrameData** pRetVal);
+
+        /// <summary>
+        ///  Execute.
+        /// </summary>
+        /// <param name="frame">The frame value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT execute(IDiaStackWalkFrame* frame);
+    }
+}

--- a/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaImageData.cs
+++ b/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaImageData.cs
@@ -1,0 +1,125 @@
+﻿// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Runtime.InteropServices;
+
+// For some reason the XML comment refs for IUnknown can't be resolved on .NET Framework without
+// explicitly using the fully qualified name, which falls afoul of the simplify warning.
+using ComIUnknown = Windows.Win32.System.Com.IUnknown;
+
+namespace Microsoft.VisualStudio.Debugging.DebugInterfaceAccess;
+
+/// <inheritdoc cref="Interface"/>
+public unsafe struct IDiaImageData : IComIID
+{
+    /// <inheritdoc cref="IComIID.Guid"/>
+#pragma warning disable IDE1006 // Naming Styles
+    public static readonly Guid IID_Guid = new(0xC8E40ED2, 0xA1D9, 0x4221, 0x86, 0x92, 0x3C, 0xE6, 0x61, 0x18, 0x4B, 0x44);
+#pragma warning restore IDE1006
+
+#if NETFRAMEWORK
+    readonly ref readonly Guid IComIID.Guid => ref IID_Guid;
+#else
+    static ref readonly Guid IComIID.Guid
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get
+        {
+            ReadOnlySpan<byte> data =
+            [
+                0xD2, 0x0E, 0xE4, 0xC8,
+                0xD9, 0xA1,
+                0x21, 0x42,
+                0x86, 0x92, 0x3C, 0xE6, 0x61, 0x18, 0x4B, 0x44
+            ];
+
+            return ref Unsafe.As<byte, Guid>(ref MemoryMarshal.GetReference(data));
+        }
+    }
+#endif
+
+    private readonly void** _lpVtbl;
+
+    /// <inheritdoc cref="ComIUnknown.QueryInterface(Guid*, void**)"/>
+    public HRESULT QueryInterface(Guid* riid, void** ppvObject)
+    {
+        fixed (IDiaImageData* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaImageData*, Guid*, void**, HRESULT>)_lpVtbl[0])(pThis, riid, ppvObject);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.AddRef"/>
+    public uint AddRef()
+    {
+        fixed (IDiaImageData* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaImageData*, uint>)_lpVtbl[1])(pThis);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.Release"/>
+    public uint Release()
+    {
+        fixed (IDiaImageData* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaImageData*, uint>)_lpVtbl[2])(pThis);
+    }
+
+    /// <inheritdoc cref="Interface.get_relativeVirtualAddress"/>
+    public HRESULT get_relativeVirtualAddress(uint* pRetVal)
+    {
+        fixed (IDiaImageData* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaImageData*, uint*, HRESULT>)_lpVtbl[3])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_virtualAddress"/>
+    public HRESULT get_virtualAddress(ulong* pRetVal)
+    {
+        fixed (IDiaImageData* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaImageData*, ulong*, HRESULT>)_lpVtbl[4])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_imageBase"/>
+    public HRESULT get_imageBase(ulong* pRetVal)
+    {
+        fixed (IDiaImageData* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaImageData*, ulong*, HRESULT>)_lpVtbl[5])(pThis, pRetVal);
+    }
+
+    /// <summary>
+    ///  Exposes the location and length of an image's loaded address, base address, and relative virtual address.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/visualstudio/debugger/debug-interface-access/idiaimagedata">
+    ///    Official documentation.
+    ///   </see>
+    ///  </para>
+    /// </remarks>
+    [ComImport]
+    [Guid("C8E40ED2-A1D9-4221-8692-3CE661184B44")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    public unsafe interface Interface
+    {
+        /// <summary>
+        ///  Retrieves the relative virtual address.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_relativeVirtualAddress(uint* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the virtual address.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_virtualAddress(ulong* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the image base.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_imageBase(ulong* pRetVal);
+    }
+}

--- a/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaInjectedSource.cs
+++ b/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaInjectedSource.cs
@@ -1,0 +1,187 @@
+﻿// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Runtime.InteropServices;
+
+// For some reason the XML comment refs for IUnknown can't be resolved on .NET Framework without
+// explicitly using the fully qualified name, which falls afoul of the simplify warning.
+using ComIUnknown = Windows.Win32.System.Com.IUnknown;
+
+namespace Microsoft.VisualStudio.Debugging.DebugInterfaceAccess;
+
+/// <inheritdoc cref="Interface"/>
+public unsafe struct IDiaInjectedSource : IComIID
+{
+    /// <inheritdoc cref="IComIID.Guid"/>
+#pragma warning disable IDE1006 // Naming Styles
+    public static readonly Guid IID_Guid = new(0xAE605CDC, 0x8105, 0x4A23, 0xB7, 0x10, 0x32, 0x59, 0xF1, 0xE2, 0x61, 0x12);
+#pragma warning restore IDE1006
+
+#if NETFRAMEWORK
+    readonly ref readonly Guid IComIID.Guid => ref IID_Guid;
+#else
+    static ref readonly Guid IComIID.Guid
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get
+        {
+            ReadOnlySpan<byte> data =
+            [
+                0xDC, 0x5C, 0x60, 0xAE,
+                0x05, 0x81,
+                0x23, 0x4A,
+                0xB7, 0x10, 0x32, 0x59, 0xF1, 0xE2, 0x61, 0x12
+            ];
+
+            return ref Unsafe.As<byte, Guid>(ref MemoryMarshal.GetReference(data));
+        }
+    }
+#endif
+
+    private readonly void** _lpVtbl;
+
+    /// <inheritdoc cref="ComIUnknown.QueryInterface(Guid*, void**)"/>
+    public HRESULT QueryInterface(Guid* riid, void** ppvObject)
+    {
+        fixed (IDiaInjectedSource* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaInjectedSource*, Guid*, void**, HRESULT>)_lpVtbl[0])(pThis, riid, ppvObject);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.AddRef"/>
+    public uint AddRef()
+    {
+        fixed (IDiaInjectedSource* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaInjectedSource*, uint>)_lpVtbl[1])(pThis);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.Release"/>
+    public uint Release()
+    {
+        fixed (IDiaInjectedSource* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaInjectedSource*, uint>)_lpVtbl[2])(pThis);
+    }
+
+    /// <inheritdoc cref="Interface.get_crc"/>
+    public HRESULT get_crc(uint* pRetVal)
+    {
+        fixed (IDiaInjectedSource* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaInjectedSource*, uint*, HRESULT>)_lpVtbl[3])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_length"/>
+    public HRESULT get_length(ulong* pRetVal)
+    {
+        fixed (IDiaInjectedSource* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaInjectedSource*, ulong*, HRESULT>)_lpVtbl[4])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_filename"/>
+    public HRESULT get_filename(BSTR* pRetVal)
+    {
+        fixed (IDiaInjectedSource* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaInjectedSource*, BSTR*, HRESULT>)_lpVtbl[5])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_objectFilename"/>
+    public HRESULT get_objectFilename(BSTR* pRetVal)
+    {
+        fixed (IDiaInjectedSource* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaInjectedSource*, BSTR*, HRESULT>)_lpVtbl[6])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_virtualFilename"/>
+    public HRESULT get_virtualFilename(BSTR* pRetVal)
+    {
+        fixed (IDiaInjectedSource* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaInjectedSource*, BSTR*, HRESULT>)_lpVtbl[7])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_sourceCompression"/>
+    public HRESULT get_sourceCompression(uint* pRetVal)
+    {
+        fixed (IDiaInjectedSource* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaInjectedSource*, uint*, HRESULT>)_lpVtbl[8])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_source"/>
+    public HRESULT get_source(uint cbData, uint* pcbData, byte* pbData)
+    {
+        fixed (IDiaInjectedSource* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaInjectedSource*, uint, uint*, byte*, HRESULT>)_lpVtbl[9])(pThis, cbData, pcbData, pbData);
+    }
+
+    /// <summary>
+    ///  Represents a program source that is injected into the symbol store.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/visualstudio/debugger/debug-interface-access/idiainjectedsource">
+    ///    Official documentation.
+    ///   </see>
+    ///  </para>
+    /// </remarks>
+    [ComImport]
+    [Guid("AE605CDC-8105-4A23-B710-3259F1E26112")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    public unsafe interface Interface
+    {
+        /// <summary>
+        ///  CRC of source bytes.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_crc(uint* pRetVal);
+
+        /// <summary>
+        ///  Length of source in bytes.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_length(ulong* pRetVal);
+
+        /// <summary>
+        ///  Source filename.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_filename(BSTR* pRetVal);
+
+        /// <summary>
+        ///  Object filename.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_objectFilename(BSTR* pRetVal);
+
+        /// <summary>
+        ///  Virtual filename.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_virtualFilename(BSTR* pRetVal);
+
+        /// <summary>
+        ///  Source compression algorithm.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_sourceCompression(uint* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the source.
+        /// </summary>
+        /// <param name="cbData">The size, in bytes, of the buffer.</param>
+        /// <param name="pcbData">Pointer to a variable that receives the number of bytes written to the buffer.</param>
+        /// <param name="pbData">Pointer to a caller-allocated buffer that receives the data.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_source(uint cbData, uint* pcbData, byte* pbData);
+    }
+}

--- a/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaInputAssemblyFile.cs
+++ b/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaInputAssemblyFile.cs
@@ -1,0 +1,172 @@
+﻿// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Runtime.InteropServices;
+
+// For some reason the XML comment refs for IUnknown can't be resolved on .NET Framework without
+// explicitly using the fully qualified name, which falls afoul of the simplify warning.
+using ComIUnknown = Windows.Win32.System.Com.IUnknown;
+
+namespace Microsoft.VisualStudio.Debugging.DebugInterfaceAccess;
+
+/// <inheritdoc cref="Interface"/>
+public unsafe struct IDiaInputAssemblyFile : IComIID
+{
+    /// <inheritdoc cref="IComIID.Guid"/>
+#pragma warning disable IDE1006 // Naming Styles
+    public static readonly Guid IID_Guid = new(0x3BFE56B0, 0x390C, 0x4863, 0x94, 0x30, 0x1F, 0x3D, 0x08, 0x3B, 0x76, 0x84);
+#pragma warning restore IDE1006
+
+#if NETFRAMEWORK
+    readonly ref readonly Guid IComIID.Guid => ref IID_Guid;
+#else
+    static ref readonly Guid IComIID.Guid
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get
+        {
+            ReadOnlySpan<byte> data =
+            [
+                0xB0, 0x56, 0xFE, 0x3B,
+                0x0C, 0x39,
+                0x63, 0x48,
+                0x94, 0x30, 0x1F, 0x3D, 0x08, 0x3B, 0x76, 0x84
+            ];
+
+            return ref Unsafe.As<byte, Guid>(ref MemoryMarshal.GetReference(data));
+        }
+    }
+#endif
+
+    private readonly void** _lpVtbl;
+
+    /// <inheritdoc cref="ComIUnknown.QueryInterface(Guid*, void**)"/>
+    public HRESULT QueryInterface(Guid* riid, void** ppvObject)
+    {
+        fixed (IDiaInputAssemblyFile* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaInputAssemblyFile*, Guid*, void**, HRESULT>)_lpVtbl[0])(pThis, riid, ppvObject);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.AddRef"/>
+    public uint AddRef()
+    {
+        fixed (IDiaInputAssemblyFile* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaInputAssemblyFile*, uint>)_lpVtbl[1])(pThis);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.Release"/>
+    public uint Release()
+    {
+        fixed (IDiaInputAssemblyFile* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaInputAssemblyFile*, uint>)_lpVtbl[2])(pThis);
+    }
+
+    /// <inheritdoc cref="Interface.get_uniqueId"/>
+    public HRESULT get_uniqueId(uint* pRetVal)
+    {
+        fixed (IDiaInputAssemblyFile* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaInputAssemblyFile*, uint*, HRESULT>)_lpVtbl[3])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_index"/>
+    public HRESULT get_index(uint* pRetVal)
+    {
+        fixed (IDiaInputAssemblyFile* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaInputAssemblyFile*, uint*, HRESULT>)_lpVtbl[4])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_timestamp"/>
+    public HRESULT get_timestamp(uint* pRetVal)
+    {
+        fixed (IDiaInputAssemblyFile* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaInputAssemblyFile*, uint*, HRESULT>)_lpVtbl[5])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_pdbAvailableAtILMerge"/>
+    public HRESULT get_pdbAvailableAtILMerge(BOOL* pRetVal)
+    {
+        fixed (IDiaInputAssemblyFile* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaInputAssemblyFile*, BOOL*, HRESULT>)_lpVtbl[6])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_fileName"/>
+    public HRESULT get_fileName(BSTR* pRetVal)
+    {
+        fixed (IDiaInputAssemblyFile* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaInputAssemblyFile*, BSTR*, HRESULT>)_lpVtbl[7])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_version"/>
+    public HRESULT get_version(uint cbData, uint* pcbData, byte* pbData)
+    {
+        fixed (IDiaInputAssemblyFile* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaInputAssemblyFile*, uint, uint*, byte*, HRESULT>)_lpVtbl[8])(pThis, cbData, pcbData, pbData);
+    }
+
+    /// <summary>
+    ///  Represents an input assembly file for the Microsoft Intermediate Language (MSIL).
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/visualstudio/debugger/debug-interface-access/idiainputassemblyfile">
+    ///    Official documentation.
+    ///   </see>
+    ///  </para>
+    /// </remarks>
+    [ComImport]
+    [Guid("3BFE56B0-390C-4863-9430-1F3D083B7684")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    public unsafe interface Interface
+    {
+        /// <summary>
+        ///  Assembly file ID.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_uniqueId(uint* pRetVal);
+
+        /// <summary>
+        ///  Assembly file index.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_index(uint* pRetVal);
+
+        /// <summary>
+        ///  Time stamp.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_timestamp(uint* pRetVal);
+
+        /// <summary>
+        ///  PDB is available at IL merge time.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_pdbAvailableAtILMerge(BOOL* pRetVal);
+
+        /// <summary>
+        ///  Assembly file name.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_fileName(BSTR* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the version.
+        /// </summary>
+        /// <param name="cbData">The size, in bytes, of the buffer.</param>
+        /// <param name="pcbData">Pointer to a variable that receives the number of bytes written to the buffer.</param>
+        /// <param name="pbData">Pointer to a caller-allocated buffer that receives the data.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_version(uint cbData, uint* pcbData, byte* pbData);
+    }
+}

--- a/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaLineNumber.cs
+++ b/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaLineNumber.cs
@@ -1,0 +1,290 @@
+﻿// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Runtime.InteropServices;
+
+// For some reason the XML comment refs for IUnknown can't be resolved on .NET Framework without
+// explicitly using the fully qualified name, which falls afoul of the simplify warning.
+using ComIUnknown = Windows.Win32.System.Com.IUnknown;
+
+namespace Microsoft.VisualStudio.Debugging.DebugInterfaceAccess;
+
+/// <inheritdoc cref="Interface"/>
+public unsafe struct IDiaLineNumber : IComIID
+{
+    /// <inheritdoc cref="IComIID.Guid"/>
+#pragma warning disable IDE1006 // Naming Styles
+    public static readonly Guid IID_Guid = new(0xB388EB14, 0xBE4D, 0x421D, 0xA8, 0xA1, 0x6C, 0xF7, 0xAB, 0x05, 0x70, 0x86);
+#pragma warning restore IDE1006
+
+#if NETFRAMEWORK
+    readonly ref readonly Guid IComIID.Guid => ref IID_Guid;
+#else
+    static ref readonly Guid IComIID.Guid
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get
+        {
+            ReadOnlySpan<byte> data =
+            [
+                0x14, 0xEB, 0x88, 0xB3,
+                0x4D, 0xBE,
+                0x1D, 0x42,
+                0xA8, 0xA1, 0x6C, 0xF7, 0xAB, 0x05, 0x70, 0x86
+            ];
+
+            return ref Unsafe.As<byte, Guid>(ref MemoryMarshal.GetReference(data));
+        }
+    }
+#endif
+
+    private readonly void** _lpVtbl;
+
+    /// <inheritdoc cref="ComIUnknown.QueryInterface(Guid*, void**)"/>
+    public HRESULT QueryInterface(Guid* riid, void** ppvObject)
+    {
+        fixed (IDiaLineNumber* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaLineNumber*, Guid*, void**, HRESULT>)_lpVtbl[0])(pThis, riid, ppvObject);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.AddRef"/>
+    public uint AddRef()
+    {
+        fixed (IDiaLineNumber* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaLineNumber*, uint>)_lpVtbl[1])(pThis);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.Release"/>
+    public uint Release()
+    {
+        fixed (IDiaLineNumber* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaLineNumber*, uint>)_lpVtbl[2])(pThis);
+    }
+
+    /// <inheritdoc cref="Interface.get_compiland"/>
+    public HRESULT get_compiland(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaLineNumber* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaLineNumber*, IDiaSymbol**, HRESULT>)_lpVtbl[3])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_sourceFile"/>
+    public HRESULT get_sourceFile(IDiaSourceFile** pRetVal)
+    {
+        fixed (IDiaLineNumber* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaLineNumber*, IDiaSourceFile**, HRESULT>)_lpVtbl[4])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_lineNumber"/>
+    public HRESULT get_lineNumber(uint* pRetVal)
+    {
+        fixed (IDiaLineNumber* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaLineNumber*, uint*, HRESULT>)_lpVtbl[5])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_lineNumberEnd"/>
+    public HRESULT get_lineNumberEnd(uint* pRetVal)
+    {
+        fixed (IDiaLineNumber* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaLineNumber*, uint*, HRESULT>)_lpVtbl[6])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_columnNumber"/>
+    public HRESULT get_columnNumber(uint* pRetVal)
+    {
+        fixed (IDiaLineNumber* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaLineNumber*, uint*, HRESULT>)_lpVtbl[7])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_columnNumberEnd"/>
+    public HRESULT get_columnNumberEnd(uint* pRetVal)
+    {
+        fixed (IDiaLineNumber* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaLineNumber*, uint*, HRESULT>)_lpVtbl[8])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_addressSection"/>
+    public HRESULT get_addressSection(uint* pRetVal)
+    {
+        fixed (IDiaLineNumber* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaLineNumber*, uint*, HRESULT>)_lpVtbl[9])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_addressOffset"/>
+    public HRESULT get_addressOffset(uint* pRetVal)
+    {
+        fixed (IDiaLineNumber* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaLineNumber*, uint*, HRESULT>)_lpVtbl[10])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_relativeVirtualAddress"/>
+    public HRESULT get_relativeVirtualAddress(uint* pRetVal)
+    {
+        fixed (IDiaLineNumber* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaLineNumber*, uint*, HRESULT>)_lpVtbl[11])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_virtualAddress"/>
+    public HRESULT get_virtualAddress(ulong* pRetVal)
+    {
+        fixed (IDiaLineNumber* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaLineNumber*, ulong*, HRESULT>)_lpVtbl[12])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_length"/>
+    public HRESULT get_length(uint* pRetVal)
+    {
+        fixed (IDiaLineNumber* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaLineNumber*, uint*, HRESULT>)_lpVtbl[13])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_sourceFileId"/>
+    public HRESULT get_sourceFileId(uint* pRetVal)
+    {
+        fixed (IDiaLineNumber* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaLineNumber*, uint*, HRESULT>)_lpVtbl[14])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_statement"/>
+    public HRESULT get_statement(BOOL* pRetVal)
+    {
+        fixed (IDiaLineNumber* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaLineNumber*, BOOL*, HRESULT>)_lpVtbl[15])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_compilandId"/>
+    public HRESULT get_compilandId(uint* pRetVal)
+    {
+        fixed (IDiaLineNumber* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaLineNumber*, uint*, HRESULT>)_lpVtbl[16])(pThis, pRetVal);
+    }
+
+    /// <summary>
+    ///  Represents the location of a compiland source line.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/visualstudio/debugger/debug-interface-access/idialinenumber">
+    ///    Official documentation.
+    ///   </see>
+    ///  </para>
+    /// </remarks>
+    [ComImport]
+    [Guid("B388EB14-BE4D-421D-A8A1-6CF7AB057086")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    public unsafe interface Interface
+    {
+        /// <summary>
+        ///  Retrieves the compiland.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_compiland(IDiaSymbol** pRetVal);
+
+        /// <summary>
+        ///  Retrieves the source file.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_sourceFile(IDiaSourceFile** pRetVal);
+
+        /// <summary>
+        ///  Retrieves the line number.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_lineNumber(uint* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the line number end.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_lineNumberEnd(uint* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the column number.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_columnNumber(uint* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the column number end.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_columnNumberEnd(uint* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the address section.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_addressSection(uint* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the address offset.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_addressOffset(uint* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the relative virtual address.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_relativeVirtualAddress(uint* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the virtual address.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_virtualAddress(ulong* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the length.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_length(uint* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the source file id.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_sourceFileId(uint* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the statement.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_statement(BOOL* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the compiland id.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_compilandId(uint* pRetVal);
+    }
+}

--- a/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaLoadCallback.cs
+++ b/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaLoadCallback.cs
@@ -1,0 +1,161 @@
+﻿// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Runtime.InteropServices;
+
+// For some reason the XML comment refs for IUnknown can't be resolved on .NET Framework without
+// explicitly using the fully qualified name, which falls afoul of the simplify warning.
+using ComIUnknown = Windows.Win32.System.Com.IUnknown;
+
+namespace Microsoft.VisualStudio.Debugging.DebugInterfaceAccess;
+
+/// <inheritdoc cref="Interface"/>
+public unsafe struct IDiaLoadCallback : IComIID
+{
+    /// <inheritdoc cref="IComIID.Guid"/>
+#pragma warning disable IDE1006 // Naming Styles
+    public static readonly Guid IID_Guid = new(0xC32ADB82, 0x73F4, 0x421B, 0x95, 0xD5, 0xA4, 0x70, 0x6E, 0xDF, 0x5D, 0xBE);
+#pragma warning restore IDE1006
+
+#if NETFRAMEWORK
+    readonly ref readonly Guid IComIID.Guid => ref IID_Guid;
+#else
+    static ref readonly Guid IComIID.Guid
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get
+        {
+            ReadOnlySpan<byte> data =
+            [
+                0x82, 0xDB, 0x2A, 0xC3,
+                0xF4, 0x73,
+                0x1B, 0x42,
+                0x95, 0xD5, 0xA4, 0x70, 0x6E, 0xDF, 0x5D, 0xBE
+            ];
+
+            return ref Unsafe.As<byte, Guid>(ref MemoryMarshal.GetReference(data));
+        }
+    }
+#endif
+
+    private readonly void** _lpVtbl;
+
+    /// <inheritdoc cref="ComIUnknown.QueryInterface(Guid*, void**)"/>
+    public HRESULT QueryInterface(Guid* riid, void** ppvObject)
+    {
+        fixed (IDiaLoadCallback* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaLoadCallback*, Guid*, void**, HRESULT>)_lpVtbl[0])(pThis, riid, ppvObject);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.AddRef"/>
+    public uint AddRef()
+    {
+        fixed (IDiaLoadCallback* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaLoadCallback*, uint>)_lpVtbl[1])(pThis);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.Release"/>
+    public uint Release()
+    {
+        fixed (IDiaLoadCallback* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaLoadCallback*, uint>)_lpVtbl[2])(pThis);
+    }
+
+    /// <inheritdoc cref="Interface.NotifyDebugDir"/>
+    public HRESULT NotifyDebugDir(BOOL fExecutable, uint cbData, byte* pbData)
+    {
+        fixed (IDiaLoadCallback* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaLoadCallback*, BOOL, uint, byte*, HRESULT>)_lpVtbl[3])(pThis, fExecutable, cbData, pbData);
+    }
+
+    /// <inheritdoc cref="Interface.NotifyOpenDBG"/>
+    public HRESULT NotifyOpenDBG(PCWSTR dbgPath, HRESULT resultCode)
+    {
+        fixed (IDiaLoadCallback* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaLoadCallback*, PCWSTR, HRESULT, HRESULT>)_lpVtbl[4])(pThis, dbgPath, resultCode);
+    }
+
+    /// <inheritdoc cref="Interface.NotifyOpenPDB"/>
+    public HRESULT NotifyOpenPDB(PCWSTR pdbPath, HRESULT resultCode)
+    {
+        fixed (IDiaLoadCallback* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaLoadCallback*, PCWSTR, HRESULT, HRESULT>)_lpVtbl[5])(pThis, pdbPath, resultCode);
+    }
+
+    /// <inheritdoc cref="Interface.RestrictRegistryAccess"/>
+    public HRESULT RestrictRegistryAccess()
+    {
+        fixed (IDiaLoadCallback* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaLoadCallback*, HRESULT>)_lpVtbl[6])(pThis);
+    }
+
+    /// <inheritdoc cref="Interface.RestrictSymbolServerAccess"/>
+    public HRESULT RestrictSymbolServerAccess()
+    {
+        fixed (IDiaLoadCallback* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaLoadCallback*, HRESULT>)_lpVtbl[7])(pThis);
+    }
+
+    /// <summary>
+    ///  Receives callbacks while the DIA SDK loads debug symbols.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/visualstudio/debugger/debug-interface-access/idialoadcallback">
+    ///    Official documentation.
+    ///   </see>
+    ///  </para>
+    /// </remarks>
+    [ComImport]
+    [Guid("C32ADB82-73F4-421B-95D5-A4706EDF5DBE")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    public unsafe interface Interface
+    {
+        /// <summary>
+        ///  Called when the DIA SDK locates a debug directory in the portable executable (PE) file.
+        /// </summary>
+        /// <param name="fExecutable"><see langword="true"/> if the debug directory comes from an executable file; otherwise, <see langword="false"/>.</param>
+        /// <param name="cbData">The size, in bytes, of the data pointed to by <paramref name="pbData"/>.</param>
+        /// <param name="pbData">Pointer to the debug directory data (an <c>IMAGE_DEBUG_DIRECTORY</c> structure).</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT NotifyDebugDir(BOOL fExecutable, uint cbData, byte* pbData);
+
+        /// <summary>
+        ///  Called when the DIA SDK opens a .dbg file while searching for debug data.
+        /// </summary>
+        /// <param name="dbgPath">The full path of the .dbg file that was opened.</param>
+        /// <param name="resultCode">The <see cref="HRESULT"/> result of opening the .dbg file.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT NotifyOpenDBG(PCWSTR dbgPath, HRESULT resultCode);
+
+        /// <summary>
+        ///  Called when the DIA SDK opens a .pdb file while searching for debug data.
+        /// </summary>
+        /// <param name="pdbPath">The full path of the .pdb file that was opened.</param>
+        /// <param name="resultCode">The <see cref="HRESULT"/> result of opening the .pdb file.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT NotifyOpenPDB(PCWSTR pdbPath, HRESULT resultCode);
+
+        /// <summary>
+        ///  Determines whether the DIA SDK may query the registry for symbol search paths.
+        /// </summary>
+        /// <returns>
+        ///  Return a value other than <c>S_OK</c> to prevent querying the registry for symbol search paths.
+        /// </returns>
+        [PreserveSig]
+        HRESULT RestrictRegistryAccess();
+
+        /// <summary>
+        ///  Determines whether the DIA SDK may access a symbol server.
+        /// </summary>
+        /// <returns>
+        ///  Return a value other than <c>S_OK</c> to prevent accessing a symbol server.
+        /// </returns>
+        [PreserveSig]
+        HRESULT RestrictSymbolServerAccess();
+    }
+}

--- a/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaLoadCallback2.cs
+++ b/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaLoadCallback2.cs
@@ -1,0 +1,179 @@
+﻿// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Runtime.InteropServices;
+
+// For some reason the XML comment refs for IUnknown can't be resolved on .NET Framework without
+// explicitly using the fully qualified name, which falls afoul of the simplify warning.
+using ComIUnknown = Windows.Win32.System.Com.IUnknown;
+
+namespace Microsoft.VisualStudio.Debugging.DebugInterfaceAccess;
+
+/// <inheritdoc cref="Interface"/>
+public unsafe struct IDiaLoadCallback2 : IComIID
+{
+    /// <inheritdoc cref="IComIID.Guid"/>
+#pragma warning disable IDE1006 // Naming Styles
+    public static readonly Guid IID_Guid = new(0x4688A074, 0x5A4D, 0x4486, 0xAE, 0xA8, 0x7B, 0x90, 0x71, 0x1D, 0x9F, 0x7C);
+#pragma warning restore IDE1006
+
+#if NETFRAMEWORK
+    readonly ref readonly Guid IComIID.Guid => ref IID_Guid;
+#else
+    static ref readonly Guid IComIID.Guid
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get
+        {
+            ReadOnlySpan<byte> data =
+            [
+                0x74, 0xA0, 0x88, 0x46,
+                0x4D, 0x5A,
+                0x86, 0x44,
+                0xAE, 0xA8, 0x7B, 0x90, 0x71, 0x1D, 0x9F, 0x7C
+            ];
+
+            return ref Unsafe.As<byte, Guid>(ref MemoryMarshal.GetReference(data));
+        }
+    }
+#endif
+
+    private readonly void** _lpVtbl;
+
+    /// <inheritdoc cref="ComIUnknown.QueryInterface(Guid*, void**)"/>
+    public HRESULT QueryInterface(Guid* riid, void** ppvObject)
+    {
+        fixed (IDiaLoadCallback2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaLoadCallback2*, Guid*, void**, HRESULT>)_lpVtbl[0])(pThis, riid, ppvObject);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.AddRef"/>
+    public uint AddRef()
+    {
+        fixed (IDiaLoadCallback2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaLoadCallback2*, uint>)_lpVtbl[1])(pThis);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.Release"/>
+    public uint Release()
+    {
+        fixed (IDiaLoadCallback2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaLoadCallback2*, uint>)_lpVtbl[2])(pThis);
+    }
+
+    /// <inheritdoc cref="IDiaLoadCallback.Interface.NotifyDebugDir"/>
+    public HRESULT NotifyDebugDir(BOOL fExecutable, uint cbData, byte* pbData)
+    {
+        fixed (IDiaLoadCallback2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaLoadCallback2*, BOOL, uint, byte*, HRESULT>)_lpVtbl[3])(pThis, fExecutable, cbData, pbData);
+    }
+
+    /// <inheritdoc cref="IDiaLoadCallback.Interface.NotifyOpenDBG"/>
+    public HRESULT NotifyOpenDBG(PCWSTR dbgPath, HRESULT resultCode)
+    {
+        fixed (IDiaLoadCallback2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaLoadCallback2*, PCWSTR, HRESULT, HRESULT>)_lpVtbl[4])(pThis, dbgPath, resultCode);
+    }
+
+    /// <inheritdoc cref="IDiaLoadCallback.Interface.NotifyOpenPDB"/>
+    public HRESULT NotifyOpenPDB(PCWSTR pdbPath, HRESULT resultCode)
+    {
+        fixed (IDiaLoadCallback2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaLoadCallback2*, PCWSTR, HRESULT, HRESULT>)_lpVtbl[5])(pThis, pdbPath, resultCode);
+    }
+
+    /// <inheritdoc cref="IDiaLoadCallback.Interface.RestrictRegistryAccess"/>
+    public HRESULT RestrictRegistryAccess()
+    {
+        fixed (IDiaLoadCallback2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaLoadCallback2*, HRESULT>)_lpVtbl[6])(pThis);
+    }
+
+    /// <inheritdoc cref="IDiaLoadCallback.Interface.RestrictSymbolServerAccess"/>
+    public HRESULT RestrictSymbolServerAccess()
+    {
+        fixed (IDiaLoadCallback2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaLoadCallback2*, HRESULT>)_lpVtbl[7])(pThis);
+    }
+
+    /// <inheritdoc cref="Interface.RestrictOriginalPathAccess"/>
+    public HRESULT RestrictOriginalPathAccess()
+    {
+        fixed (IDiaLoadCallback2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaLoadCallback2*, HRESULT>)_lpVtbl[8])(pThis);
+    }
+
+    /// <inheritdoc cref="Interface.RestrictReferencePathAccess"/>
+    public HRESULT RestrictReferencePathAccess()
+    {
+        fixed (IDiaLoadCallback2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaLoadCallback2*, HRESULT>)_lpVtbl[9])(pThis);
+    }
+
+    /// <inheritdoc cref="Interface.RestrictDBGAccess"/>
+    public HRESULT RestrictDBGAccess()
+    {
+        fixed (IDiaLoadCallback2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaLoadCallback2*, HRESULT>)_lpVtbl[10])(pThis);
+    }
+
+    /// <inheritdoc cref="Interface.RestrictSystemRootAccess"/>
+    public HRESULT RestrictSystemRootAccess()
+    {
+        fixed (IDiaLoadCallback2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaLoadCallback2*, HRESULT>)_lpVtbl[11])(pThis);
+    }
+
+    /// <summary>
+    ///  Receives callbacks while the DIA SDK searches for and loads debug symbols.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/visualstudio/debugger/debug-interface-access/idialoadcallback2">
+    ///    Official documentation.
+    ///   </see>
+    ///  </para>
+    /// </remarks>
+    [ComImport]
+    [Guid("4688A074-5A4D-4486-AEA8-7B90711D9F7C")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    public interface Interface : IDiaLoadCallback.Interface
+    {
+        /// <summary>
+        ///  Determines whether the DIA SDK may look up the PDB specified in the debug directory of the executable.
+        /// </summary>
+        /// <returns>
+        ///  Return a value other than <c>S_OK</c> to prevent looking up the PDB specified in the debug directory.
+        /// </returns>
+        [PreserveSig]
+        HRESULT RestrictOriginalPathAccess();
+
+        /// <summary>
+        ///  Determines whether the DIA SDK may look up the PDB in the location where the executable file resides.
+        /// </summary>
+        /// <returns>
+        ///  Return a value other than <c>S_OK</c> to prevent looking up the PDB where the executable is located.
+        /// </returns>
+        [PreserveSig]
+        HRESULT RestrictReferencePathAccess();
+
+        /// <summary>
+        ///  Determines whether the DIA SDK may look up debug information from .dbg files.
+        /// </summary>
+        /// <returns>
+        ///  Return a value other than <c>S_OK</c> to prevent looking up debug information from .dbg files.
+        /// </returns>
+        [PreserveSig]
+        HRESULT RestrictDBGAccess();
+
+        /// <summary>
+        ///  Determines whether the DIA SDK may look up PDBs in the system root directory.
+        /// </summary>
+        /// <returns>
+        ///  Return a value other than <c>S_OK</c> to prevent looking up PDBs in the system root.
+        /// </returns>
+        [PreserveSig]
+        HRESULT RestrictSystemRootAccess();
+    }
+}

--- a/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaPropertyStorage.cs
+++ b/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaPropertyStorage.cs
@@ -1,0 +1,210 @@
+﻿// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Runtime.InteropServices;
+using Windows.Win32.System.Com.StructuredStorage;
+
+// For some reason the XML comment refs for IUnknown can't be resolved on .NET Framework without
+// explicitly using the fully qualified name, which falls afoul of the simplify warning.
+using ComIUnknown = Windows.Win32.System.Com.IUnknown;
+
+namespace Microsoft.VisualStudio.Debugging.DebugInterfaceAccess;
+
+/// <inheritdoc cref="Interface"/>
+public unsafe struct IDiaPropertyStorage : IComIID
+{
+    /// <inheritdoc cref="IComIID.Guid"/>
+#pragma warning disable IDE1006 // Naming Styles
+    public static readonly Guid IID_Guid = new(0x9D416F9C, 0xE184, 0x45B2, 0xA4, 0xF0, 0xCE, 0x51, 0x7F, 0x71, 0x9E, 0x9B);
+#pragma warning restore IDE1006
+
+#if NETFRAMEWORK
+    readonly ref readonly Guid IComIID.Guid => ref IID_Guid;
+#else
+    static ref readonly Guid IComIID.Guid
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get
+        {
+            ReadOnlySpan<byte> data =
+            [
+                0x9C, 0x6F, 0x41, 0x9D,
+                0x84, 0xE1,
+                0xB2, 0x45,
+                0xA4, 0xF0, 0xCE, 0x51, 0x7F, 0x71, 0x9E, 0x9B
+            ];
+
+            return ref Unsafe.As<byte, Guid>(ref MemoryMarshal.GetReference(data));
+        }
+    }
+#endif
+
+    private readonly void** _lpVtbl;
+
+    /// <inheritdoc cref="ComIUnknown.QueryInterface(Guid*, void**)"/>
+    public HRESULT QueryInterface(Guid* riid, void** ppvObject)
+    {
+        fixed (IDiaPropertyStorage* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaPropertyStorage*, Guid*, void**, HRESULT>)_lpVtbl[0])(pThis, riid, ppvObject);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.AddRef"/>
+    public uint AddRef()
+    {
+        fixed (IDiaPropertyStorage* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaPropertyStorage*, uint>)_lpVtbl[1])(pThis);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.Release"/>
+    public uint Release()
+    {
+        fixed (IDiaPropertyStorage* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaPropertyStorage*, uint>)_lpVtbl[2])(pThis);
+    }
+
+    /// <inheritdoc cref="Interface.ReadMultiple"/>
+    public HRESULT ReadMultiple(uint cpspec, PROPSPEC* rgpspec, PROPVARIANT* rgvar)
+    {
+        fixed (IDiaPropertyStorage* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaPropertyStorage*, uint, PROPSPEC*, PROPVARIANT*, HRESULT>)_lpVtbl[3])(pThis, cpspec, rgpspec, rgvar);
+    }
+
+    /// <inheritdoc cref="Interface.ReadPropertyNames"/>
+    public HRESULT ReadPropertyNames(uint cpropid, uint* rgpropid, BSTR* rglpwstrName)
+    {
+        fixed (IDiaPropertyStorage* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaPropertyStorage*, uint, uint*, BSTR*, HRESULT>)_lpVtbl[4])(pThis, cpropid, rgpropid, rglpwstrName);
+    }
+
+    /// <inheritdoc cref="Interface.Enum"/>
+    public HRESULT Enum(IEnumSTATPROPSTG** ppenum)
+    {
+        fixed (IDiaPropertyStorage* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaPropertyStorage*, IEnumSTATPROPSTG**, HRESULT>)_lpVtbl[5])(pThis, ppenum);
+    }
+
+    /// <inheritdoc cref="Interface.ReadDWORD"/>
+    public HRESULT ReadDWORD(uint id, uint* pValue)
+    {
+        fixed (IDiaPropertyStorage* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaPropertyStorage*, uint, uint*, HRESULT>)_lpVtbl[6])(pThis, id, pValue);
+    }
+
+    /// <inheritdoc cref="Interface.ReadLONG"/>
+    public HRESULT ReadLONG(uint id, int* pValue)
+    {
+        fixed (IDiaPropertyStorage* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaPropertyStorage*, uint, int*, HRESULT>)_lpVtbl[7])(pThis, id, pValue);
+    }
+
+    /// <inheritdoc cref="Interface.ReadBOOL"/>
+    public HRESULT ReadBOOL(uint id, BOOL* pValue)
+    {
+        fixed (IDiaPropertyStorage* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaPropertyStorage*, uint, BOOL*, HRESULT>)_lpVtbl[8])(pThis, id, pValue);
+    }
+
+    /// <inheritdoc cref="Interface.ReadULONGLONG"/>
+    public HRESULT ReadULONGLONG(uint id, ulong* pValue)
+    {
+        fixed (IDiaPropertyStorage* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaPropertyStorage*, uint, ulong*, HRESULT>)_lpVtbl[9])(pThis, id, pValue);
+    }
+
+    /// <inheritdoc cref="Interface.ReadBSTR"/>
+    public HRESULT ReadBSTR(uint id, BSTR* pValue)
+    {
+        fixed (IDiaPropertyStorage* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaPropertyStorage*, uint, BSTR*, HRESULT>)_lpVtbl[10])(pThis, id, pValue);
+    }
+
+    /// <summary>
+    ///  Provides access to a property set through the standard property browser interface.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/visualstudio/debugger/debug-interface-access/idiapropertystorage">
+    ///    Official documentation.
+    ///   </see>
+    ///  </para>
+    /// </remarks>
+    [ComImport]
+    [Guid("9D416F9C-E184-45B2-A4F0-CE517F719E9B")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    public unsafe interface Interface
+    {
+        /// <summary>
+        ///  Read multiple.
+        /// </summary>
+        /// <param name="cpspec">The cpspec value.</param>
+        /// <param name="rgpspec">Pointer to a buffer that contains the input data.</param>
+        /// <param name="rgvar">Pointer to a caller-allocated buffer that receives the data.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT ReadMultiple(uint cpspec, PROPSPEC* rgpspec, PROPVARIANT* rgvar);
+
+        /// <summary>
+        ///  Read property names.
+        /// </summary>
+        /// <param name="cpropid">The cpropid value.</param>
+        /// <param name="rgpropid">Pointer to a buffer that contains the input data.</param>
+        /// <param name="rglpwstrName">Pointer to a caller-allocated buffer that receives the data.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT ReadPropertyNames(uint cpropid, uint* rgpropid, BSTR* rglpwstrName);
+
+        /// <summary>
+        ///  Enum.
+        /// </summary>
+        /// <param name="ppenum">Pointer to a variable that receives the cloned enumerator.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT Enum(IEnumSTATPROPSTG** ppenum);
+
+        /// <summary>
+        ///  Read dword.
+        /// </summary>
+        /// <param name="id">The id value.</param>
+        /// <param name="pValue">Pointer to a variable that receives the requested value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT ReadDWORD(uint id, uint* pValue);
+
+        /// <summary>
+        ///  Read long.
+        /// </summary>
+        /// <param name="id">The id value.</param>
+        /// <param name="pValue">Pointer to a variable that receives the requested value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT ReadLONG(uint id, int* pValue);
+
+        /// <summary>
+        ///  Read bool.
+        /// </summary>
+        /// <param name="id">The id value.</param>
+        /// <param name="pValue">Pointer to a variable that receives the requested value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT ReadBOOL(uint id, BOOL* pValue);
+
+        /// <summary>
+        ///  Read ulonglong.
+        /// </summary>
+        /// <param name="id">The id value.</param>
+        /// <param name="pValue">Pointer to a variable that receives the requested value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT ReadULONGLONG(uint id, ulong* pValue);
+
+        /// <summary>
+        ///  Read bstr.
+        /// </summary>
+        /// <param name="id">The id value.</param>
+        /// <param name="pValue">Pointer to a variable that receives the requested value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT ReadBSTR(uint id, BSTR* pValue);
+    }
+}

--- a/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaReadExeAtOffsetCallback.cs
+++ b/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaReadExeAtOffsetCallback.cs
@@ -1,0 +1,101 @@
+﻿// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Runtime.InteropServices;
+
+// For some reason the XML comment refs for IUnknown can't be resolved on .NET Framework without
+// explicitly using the fully qualified name, which falls afoul of the simplify warning.
+using ComIUnknown = Windows.Win32.System.Com.IUnknown;
+
+namespace Microsoft.VisualStudio.Debugging.DebugInterfaceAccess;
+
+/// <inheritdoc cref="Interface"/>
+public unsafe struct IDiaReadExeAtOffsetCallback : IComIID
+{
+    /// <inheritdoc cref="IComIID.Guid"/>
+#pragma warning disable IDE1006 // Naming Styles
+    public static readonly Guid IID_Guid = new(0x587A461C, 0xB80B, 0x4F54, 0x91, 0x94, 0x50, 0x32, 0x58, 0x9A, 0x63, 0x19);
+#pragma warning restore IDE1006
+
+#if NETFRAMEWORK
+    readonly ref readonly Guid IComIID.Guid => ref IID_Guid;
+#else
+    static ref readonly Guid IComIID.Guid
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get
+        {
+            ReadOnlySpan<byte> data =
+            [
+                0x1C, 0x46, 0x7A, 0x58,
+                0x0B, 0xB8,
+                0x54, 0x4F,
+                0x91, 0x94, 0x50, 0x32, 0x58, 0x9A, 0x63, 0x19
+            ];
+
+            return ref Unsafe.As<byte, Guid>(ref MemoryMarshal.GetReference(data));
+        }
+    }
+#endif
+
+    private readonly void** _lpVtbl;
+
+    /// <inheritdoc cref="ComIUnknown.QueryInterface(Guid*, void**)"/>
+    public HRESULT QueryInterface(Guid* riid, void** ppvObject)
+    {
+        fixed (IDiaReadExeAtOffsetCallback* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaReadExeAtOffsetCallback*, Guid*, void**, HRESULT>)_lpVtbl[0])(pThis, riid, ppvObject);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.AddRef"/>
+    public uint AddRef()
+    {
+        fixed (IDiaReadExeAtOffsetCallback* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaReadExeAtOffsetCallback*, uint>)_lpVtbl[1])(pThis);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.Release"/>
+    public uint Release()
+    {
+        fixed (IDiaReadExeAtOffsetCallback* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaReadExeAtOffsetCallback*, uint>)_lpVtbl[2])(pThis);
+    }
+
+    /// <inheritdoc cref="Interface.ReadExecutableAt"/>
+    public HRESULT ReadExecutableAt(ulong fileOffset, uint cbData, uint* pcbData, byte* pbData)
+    {
+        fixed (IDiaReadExeAtOffsetCallback* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaReadExeAtOffsetCallback*, ulong, uint, uint*, byte*, HRESULT>)_lpVtbl[3])(pThis, fileOffset, cbData, pcbData, pbData);
+    }
+
+    /// <summary>
+    ///  Allows a client to read from a portion of an executable file by file offset when the file is not on the symbol path.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/visualstudio/debugger/debug-interface-access/idiareadexeatoffsetcallback">
+    ///    Official documentation.
+    ///   </see>
+    ///  </para>
+    /// </remarks>
+    [ComImport]
+    [Guid("587A461C-B80B-4F54-9194-5032589A6319")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    public unsafe interface Interface
+    {
+        /// <summary>
+        ///  Read executable at.
+        /// </summary>
+        /// <summary>
+        ///  Reads data from the executable file at the specified file offset.
+        /// </summary>
+        /// <param name="fileOffset">The offset, in bytes, from the start of the executable file at which to begin reading.</param>
+        /// <param name="cbData">The size, in bytes, of the buffer.</param>
+        /// <param name="pcbData">Pointer to a variable that receives the number of bytes written to the buffer.</param>
+        /// <param name="pbData">Pointer to a caller-allocated buffer that receives the data.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT ReadExecutableAt(ulong fileOffset, uint cbData, uint* pcbData, byte* pbData);
+    }
+}

--- a/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaReadExeAtRVACallback.cs
+++ b/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaReadExeAtRVACallback.cs
@@ -1,0 +1,101 @@
+﻿// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Runtime.InteropServices;
+
+// For some reason the XML comment refs for IUnknown can't be resolved on .NET Framework without
+// explicitly using the fully qualified name, which falls afoul of the simplify warning.
+using ComIUnknown = Windows.Win32.System.Com.IUnknown;
+
+namespace Microsoft.VisualStudio.Debugging.DebugInterfaceAccess;
+
+/// <inheritdoc cref="Interface"/>
+public unsafe struct IDiaReadExeAtRVACallback : IComIID
+{
+    /// <inheritdoc cref="IComIID.Guid"/>
+#pragma warning disable IDE1006 // Naming Styles
+    public static readonly Guid IID_Guid = new(0x8E3F80CA, 0x7517, 0x432A, 0xBA, 0x07, 0x28, 0x51, 0x34, 0xAA, 0xEA, 0x8E);
+#pragma warning restore IDE1006
+
+#if NETFRAMEWORK
+    readonly ref readonly Guid IComIID.Guid => ref IID_Guid;
+#else
+    static ref readonly Guid IComIID.Guid
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get
+        {
+            ReadOnlySpan<byte> data =
+            [
+                0xCA, 0x80, 0x3F, 0x8E,
+                0x17, 0x75,
+                0x2A, 0x43,
+                0xBA, 0x07, 0x28, 0x51, 0x34, 0xAA, 0xEA, 0x8E
+            ];
+
+            return ref Unsafe.As<byte, Guid>(ref MemoryMarshal.GetReference(data));
+        }
+    }
+#endif
+
+    private readonly void** _lpVtbl;
+
+    /// <inheritdoc cref="ComIUnknown.QueryInterface(Guid*, void**)"/>
+    public HRESULT QueryInterface(Guid* riid, void** ppvObject)
+    {
+        fixed (IDiaReadExeAtRVACallback* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaReadExeAtRVACallback*, Guid*, void**, HRESULT>)_lpVtbl[0])(pThis, riid, ppvObject);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.AddRef"/>
+    public uint AddRef()
+    {
+        fixed (IDiaReadExeAtRVACallback* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaReadExeAtRVACallback*, uint>)_lpVtbl[1])(pThis);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.Release"/>
+    public uint Release()
+    {
+        fixed (IDiaReadExeAtRVACallback* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaReadExeAtRVACallback*, uint>)_lpVtbl[2])(pThis);
+    }
+
+    /// <inheritdoc cref="Interface.ReadExecutableAtRVA"/>
+    public HRESULT ReadExecutableAtRVA(uint relativeVirtualAddress, uint cbData, uint* pcbData, byte* pbData)
+    {
+        fixed (IDiaReadExeAtRVACallback* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaReadExeAtRVACallback*, uint, uint, uint*, byte*, HRESULT>)_lpVtbl[3])(pThis, relativeVirtualAddress, cbData, pcbData, pbData);
+    }
+
+    /// <summary>
+    ///  Allows a client to read from a portion of an executable file by relative virtual address when the file is not on the symbol path.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/visualstudio/debugger/debug-interface-access/idiareadexeatrvacallback">
+    ///    Official documentation.
+    ///   </see>
+    ///  </para>
+    /// </remarks>
+    [ComImport]
+    [Guid("8E3F80CA-7517-432A-BA07-285134AAEA8E")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    public unsafe interface Interface
+    {
+        /// <summary>
+        ///  Read executable at rva.
+        /// </summary>
+        /// <summary>
+        ///  Reads data from the executable file at the specified relative virtual address (RVA).
+        /// </summary>
+        /// <param name="relativeVirtualAddress">The relative virtual address (RVA) at which to begin reading.</param>
+        /// <param name="cbData">The size, in bytes, of the buffer.</param>
+        /// <param name="pcbData">Pointer to a variable that receives the number of bytes written to the buffer.</param>
+        /// <param name="pbData">Pointer to a caller-allocated buffer that receives the data.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT ReadExecutableAtRVA(uint relativeVirtualAddress, uint cbData, uint* pcbData, byte* pbData);
+    }
+}

--- a/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaSectionContrib.cs
+++ b/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaSectionContrib.cs
@@ -1,0 +1,410 @@
+﻿// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Runtime.InteropServices;
+
+// For some reason the XML comment refs for IUnknown can't be resolved on .NET Framework without
+// explicitly using the fully qualified name, which falls afoul of the simplify warning.
+using ComIUnknown = Windows.Win32.System.Com.IUnknown;
+
+namespace Microsoft.VisualStudio.Debugging.DebugInterfaceAccess;
+
+/// <inheritdoc cref="Interface"/>
+public unsafe struct IDiaSectionContrib : IComIID
+{
+    /// <inheritdoc cref="IComIID.Guid"/>
+#pragma warning disable IDE1006 // Naming Styles
+    public static readonly Guid IID_Guid = new(0x0CF4B60E, 0x35B1, 0x4C6C, 0xBD, 0xD8, 0x85, 0x4B, 0x9C, 0x8E, 0x38, 0x57);
+#pragma warning restore IDE1006
+
+#if NETFRAMEWORK
+    readonly ref readonly Guid IComIID.Guid => ref IID_Guid;
+#else
+    static ref readonly Guid IComIID.Guid
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get
+        {
+            ReadOnlySpan<byte> data =
+            [
+                0x0E, 0xB6, 0xF4, 0x0C,
+                0xB1, 0x35,
+                0x6C, 0x4C,
+                0xBD, 0xD8, 0x85, 0x4B, 0x9C, 0x8E, 0x38, 0x57
+            ];
+
+            return ref Unsafe.As<byte, Guid>(ref MemoryMarshal.GetReference(data));
+        }
+    }
+#endif
+
+    private readonly void** _lpVtbl;
+
+    /// <inheritdoc cref="ComIUnknown.QueryInterface(Guid*, void**)"/>
+    public HRESULT QueryInterface(Guid* riid, void** ppvObject)
+    {
+        fixed (IDiaSectionContrib* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSectionContrib*, Guid*, void**, HRESULT>)_lpVtbl[0])(pThis, riid, ppvObject);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.AddRef"/>
+    public uint AddRef()
+    {
+        fixed (IDiaSectionContrib* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSectionContrib*, uint>)_lpVtbl[1])(pThis);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.Release"/>
+    public uint Release()
+    {
+        fixed (IDiaSectionContrib* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSectionContrib*, uint>)_lpVtbl[2])(pThis);
+    }
+
+    /// <inheritdoc cref="Interface.get_compiland"/>
+    public HRESULT get_compiland(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSectionContrib* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSectionContrib*, IDiaSymbol**, HRESULT>)_lpVtbl[3])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_addressSection"/>
+    public HRESULT get_addressSection(uint* pRetVal)
+    {
+        fixed (IDiaSectionContrib* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSectionContrib*, uint*, HRESULT>)_lpVtbl[4])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_addressOffset"/>
+    public HRESULT get_addressOffset(uint* pRetVal)
+    {
+        fixed (IDiaSectionContrib* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSectionContrib*, uint*, HRESULT>)_lpVtbl[5])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_relativeVirtualAddress"/>
+    public HRESULT get_relativeVirtualAddress(uint* pRetVal)
+    {
+        fixed (IDiaSectionContrib* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSectionContrib*, uint*, HRESULT>)_lpVtbl[6])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_virtualAddress"/>
+    public HRESULT get_virtualAddress(ulong* pRetVal)
+    {
+        fixed (IDiaSectionContrib* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSectionContrib*, ulong*, HRESULT>)_lpVtbl[7])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_length"/>
+    public HRESULT get_length(uint* pRetVal)
+    {
+        fixed (IDiaSectionContrib* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSectionContrib*, uint*, HRESULT>)_lpVtbl[8])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_notPaged"/>
+    public HRESULT get_notPaged(BOOL* pRetVal)
+    {
+        fixed (IDiaSectionContrib* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSectionContrib*, BOOL*, HRESULT>)_lpVtbl[9])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_code"/>
+    public HRESULT get_code(BOOL* pRetVal)
+    {
+        fixed (IDiaSectionContrib* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSectionContrib*, BOOL*, HRESULT>)_lpVtbl[10])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_initializedData"/>
+    public HRESULT get_initializedData(BOOL* pRetVal)
+    {
+        fixed (IDiaSectionContrib* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSectionContrib*, BOOL*, HRESULT>)_lpVtbl[11])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_uninitializedData"/>
+    public HRESULT get_uninitializedData(BOOL* pRetVal)
+    {
+        fixed (IDiaSectionContrib* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSectionContrib*, BOOL*, HRESULT>)_lpVtbl[12])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_remove"/>
+    public HRESULT get_remove(BOOL* pRetVal)
+    {
+        fixed (IDiaSectionContrib* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSectionContrib*, BOOL*, HRESULT>)_lpVtbl[13])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_comdat"/>
+    public HRESULT get_comdat(BOOL* pRetVal)
+    {
+        fixed (IDiaSectionContrib* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSectionContrib*, BOOL*, HRESULT>)_lpVtbl[14])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_discardable"/>
+    public HRESULT get_discardable(BOOL* pRetVal)
+    {
+        fixed (IDiaSectionContrib* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSectionContrib*, BOOL*, HRESULT>)_lpVtbl[15])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_notCached"/>
+    public HRESULT get_notCached(BOOL* pRetVal)
+    {
+        fixed (IDiaSectionContrib* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSectionContrib*, BOOL*, HRESULT>)_lpVtbl[16])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_share"/>
+    public HRESULT get_share(BOOL* pRetVal)
+    {
+        fixed (IDiaSectionContrib* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSectionContrib*, BOOL*, HRESULT>)_lpVtbl[17])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_execute"/>
+    public HRESULT get_execute(BOOL* pRetVal)
+    {
+        fixed (IDiaSectionContrib* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSectionContrib*, BOOL*, HRESULT>)_lpVtbl[18])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_read"/>
+    public HRESULT get_read(BOOL* pRetVal)
+    {
+        fixed (IDiaSectionContrib* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSectionContrib*, BOOL*, HRESULT>)_lpVtbl[19])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_write"/>
+    public HRESULT get_write(BOOL* pRetVal)
+    {
+        fixed (IDiaSectionContrib* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSectionContrib*, BOOL*, HRESULT>)_lpVtbl[20])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_dataCrc"/>
+    public HRESULT get_dataCrc(uint* pRetVal)
+    {
+        fixed (IDiaSectionContrib* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSectionContrib*, uint*, HRESULT>)_lpVtbl[21])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_relocationsCrc"/>
+    public HRESULT get_relocationsCrc(uint* pRetVal)
+    {
+        fixed (IDiaSectionContrib* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSectionContrib*, uint*, HRESULT>)_lpVtbl[22])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_compilandId"/>
+    public HRESULT get_compilandId(uint* pRetVal)
+    {
+        fixed (IDiaSectionContrib* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSectionContrib*, uint*, HRESULT>)_lpVtbl[23])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_code16bit"/>
+    public HRESULT get_code16bit(BOOL* pRetVal)
+    {
+        fixed (IDiaSectionContrib* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSectionContrib*, BOOL*, HRESULT>)_lpVtbl[24])(pThis, pRetVal);
+    }
+
+    /// <summary>
+    ///  Represents a section contribution; that is, a contiguous block of memory contributed to the image by a compiland.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/visualstudio/debugger/debug-interface-access/idiasectioncontrib">
+    ///    Official documentation.
+    ///   </see>
+    ///  </para>
+    /// </remarks>
+    [ComImport]
+    [Guid("0CF4B60E-35B1-4C6C-BDD8-854B9C8E3857")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    public unsafe interface Interface
+    {
+        /// <summary>
+        ///  Retrieves the compiland.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_compiland(IDiaSymbol** pRetVal);
+
+        /// <summary>
+        ///  Retrieves the address section.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_addressSection(uint* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the address offset.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_addressOffset(uint* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the relative virtual address.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_relativeVirtualAddress(uint* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the virtual address.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_virtualAddress(ulong* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the length.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_length(uint* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the not paged.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_notPaged(BOOL* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the code.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_code(BOOL* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the initialized data.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_initializedData(BOOL* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the uninitialized data.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_uninitializedData(BOOL* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the remove.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_remove(BOOL* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the comdat.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_comdat(BOOL* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the discardable.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_discardable(BOOL* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the not cached.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_notCached(BOOL* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the share.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_share(BOOL* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the execute.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_execute(BOOL* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the read.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_read(BOOL* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the write.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_write(BOOL* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the data crc.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_dataCrc(uint* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the relocations crc.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_relocationsCrc(uint* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the compiland id.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_compilandId(uint* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the code16bit.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_code16bit(BOOL* pRetVal);
+    }
+}

--- a/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaSegment.cs
+++ b/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaSegment.cs
@@ -1,0 +1,215 @@
+﻿// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Runtime.InteropServices;
+
+// For some reason the XML comment refs for IUnknown can't be resolved on .NET Framework without
+// explicitly using the fully qualified name, which falls afoul of the simplify warning.
+using ComIUnknown = Windows.Win32.System.Com.IUnknown;
+
+namespace Microsoft.VisualStudio.Debugging.DebugInterfaceAccess;
+
+/// <inheritdoc cref="Interface"/>
+public unsafe struct IDiaSegment : IComIID
+{
+    /// <inheritdoc cref="IComIID.Guid"/>
+#pragma warning disable IDE1006 // Naming Styles
+    public static readonly Guid IID_Guid = new(0x0775B784, 0xC75B, 0x4449, 0x84, 0x8B, 0xB7, 0xBD, 0x31, 0x59, 0x54, 0x5B);
+#pragma warning restore IDE1006
+
+#if NETFRAMEWORK
+    readonly ref readonly Guid IComIID.Guid => ref IID_Guid;
+#else
+    static ref readonly Guid IComIID.Guid
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get
+        {
+            ReadOnlySpan<byte> data =
+            [
+                0x84, 0xB7, 0x75, 0x07,
+                0x5B, 0xC7,
+                0x49, 0x44,
+                0x84, 0x8B, 0xB7, 0xBD, 0x31, 0x59, 0x54, 0x5B
+            ];
+
+            return ref Unsafe.As<byte, Guid>(ref MemoryMarshal.GetReference(data));
+        }
+    }
+#endif
+
+    private readonly void** _lpVtbl;
+
+    /// <inheritdoc cref="ComIUnknown.QueryInterface(Guid*, void**)"/>
+    public HRESULT QueryInterface(Guid* riid, void** ppvObject)
+    {
+        fixed (IDiaSegment* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSegment*, Guid*, void**, HRESULT>)_lpVtbl[0])(pThis, riid, ppvObject);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.AddRef"/>
+    public uint AddRef()
+    {
+        fixed (IDiaSegment* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSegment*, uint>)_lpVtbl[1])(pThis);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.Release"/>
+    public uint Release()
+    {
+        fixed (IDiaSegment* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSegment*, uint>)_lpVtbl[2])(pThis);
+    }
+
+    /// <inheritdoc cref="Interface.get_frame"/>
+    public HRESULT get_frame(uint* pRetVal)
+    {
+        fixed (IDiaSegment* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSegment*, uint*, HRESULT>)_lpVtbl[3])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_offset"/>
+    public HRESULT get_offset(uint* pRetVal)
+    {
+        fixed (IDiaSegment* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSegment*, uint*, HRESULT>)_lpVtbl[4])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_length"/>
+    public HRESULT get_length(uint* pRetVal)
+    {
+        fixed (IDiaSegment* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSegment*, uint*, HRESULT>)_lpVtbl[5])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_read"/>
+    public HRESULT get_read(BOOL* pRetVal)
+    {
+        fixed (IDiaSegment* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSegment*, BOOL*, HRESULT>)_lpVtbl[6])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_write"/>
+    public HRESULT get_write(BOOL* pRetVal)
+    {
+        fixed (IDiaSegment* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSegment*, BOOL*, HRESULT>)_lpVtbl[7])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_execute"/>
+    public HRESULT get_execute(BOOL* pRetVal)
+    {
+        fixed (IDiaSegment* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSegment*, BOOL*, HRESULT>)_lpVtbl[8])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_addressSection"/>
+    public HRESULT get_addressSection(uint* pRetVal)
+    {
+        fixed (IDiaSegment* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSegment*, uint*, HRESULT>)_lpVtbl[9])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_relativeVirtualAddress"/>
+    public HRESULT get_relativeVirtualAddress(uint* pRetVal)
+    {
+        fixed (IDiaSegment* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSegment*, uint*, HRESULT>)_lpVtbl[10])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_virtualAddress"/>
+    public HRESULT get_virtualAddress(ulong* pRetVal)
+    {
+        fixed (IDiaSegment* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSegment*, ulong*, HRESULT>)_lpVtbl[11])(pThis, pRetVal);
+    }
+
+    /// <summary>
+    ///  Describes a segment in a portable executable (PE) file's segment map.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/visualstudio/debugger/debug-interface-access/idiasegment">
+    ///    Official documentation.
+    ///   </see>
+    ///  </para>
+    /// </remarks>
+    [ComImport]
+    [Guid("0775B784-C75B-4449-848B-B7BD3159545B")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    public unsafe interface Interface
+    {
+        /// <summary>
+        ///  Frame.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_frame(uint* pRetVal);
+
+        /// <summary>
+        ///  Offset in physical section.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_offset(uint* pRetVal);
+
+        /// <summary>
+        ///  Length in bytes of segment.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_length(uint* pRetVal);
+
+        /// <summary>
+        ///  Read allowed.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_read(BOOL* pRetVal);
+
+        /// <summary>
+        ///  Write allowed.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_write(BOOL* pRetVal);
+
+        /// <summary>
+        ///  Execute allowed.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_execute(BOOL* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the address section.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_addressSection(uint* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the relative virtual address.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_relativeVirtualAddress(uint* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the virtual address.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_virtualAddress(ulong* pRetVal);
+    }
+}

--- a/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaSession.cs
+++ b/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaSession.cs
@@ -1,0 +1,1089 @@
+﻿// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Runtime.InteropServices;
+
+// For some reason the XML comment refs for IUnknown can't be resolved on .NET Framework without
+// explicitly using the fully qualified name, which falls afoul of the simplify warning.
+using ComIUnknown = Windows.Win32.System.Com.IUnknown;
+
+namespace Microsoft.VisualStudio.Debugging.DebugInterfaceAccess;
+
+/// <inheritdoc cref="Interface"/>
+public unsafe struct IDiaSession : IComIID
+{
+    /// <inheritdoc cref="IComIID.Guid"/>
+#pragma warning disable IDE1006 // Naming Styles
+    public static readonly Guid IID_Guid = new(0x2F609EE1, 0xD1C8, 0x4E24, 0x82, 0x88, 0x33, 0x26, 0xBA, 0xDC, 0xD2, 0x11);
+#pragma warning restore IDE1006
+
+#if NETFRAMEWORK
+    readonly ref readonly Guid IComIID.Guid => ref IID_Guid;
+#else
+    static ref readonly Guid IComIID.Guid
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get
+        {
+            ReadOnlySpan<byte> data =
+            [
+                0xE1, 0x9E, 0x60, 0x2F,
+                0xC8, 0xD1,
+                0x24, 0x4E,
+                0x82, 0x88, 0x33, 0x26, 0xBA, 0xDC, 0xD2, 0x11
+            ];
+
+            return ref Unsafe.As<byte, Guid>(ref MemoryMarshal.GetReference(data));
+        }
+    }
+#endif
+
+    private readonly void** _lpVtbl;
+
+    /// <inheritdoc cref="ComIUnknown.QueryInterface(Guid*, void**)"/>
+    public HRESULT QueryInterface(Guid* riid, void** ppvObject)
+    {
+        fixed (IDiaSession* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSession*, Guid*, void**, HRESULT>)_lpVtbl[0])(pThis, riid, ppvObject);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.AddRef"/>
+    public uint AddRef()
+    {
+        fixed (IDiaSession* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSession*, uint>)_lpVtbl[1])(pThis);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.Release"/>
+    public uint Release()
+    {
+        fixed (IDiaSession* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSession*, uint>)_lpVtbl[2])(pThis);
+    }
+
+    /// <inheritdoc cref="Interface.get_loadAddress"/>
+    public HRESULT get_loadAddress(ulong* pRetVal)
+    {
+        fixed (IDiaSession* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSession*, ulong*, HRESULT>)_lpVtbl[3])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.put_loadAddress"/>
+    public HRESULT put_loadAddress(ulong NewVal)
+    {
+        fixed (IDiaSession* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSession*, ulong, HRESULT>)_lpVtbl[4])(pThis, NewVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_globalScope"/>
+    public HRESULT get_globalScope(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSession* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSession*, IDiaSymbol**, HRESULT>)_lpVtbl[5])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.getEnumTables"/>
+    public HRESULT getEnumTables(IDiaEnumTables** ppEnumTables)
+    {
+        fixed (IDiaSession* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSession*, IDiaEnumTables**, HRESULT>)_lpVtbl[6])(pThis, ppEnumTables);
+    }
+
+    /// <inheritdoc cref="Interface.getSymbolsByAddr"/>
+    public HRESULT getSymbolsByAddr(IDiaEnumSymbolsByAddr** ppEnumbyAddr)
+    {
+        fixed (IDiaSession* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSession*, IDiaEnumSymbolsByAddr**, HRESULT>)_lpVtbl[7])(pThis, ppEnumbyAddr);
+    }
+
+    /// <inheritdoc cref="Interface.findChildren"/>
+    public HRESULT findChildren(IDiaSymbol* parent, SymTagEnum symtag, PCWSTR name, uint compareFlags, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSession* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSession*, IDiaSymbol*, SymTagEnum, PCWSTR, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[8])(pThis, parent, symtag, name, compareFlags, ppResult);
+    }
+
+    /// <inheritdoc cref="Interface.findChildrenEx"/>
+    public HRESULT findChildrenEx(IDiaSymbol* parent, SymTagEnum symtag, PCWSTR name, uint compareFlags, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSession* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSession*, IDiaSymbol*, SymTagEnum, PCWSTR, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[9])(pThis, parent, symtag, name, compareFlags, ppResult);
+    }
+
+    /// <inheritdoc cref="Interface.findChildrenExByAddr"/>
+    public HRESULT findChildrenExByAddr(IDiaSymbol* parent, SymTagEnum symtag, PCWSTR name, uint compareFlags, uint isect, uint offset, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSession* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSession*, IDiaSymbol*, SymTagEnum, PCWSTR, uint, uint, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[10])(pThis, parent, symtag, name, compareFlags, isect, offset, ppResult);
+    }
+
+    /// <inheritdoc cref="Interface.findChildrenExByVA"/>
+    public HRESULT findChildrenExByVA(IDiaSymbol* parent, SymTagEnum symtag, PCWSTR name, uint compareFlags, ulong va, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSession* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSession*, IDiaSymbol*, SymTagEnum, PCWSTR, uint, ulong, IDiaEnumSymbols**, HRESULT>)_lpVtbl[11])(pThis, parent, symtag, name, compareFlags, va, ppResult);
+    }
+
+    /// <inheritdoc cref="Interface.findChildrenExByRVA"/>
+    public HRESULT findChildrenExByRVA(IDiaSymbol* parent, SymTagEnum symtag, PCWSTR name, uint compareFlags, uint rva, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSession* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSession*, IDiaSymbol*, SymTagEnum, PCWSTR, uint, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[12])(pThis, parent, symtag, name, compareFlags, rva, ppResult);
+    }
+
+    /// <inheritdoc cref="Interface.findSymbolByAddr"/>
+    public HRESULT findSymbolByAddr(uint isect, uint offset, SymTagEnum symtag, IDiaSymbol** ppSymbol)
+    {
+        fixed (IDiaSession* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSession*, uint, uint, SymTagEnum, IDiaSymbol**, HRESULT>)_lpVtbl[13])(pThis, isect, offset, symtag, ppSymbol);
+    }
+
+    /// <inheritdoc cref="Interface.findSymbolByRVA"/>
+    public HRESULT findSymbolByRVA(uint rva, SymTagEnum symtag, IDiaSymbol** ppSymbol)
+    {
+        fixed (IDiaSession* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSession*, uint, SymTagEnum, IDiaSymbol**, HRESULT>)_lpVtbl[14])(pThis, rva, symtag, ppSymbol);
+    }
+
+    /// <inheritdoc cref="Interface.findSymbolByVA"/>
+    public HRESULT findSymbolByVA(ulong va, SymTagEnum symtag, IDiaSymbol** ppSymbol)
+    {
+        fixed (IDiaSession* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSession*, ulong, SymTagEnum, IDiaSymbol**, HRESULT>)_lpVtbl[15])(pThis, va, symtag, ppSymbol);
+    }
+
+    /// <inheritdoc cref="Interface.findSymbolByToken"/>
+    public HRESULT findSymbolByToken(uint token, SymTagEnum symtag, IDiaSymbol** ppSymbol)
+    {
+        fixed (IDiaSession* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSession*, uint, SymTagEnum, IDiaSymbol**, HRESULT>)_lpVtbl[16])(pThis, token, symtag, ppSymbol);
+    }
+
+    /// <inheritdoc cref="Interface.symsAreEquiv"/>
+    public HRESULT symsAreEquiv(IDiaSymbol* symbolA, IDiaSymbol* symbolB)
+    {
+        fixed (IDiaSession* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSession*, IDiaSymbol*, IDiaSymbol*, HRESULT>)_lpVtbl[17])(pThis, symbolA, symbolB);
+    }
+
+    /// <inheritdoc cref="Interface.symbolById"/>
+    public HRESULT symbolById(uint id, IDiaSymbol** ppSymbol)
+    {
+        fixed (IDiaSession* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSession*, uint, IDiaSymbol**, HRESULT>)_lpVtbl[18])(pThis, id, ppSymbol);
+    }
+
+    /// <inheritdoc cref="Interface.findSymbolByRVAEx"/>
+    public HRESULT findSymbolByRVAEx(uint rva, SymTagEnum symtag, IDiaSymbol** ppSymbol, int* displacement)
+    {
+        fixed (IDiaSession* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSession*, uint, SymTagEnum, IDiaSymbol**, int*, HRESULT>)_lpVtbl[19])(pThis, rva, symtag, ppSymbol, displacement);
+    }
+
+    /// <inheritdoc cref="Interface.findSymbolByVAEx"/>
+    public HRESULT findSymbolByVAEx(ulong va, SymTagEnum symtag, IDiaSymbol** ppSymbol, int* displacement)
+    {
+        fixed (IDiaSession* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSession*, ulong, SymTagEnum, IDiaSymbol**, int*, HRESULT>)_lpVtbl[20])(pThis, va, symtag, ppSymbol, displacement);
+    }
+
+    /// <inheritdoc cref="Interface.findFile"/>
+    public HRESULT findFile(IDiaSymbol* pCompiland, PCWSTR name, uint compareFlags, IDiaEnumSourceFiles** ppResult)
+    {
+        fixed (IDiaSession* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSession*, IDiaSymbol*, PCWSTR, uint, IDiaEnumSourceFiles**, HRESULT>)_lpVtbl[21])(pThis, pCompiland, name, compareFlags, ppResult);
+    }
+
+    /// <inheritdoc cref="Interface.findFileById"/>
+    public HRESULT findFileById(uint uniqueId, IDiaSourceFile** ppResult)
+    {
+        fixed (IDiaSession* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSession*, uint, IDiaSourceFile**, HRESULT>)_lpVtbl[22])(pThis, uniqueId, ppResult);
+    }
+
+    /// <inheritdoc cref="Interface.findLines"/>
+    public HRESULT findLines(IDiaSymbol* compiland, IDiaSourceFile* file, IDiaEnumLineNumbers** ppResult)
+    {
+        fixed (IDiaSession* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSession*, IDiaSymbol*, IDiaSourceFile*, IDiaEnumLineNumbers**, HRESULT>)_lpVtbl[23])(pThis, compiland, file, ppResult);
+    }
+
+    /// <inheritdoc cref="Interface.findLinesByAddr"/>
+    public HRESULT findLinesByAddr(uint seg, uint offset, uint length, IDiaEnumLineNumbers** ppResult)
+    {
+        fixed (IDiaSession* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSession*, uint, uint, uint, IDiaEnumLineNumbers**, HRESULT>)_lpVtbl[24])(pThis, seg, offset, length, ppResult);
+    }
+
+    /// <inheritdoc cref="Interface.findLinesByRVA"/>
+    public HRESULT findLinesByRVA(uint rva, uint length, IDiaEnumLineNumbers** ppResult)
+    {
+        fixed (IDiaSession* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSession*, uint, uint, IDiaEnumLineNumbers**, HRESULT>)_lpVtbl[25])(pThis, rva, length, ppResult);
+    }
+
+    /// <inheritdoc cref="Interface.findLinesByVA"/>
+    public HRESULT findLinesByVA(ulong va, uint length, IDiaEnumLineNumbers** ppResult)
+    {
+        fixed (IDiaSession* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSession*, ulong, uint, IDiaEnumLineNumbers**, HRESULT>)_lpVtbl[26])(pThis, va, length, ppResult);
+    }
+
+    /// <inheritdoc cref="Interface.findLinesByLinenum"/>
+    public HRESULT findLinesByLinenum(IDiaSymbol* compiland, IDiaSourceFile* file, uint linenum, uint column, IDiaEnumLineNumbers** ppResult)
+    {
+        fixed (IDiaSession* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSession*, IDiaSymbol*, IDiaSourceFile*, uint, uint, IDiaEnumLineNumbers**, HRESULT>)_lpVtbl[27])(pThis, compiland, file, linenum, column, ppResult);
+    }
+
+    /// <inheritdoc cref="Interface.findInjectedSource"/>
+    public HRESULT findInjectedSource(PCWSTR srcFile, IDiaEnumInjectedSources** ppResult)
+    {
+        fixed (IDiaSession* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSession*, PCWSTR, IDiaEnumInjectedSources**, HRESULT>)_lpVtbl[28])(pThis, srcFile, ppResult);
+    }
+
+    /// <inheritdoc cref="Interface.getEnumDebugStreams"/>
+    public HRESULT getEnumDebugStreams(IDiaEnumDebugStreams** ppEnumDebugStreams)
+    {
+        fixed (IDiaSession* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSession*, IDiaEnumDebugStreams**, HRESULT>)_lpVtbl[29])(pThis, ppEnumDebugStreams);
+    }
+
+    /// <inheritdoc cref="Interface.findInlineFramesByAddr"/>
+    public HRESULT findInlineFramesByAddr(IDiaSymbol* parent, uint isect, uint offset, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSession* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSession*, IDiaSymbol*, uint, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[30])(pThis, parent, isect, offset, ppResult);
+    }
+
+    /// <inheritdoc cref="Interface.findInlineFramesByRVA"/>
+    public HRESULT findInlineFramesByRVA(IDiaSymbol* parent, uint rva, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSession* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSession*, IDiaSymbol*, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[31])(pThis, parent, rva, ppResult);
+    }
+
+    /// <inheritdoc cref="Interface.findInlineFramesByVA"/>
+    public HRESULT findInlineFramesByVA(IDiaSymbol* parent, ulong va, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSession* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSession*, IDiaSymbol*, ulong, IDiaEnumSymbols**, HRESULT>)_lpVtbl[32])(pThis, parent, va, ppResult);
+    }
+
+    /// <inheritdoc cref="Interface.findInlineeLines"/>
+    public HRESULT findInlineeLines(IDiaSymbol* parent, IDiaEnumLineNumbers** ppResult)
+    {
+        fixed (IDiaSession* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSession*, IDiaSymbol*, IDiaEnumLineNumbers**, HRESULT>)_lpVtbl[33])(pThis, parent, ppResult);
+    }
+
+    /// <inheritdoc cref="Interface.findInlineeLinesByAddr"/>
+    public HRESULT findInlineeLinesByAddr(IDiaSymbol* parent, uint isect, uint offset, uint length, IDiaEnumLineNumbers** ppResult)
+    {
+        fixed (IDiaSession* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSession*, IDiaSymbol*, uint, uint, uint, IDiaEnumLineNumbers**, HRESULT>)_lpVtbl[34])(pThis, parent, isect, offset, length, ppResult);
+    }
+
+    /// <inheritdoc cref="Interface.findInlineeLinesByRVA"/>
+    public HRESULT findInlineeLinesByRVA(IDiaSymbol* parent, uint rva, uint length, IDiaEnumLineNumbers** ppResult)
+    {
+        fixed (IDiaSession* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSession*, IDiaSymbol*, uint, uint, IDiaEnumLineNumbers**, HRESULT>)_lpVtbl[35])(pThis, parent, rva, length, ppResult);
+    }
+
+    /// <inheritdoc cref="Interface.findInlineeLinesByVA"/>
+    public HRESULT findInlineeLinesByVA(IDiaSymbol* parent, ulong va, uint length, IDiaEnumLineNumbers** ppResult)
+    {
+        fixed (IDiaSession* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSession*, IDiaSymbol*, ulong, uint, IDiaEnumLineNumbers**, HRESULT>)_lpVtbl[36])(pThis, parent, va, length, ppResult);
+    }
+
+    /// <inheritdoc cref="Interface.findInlineeLinesByLinenum"/>
+    public HRESULT findInlineeLinesByLinenum(IDiaSymbol* compiland, IDiaSourceFile* file, uint linenum, uint column, IDiaEnumLineNumbers** ppResult)
+    {
+        fixed (IDiaSession* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSession*, IDiaSymbol*, IDiaSourceFile*, uint, uint, IDiaEnumLineNumbers**, HRESULT>)_lpVtbl[37])(pThis, compiland, file, linenum, column, ppResult);
+    }
+
+    /// <inheritdoc cref="Interface.findInlineesByName"/>
+    public HRESULT findInlineesByName(PCWSTR name, uint option, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSession* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSession*, PCWSTR, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[38])(pThis, name, option, ppResult);
+    }
+
+    /// <inheritdoc cref="Interface.findAcceleratorInlineeLinesByLinenum"/>
+    public HRESULT findAcceleratorInlineeLinesByLinenum(IDiaSymbol* parent, IDiaSourceFile* file, uint linenum, uint column, IDiaEnumLineNumbers** ppResult)
+    {
+        fixed (IDiaSession* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSession*, IDiaSymbol*, IDiaSourceFile*, uint, uint, IDiaEnumLineNumbers**, HRESULT>)_lpVtbl[39])(pThis, parent, file, linenum, column, ppResult);
+    }
+
+    /// <inheritdoc cref="Interface.findSymbolsForAcceleratorPointerTag"/>
+    public HRESULT findSymbolsForAcceleratorPointerTag(IDiaSymbol* parent, uint tagValue, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSession* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSession*, IDiaSymbol*, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[40])(pThis, parent, tagValue, ppResult);
+    }
+
+    /// <inheritdoc cref="Interface.findSymbolsByRVAForAcceleratorPointerTag"/>
+    public HRESULT findSymbolsByRVAForAcceleratorPointerTag(IDiaSymbol* parent, uint tagValue, uint rva, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSession* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSession*, IDiaSymbol*, uint, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[41])(pThis, parent, tagValue, rva, ppResult);
+    }
+
+    /// <inheritdoc cref="Interface.findAcceleratorInlineesByName"/>
+    public HRESULT findAcceleratorInlineesByName(PCWSTR name, uint option, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSession* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSession*, PCWSTR, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[42])(pThis, name, option, ppResult);
+    }
+
+    /// <inheritdoc cref="Interface.addressForVA"/>
+    public HRESULT addressForVA(ulong va, uint* pISect, uint* pOffset)
+    {
+        fixed (IDiaSession* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSession*, ulong, uint*, uint*, HRESULT>)_lpVtbl[43])(pThis, va, pISect, pOffset);
+    }
+
+    /// <inheritdoc cref="Interface.addressForRVA"/>
+    public HRESULT addressForRVA(uint rva, uint* pISect, uint* pOffset)
+    {
+        fixed (IDiaSession* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSession*, uint, uint*, uint*, HRESULT>)_lpVtbl[44])(pThis, rva, pISect, pOffset);
+    }
+
+    /// <inheritdoc cref="Interface.findILOffsetsByAddr"/>
+    public HRESULT findILOffsetsByAddr(uint isect, uint offset, uint length, IDiaEnumLineNumbers** ppResult)
+    {
+        fixed (IDiaSession* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSession*, uint, uint, uint, IDiaEnumLineNumbers**, HRESULT>)_lpVtbl[45])(pThis, isect, offset, length, ppResult);
+    }
+
+    /// <inheritdoc cref="Interface.findILOffsetsByRVA"/>
+    public HRESULT findILOffsetsByRVA(uint rva, uint length, IDiaEnumLineNumbers** ppResult)
+    {
+        fixed (IDiaSession* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSession*, uint, uint, IDiaEnumLineNumbers**, HRESULT>)_lpVtbl[46])(pThis, rva, length, ppResult);
+    }
+
+    /// <inheritdoc cref="Interface.findILOffsetsByVA"/>
+    public HRESULT findILOffsetsByVA(ulong va, uint length, IDiaEnumLineNumbers** ppResult)
+    {
+        fixed (IDiaSession* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSession*, ulong, uint, IDiaEnumLineNumbers**, HRESULT>)_lpVtbl[47])(pThis, va, length, ppResult);
+    }
+
+    /// <inheritdoc cref="Interface.findInputAssemblyFiles"/>
+    public HRESULT findInputAssemblyFiles(IDiaEnumInputAssemblyFiles** ppResult)
+    {
+        fixed (IDiaSession* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSession*, IDiaEnumInputAssemblyFiles**, HRESULT>)_lpVtbl[48])(pThis, ppResult);
+    }
+
+    /// <inheritdoc cref="Interface.findInputAssembly"/>
+    public HRESULT findInputAssembly(uint index, IDiaInputAssemblyFile** ppResult)
+    {
+        fixed (IDiaSession* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSession*, uint, IDiaInputAssemblyFile**, HRESULT>)_lpVtbl[49])(pThis, index, ppResult);
+    }
+
+    /// <inheritdoc cref="Interface.findInputAssemblyById"/>
+    public HRESULT findInputAssemblyById(uint uniqueId, IDiaInputAssemblyFile** ppResult)
+    {
+        fixed (IDiaSession* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSession*, uint, IDiaInputAssemblyFile**, HRESULT>)_lpVtbl[50])(pThis, uniqueId, ppResult);
+    }
+
+    /// <inheritdoc cref="Interface.getFuncMDTokenMapSize"/>
+    public HRESULT getFuncMDTokenMapSize(uint* pcb)
+    {
+        fixed (IDiaSession* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSession*, uint*, HRESULT>)_lpVtbl[51])(pThis, pcb);
+    }
+
+    /// <inheritdoc cref="Interface.getFuncMDTokenMap"/>
+    public HRESULT getFuncMDTokenMap(uint cb, uint* pcb, byte* pb)
+    {
+        fixed (IDiaSession* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSession*, uint, uint*, byte*, HRESULT>)_lpVtbl[52])(pThis, cb, pcb, pb);
+    }
+
+    /// <inheritdoc cref="Interface.getTypeMDTokenMapSize"/>
+    public HRESULT getTypeMDTokenMapSize(uint* pcb)
+    {
+        fixed (IDiaSession* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSession*, uint*, HRESULT>)_lpVtbl[53])(pThis, pcb);
+    }
+
+    /// <inheritdoc cref="Interface.getTypeMDTokenMap"/>
+    public HRESULT getTypeMDTokenMap(uint cb, uint* pcb, byte* pb)
+    {
+        fixed (IDiaSession* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSession*, uint, uint*, byte*, HRESULT>)_lpVtbl[54])(pThis, cb, pcb, pb);
+    }
+
+    /// <inheritdoc cref="Interface.getNumberOfFunctionFragments_VA"/>
+    public HRESULT getNumberOfFunctionFragments_VA(ulong vaFunc, uint cbFunc, uint* pNumFragments)
+    {
+        fixed (IDiaSession* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSession*, ulong, uint, uint*, HRESULT>)_lpVtbl[55])(pThis, vaFunc, cbFunc, pNumFragments);
+    }
+
+    /// <inheritdoc cref="Interface.getNumberOfFunctionFragments_RVA"/>
+    public HRESULT getNumberOfFunctionFragments_RVA(uint rvaFunc, uint cbFunc, uint* pNumFragments)
+    {
+        fixed (IDiaSession* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSession*, uint, uint, uint*, HRESULT>)_lpVtbl[56])(pThis, rvaFunc, cbFunc, pNumFragments);
+    }
+
+    /// <inheritdoc cref="Interface.getFunctionFragments_VA"/>
+    public HRESULT getFunctionFragments_VA(ulong vaFunc, uint cbFunc, uint cFragments, ulong* pVaFragment, uint* pLenFragment)
+    {
+        fixed (IDiaSession* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSession*, ulong, uint, uint, ulong*, uint*, HRESULT>)_lpVtbl[57])(pThis, vaFunc, cbFunc, cFragments, pVaFragment, pLenFragment);
+    }
+
+    /// <inheritdoc cref="Interface.getFunctionFragments_RVA"/>
+    public HRESULT getFunctionFragments_RVA(uint rvaFunc, uint cbFunc, uint cFragments, uint* pRvaFragment, uint* pLenFragment)
+    {
+        fixed (IDiaSession* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSession*, uint, uint, uint, uint*, uint*, HRESULT>)_lpVtbl[58])(pThis, rvaFunc, cbFunc, cFragments, pRvaFragment, pLenFragment);
+    }
+
+    /// <inheritdoc cref="Interface.getExports"/>
+    public HRESULT getExports(IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSession* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSession*, IDiaEnumSymbols**, HRESULT>)_lpVtbl[59])(pThis, ppResult);
+    }
+
+    /// <inheritdoc cref="Interface.getHeapAllocationSites"/>
+    public HRESULT getHeapAllocationSites(IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSession* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSession*, IDiaEnumSymbols**, HRESULT>)_lpVtbl[60])(pThis, ppResult);
+    }
+
+    /// <inheritdoc cref="Interface.findInputAssemblyFile"/>
+    public HRESULT findInputAssemblyFile(IDiaSymbol* pSymbol, IDiaInputAssemblyFile** ppResult)
+    {
+        fixed (IDiaSession* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSession*, IDiaSymbol*, IDiaInputAssemblyFile**, HRESULT>)_lpVtbl[61])(pThis, pSymbol, ppResult);
+    }
+
+    /// <summary>
+    ///  Provides a query context for debug symbols.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/visualstudio/debugger/debug-interface-access/idiasession">
+    ///    Official documentation.
+    ///   </see>
+    ///  </para>
+    /// </remarks>
+    [ComImport]
+    [Guid("2F609EE1-D1C8-4E24-8288-3326BADCD211")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    public unsafe interface Interface
+    {
+        /// <summary>
+        ///  Dll/Exe load address.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_loadAddress(ulong* pRetVal);
+
+        /// <summary>
+        ///  Dll/Exe load address.
+        /// </summary>
+        /// <param name="NewVal">The NewVal value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT put_loadAddress(ulong NewVal);
+
+        /// <summary>
+        ///  Global scope (exe) symbol.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_globalScope(IDiaSymbol** pRetVal);
+
+        /// <summary>
+        ///  Get enum tables.
+        /// </summary>
+        /// <param name="ppEnumTables">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT getEnumTables(IDiaEnumTables** ppEnumTables);
+
+        /// <summary>
+        ///  Get symbols by addr.
+        /// </summary>
+        /// <param name="ppEnumbyAddr">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT getSymbolsByAddr(IDiaEnumSymbolsByAddr** ppEnumbyAddr);
+
+        /// <summary>
+        ///  Find children.
+        /// </summary>
+        /// <param name="parent">The parent value.</param>
+        /// <param name="symtag">The symbol tag that restricts the kinds of symbols returned, or SymTagNull to match all symbols.</param>
+        /// <param name="name">The name value.</param>
+        /// <param name="compareFlags">A combination of name-comparison flags that control how the name is matched.</param>
+        /// <param name="ppResult">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT findChildren(IDiaSymbol* parent, SymTagEnum symtag, PCWSTR name, uint compareFlags, IDiaEnumSymbols** ppResult);
+
+        /// <summary>
+        ///  Find children ex.
+        /// </summary>
+        /// <param name="parent">The parent value.</param>
+        /// <param name="symtag">The symbol tag that restricts the kinds of symbols returned, or SymTagNull to match all symbols.</param>
+        /// <param name="name">The name value.</param>
+        /// <param name="compareFlags">A combination of name-comparison flags that control how the name is matched.</param>
+        /// <param name="ppResult">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT findChildrenEx(IDiaSymbol* parent, SymTagEnum symtag, PCWSTR name, uint compareFlags, IDiaEnumSymbols** ppResult);
+
+        /// <summary>
+        ///  Find children ex by addr.
+        /// </summary>
+        /// <param name="parent">The parent value.</param>
+        /// <param name="symtag">The symbol tag that restricts the kinds of symbols returned, or SymTagNull to match all symbols.</param>
+        /// <param name="name">The name value.</param>
+        /// <param name="compareFlags">A combination of name-comparison flags that control how the name is matched.</param>
+        /// <param name="isect">The section index component of the address.</param>
+        /// <param name="offset">The offset component of the address within the section.</param>
+        /// <param name="ppResult">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT findChildrenExByAddr(IDiaSymbol* parent, SymTagEnum symtag, PCWSTR name, uint compareFlags, uint isect, uint offset, IDiaEnumSymbols** ppResult);
+
+        /// <summary>
+        ///  Find children ex by va.
+        /// </summary>
+        /// <param name="parent">The parent value.</param>
+        /// <param name="symtag">The symbol tag that restricts the kinds of symbols returned, or SymTagNull to match all symbols.</param>
+        /// <param name="name">The name value.</param>
+        /// <param name="compareFlags">A combination of name-comparison flags that control how the name is matched.</param>
+        /// <param name="va">The virtual address (VA).</param>
+        /// <param name="ppResult">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT findChildrenExByVA(IDiaSymbol* parent, SymTagEnum symtag, PCWSTR name, uint compareFlags, ulong va, IDiaEnumSymbols** ppResult);
+
+        /// <summary>
+        ///  Find children ex by rva.
+        /// </summary>
+        /// <param name="parent">The parent value.</param>
+        /// <param name="symtag">The symbol tag that restricts the kinds of symbols returned, or SymTagNull to match all symbols.</param>
+        /// <param name="name">The name value.</param>
+        /// <param name="compareFlags">A combination of name-comparison flags that control how the name is matched.</param>
+        /// <param name="rva">The relative virtual address (RVA).</param>
+        /// <param name="ppResult">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT findChildrenExByRVA(IDiaSymbol* parent, SymTagEnum symtag, PCWSTR name, uint compareFlags, uint rva, IDiaEnumSymbols** ppResult);
+
+        /// <summary>
+        ///  Find symbol by addr.
+        /// </summary>
+        /// <param name="isect">The section index component of the address.</param>
+        /// <param name="offset">The offset component of the address within the section.</param>
+        /// <param name="symtag">The symbol tag that restricts the kinds of symbols returned, or SymTagNull to match all symbols.</param>
+        /// <param name="ppSymbol">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT findSymbolByAddr(uint isect, uint offset, SymTagEnum symtag, IDiaSymbol** ppSymbol);
+
+        /// <summary>
+        ///  Find symbol by rva.
+        /// </summary>
+        /// <param name="rva">The relative virtual address (RVA).</param>
+        /// <param name="symtag">The symbol tag that restricts the kinds of symbols returned, or SymTagNull to match all symbols.</param>
+        /// <param name="ppSymbol">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT findSymbolByRVA(uint rva, SymTagEnum symtag, IDiaSymbol** ppSymbol);
+
+        /// <summary>
+        ///  Find symbol by va.
+        /// </summary>
+        /// <param name="va">The virtual address (VA).</param>
+        /// <param name="symtag">The symbol tag that restricts the kinds of symbols returned, or SymTagNull to match all symbols.</param>
+        /// <param name="ppSymbol">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT findSymbolByVA(ulong va, SymTagEnum symtag, IDiaSymbol** ppSymbol);
+
+        /// <summary>
+        ///  Find symbol by token.
+        /// </summary>
+        /// <param name="token">The token value.</param>
+        /// <param name="symtag">The symbol tag that restricts the kinds of symbols returned, or SymTagNull to match all symbols.</param>
+        /// <param name="ppSymbol">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT findSymbolByToken(uint token, SymTagEnum symtag, IDiaSymbol** ppSymbol);
+
+        /// <summary>
+        ///  Syms are equiv.
+        /// </summary>
+        /// <param name="symbolA">The symbolA value.</param>
+        /// <param name="symbolB">The symbolB value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT symsAreEquiv(IDiaSymbol* symbolA, IDiaSymbol* symbolB);
+
+        /// <summary>
+        ///  Symbol by id.
+        /// </summary>
+        /// <param name="id">The id value.</param>
+        /// <param name="ppSymbol">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT symbolById(uint id, IDiaSymbol** ppSymbol);
+
+        /// <summary>
+        ///  Find symbol by rvaex.
+        /// </summary>
+        /// <param name="rva">The relative virtual address (RVA).</param>
+        /// <param name="symtag">The symbol tag that restricts the kinds of symbols returned, or SymTagNull to match all symbols.</param>
+        /// <param name="ppSymbol">Pointer to a variable that receives the requested object.</param>
+        /// <param name="displacement">Pointer to a variable that receives the requested value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT findSymbolByRVAEx(uint rva, SymTagEnum symtag, IDiaSymbol** ppSymbol, int* displacement);
+
+        /// <summary>
+        ///  Find symbol by vaex.
+        /// </summary>
+        /// <param name="va">The virtual address (VA).</param>
+        /// <param name="symtag">The symbol tag that restricts the kinds of symbols returned, or SymTagNull to match all symbols.</param>
+        /// <param name="ppSymbol">Pointer to a variable that receives the requested object.</param>
+        /// <param name="displacement">Pointer to a variable that receives the requested value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT findSymbolByVAEx(ulong va, SymTagEnum symtag, IDiaSymbol** ppSymbol, int* displacement);
+
+        /// <summary>
+        ///  Find file.
+        /// </summary>
+        /// <param name="pCompiland">The pCompiland value.</param>
+        /// <param name="name">The name value.</param>
+        /// <param name="compareFlags">A combination of name-comparison flags that control how the name is matched.</param>
+        /// <param name="ppResult">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT findFile(IDiaSymbol* pCompiland, PCWSTR name, uint compareFlags, IDiaEnumSourceFiles** ppResult);
+
+        /// <summary>
+        ///  Find file by id.
+        /// </summary>
+        /// <param name="uniqueId">The uniqueId value.</param>
+        /// <param name="ppResult">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT findFileById(uint uniqueId, IDiaSourceFile** ppResult);
+
+        /// <summary>
+        ///  Find lines.
+        /// </summary>
+        /// <param name="compiland">The compiland value.</param>
+        /// <param name="file">The file value.</param>
+        /// <param name="ppResult">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT findLines(IDiaSymbol* compiland, IDiaSourceFile* file, IDiaEnumLineNumbers** ppResult);
+
+        /// <summary>
+        ///  Find lines by addr.
+        /// </summary>
+        /// <param name="seg">The seg value.</param>
+        /// <param name="offset">The offset component of the address within the section.</param>
+        /// <param name="length">The number of bytes in the address range.</param>
+        /// <param name="ppResult">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT findLinesByAddr(uint seg, uint offset, uint length, IDiaEnumLineNumbers** ppResult);
+
+        /// <summary>
+        ///  Find lines by rva.
+        /// </summary>
+        /// <param name="rva">The relative virtual address (RVA).</param>
+        /// <param name="length">The number of bytes in the address range.</param>
+        /// <param name="ppResult">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT findLinesByRVA(uint rva, uint length, IDiaEnumLineNumbers** ppResult);
+
+        /// <summary>
+        ///  Find lines by va.
+        /// </summary>
+        /// <param name="va">The virtual address (VA).</param>
+        /// <param name="length">The number of bytes in the address range.</param>
+        /// <param name="ppResult">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT findLinesByVA(ulong va, uint length, IDiaEnumLineNumbers** ppResult);
+
+        /// <summary>
+        ///  Find lines by linenum.
+        /// </summary>
+        /// <param name="compiland">The compiland value.</param>
+        /// <param name="file">The file value.</param>
+        /// <param name="linenum">The linenum value.</param>
+        /// <param name="column">The column value.</param>
+        /// <param name="ppResult">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT findLinesByLinenum(IDiaSymbol* compiland, IDiaSourceFile* file, uint linenum, uint column, IDiaEnumLineNumbers** ppResult);
+
+        /// <summary>
+        ///  Find injected source.
+        /// </summary>
+        /// <param name="srcFile">The srcFile value.</param>
+        /// <param name="ppResult">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT findInjectedSource(PCWSTR srcFile, IDiaEnumInjectedSources** ppResult);
+
+        /// <summary>
+        ///  Get enum debug streams.
+        /// </summary>
+        /// <param name="ppEnumDebugStreams">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT getEnumDebugStreams(IDiaEnumDebugStreams** ppEnumDebugStreams);
+
+        /// <summary>
+        ///  Find inline frames by addr.
+        /// </summary>
+        /// <param name="parent">The parent value.</param>
+        /// <param name="isect">The section index component of the address.</param>
+        /// <param name="offset">The offset component of the address within the section.</param>
+        /// <param name="ppResult">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT findInlineFramesByAddr(IDiaSymbol* parent, uint isect, uint offset, IDiaEnumSymbols** ppResult);
+
+        /// <summary>
+        ///  Find inline frames by rva.
+        /// </summary>
+        /// <param name="parent">The parent value.</param>
+        /// <param name="rva">The relative virtual address (RVA).</param>
+        /// <param name="ppResult">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT findInlineFramesByRVA(IDiaSymbol* parent, uint rva, IDiaEnumSymbols** ppResult);
+
+        /// <summary>
+        ///  Find inline frames by va.
+        /// </summary>
+        /// <param name="parent">The parent value.</param>
+        /// <param name="va">The virtual address (VA).</param>
+        /// <param name="ppResult">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT findInlineFramesByVA(IDiaSymbol* parent, ulong va, IDiaEnumSymbols** ppResult);
+
+        /// <summary>
+        ///  Find inlinee lines.
+        /// </summary>
+        /// <param name="parent">The parent value.</param>
+        /// <param name="ppResult">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT findInlineeLines(IDiaSymbol* parent, IDiaEnumLineNumbers** ppResult);
+
+        /// <summary>
+        ///  Find inlinee lines by addr.
+        /// </summary>
+        /// <param name="parent">The parent value.</param>
+        /// <param name="isect">The section index component of the address.</param>
+        /// <param name="offset">The offset component of the address within the section.</param>
+        /// <param name="length">The number of bytes in the address range.</param>
+        /// <param name="ppResult">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT findInlineeLinesByAddr(IDiaSymbol* parent, uint isect, uint offset, uint length, IDiaEnumLineNumbers** ppResult);
+
+        /// <summary>
+        ///  Find inlinee lines by rva.
+        /// </summary>
+        /// <param name="parent">The parent value.</param>
+        /// <param name="rva">The relative virtual address (RVA).</param>
+        /// <param name="length">The number of bytes in the address range.</param>
+        /// <param name="ppResult">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT findInlineeLinesByRVA(IDiaSymbol* parent, uint rva, uint length, IDiaEnumLineNumbers** ppResult);
+
+        /// <summary>
+        ///  Find inlinee lines by va.
+        /// </summary>
+        /// <param name="parent">The parent value.</param>
+        /// <param name="va">The virtual address (VA).</param>
+        /// <param name="length">The number of bytes in the address range.</param>
+        /// <param name="ppResult">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT findInlineeLinesByVA(IDiaSymbol* parent, ulong va, uint length, IDiaEnumLineNumbers** ppResult);
+
+        /// <summary>
+        ///  Find inlinee lines by linenum.
+        /// </summary>
+        /// <param name="compiland">The compiland value.</param>
+        /// <param name="file">The file value.</param>
+        /// <param name="linenum">The linenum value.</param>
+        /// <param name="column">The column value.</param>
+        /// <param name="ppResult">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT findInlineeLinesByLinenum(IDiaSymbol* compiland, IDiaSourceFile* file, uint linenum, uint column, IDiaEnumLineNumbers** ppResult);
+
+        /// <summary>
+        ///  Find inlinees by name.
+        /// </summary>
+        /// <param name="name">The name value.</param>
+        /// <param name="option">The option value.</param>
+        /// <param name="ppResult">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT findInlineesByName(PCWSTR name, uint option, IDiaEnumSymbols** ppResult);
+
+        /// <summary>
+        ///  Find accelerator inlinee lines by linenum.
+        /// </summary>
+        /// <param name="parent">The parent value.</param>
+        /// <param name="file">The file value.</param>
+        /// <param name="linenum">The linenum value.</param>
+        /// <param name="column">The column value.</param>
+        /// <param name="ppResult">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT findAcceleratorInlineeLinesByLinenum(IDiaSymbol* parent, IDiaSourceFile* file, uint linenum, uint column, IDiaEnumLineNumbers** ppResult);
+
+        /// <summary>
+        ///  Find symbols for accelerator pointer tag.
+        /// </summary>
+        /// <param name="parent">The parent value.</param>
+        /// <param name="tagValue">The tagValue value.</param>
+        /// <param name="ppResult">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT findSymbolsForAcceleratorPointerTag(IDiaSymbol* parent, uint tagValue, IDiaEnumSymbols** ppResult);
+
+        /// <summary>
+        ///  Find symbols by rvafor accelerator pointer tag.
+        /// </summary>
+        /// <param name="parent">The parent value.</param>
+        /// <param name="tagValue">The tagValue value.</param>
+        /// <param name="rva">The relative virtual address (RVA).</param>
+        /// <param name="ppResult">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT findSymbolsByRVAForAcceleratorPointerTag(IDiaSymbol* parent, uint tagValue, uint rva, IDiaEnumSymbols** ppResult);
+
+        /// <summary>
+        ///  Find accelerator inlinees by name.
+        /// </summary>
+        /// <param name="name">The name value.</param>
+        /// <param name="option">The option value.</param>
+        /// <param name="ppResult">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT findAcceleratorInlineesByName(PCWSTR name, uint option, IDiaEnumSymbols** ppResult);
+
+        /// <summary>
+        ///  Address for va.
+        /// </summary>
+        /// <param name="va">The virtual address (VA).</param>
+        /// <param name="pISect">Pointer to a variable that receives the requested value.</param>
+        /// <param name="pOffset">Pointer to a variable that receives the requested value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT addressForVA(ulong va, uint* pISect, uint* pOffset);
+
+        /// <summary>
+        ///  Address for rva.
+        /// </summary>
+        /// <param name="rva">The relative virtual address (RVA).</param>
+        /// <param name="pISect">Pointer to a variable that receives the requested value.</param>
+        /// <param name="pOffset">Pointer to a variable that receives the requested value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT addressForRVA(uint rva, uint* pISect, uint* pOffset);
+
+        /// <summary>
+        ///  Find iloffsets by addr.
+        /// </summary>
+        /// <param name="isect">The section index component of the address.</param>
+        /// <param name="offset">The offset component of the address within the section.</param>
+        /// <param name="length">The number of bytes in the address range.</param>
+        /// <param name="ppResult">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT findILOffsetsByAddr(uint isect, uint offset, uint length, IDiaEnumLineNumbers** ppResult);
+
+        /// <summary>
+        ///  Find iloffsets by rva.
+        /// </summary>
+        /// <param name="rva">The relative virtual address (RVA).</param>
+        /// <param name="length">The number of bytes in the address range.</param>
+        /// <param name="ppResult">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT findILOffsetsByRVA(uint rva, uint length, IDiaEnumLineNumbers** ppResult);
+
+        /// <summary>
+        ///  Find iloffsets by va.
+        /// </summary>
+        /// <param name="va">The virtual address (VA).</param>
+        /// <param name="length">The number of bytes in the address range.</param>
+        /// <param name="ppResult">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT findILOffsetsByVA(ulong va, uint length, IDiaEnumLineNumbers** ppResult);
+
+        /// <summary>
+        ///  Find input assembly files.
+        /// </summary>
+        /// <param name="ppResult">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT findInputAssemblyFiles(IDiaEnumInputAssemblyFiles** ppResult);
+
+        /// <summary>
+        ///  Find input assembly.
+        /// </summary>
+        /// <param name="index">The zero-based index of the item to retrieve.</param>
+        /// <param name="ppResult">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT findInputAssembly(uint index, IDiaInputAssemblyFile** ppResult);
+
+        /// <summary>
+        ///  Find input assembly by id.
+        /// </summary>
+        /// <param name="uniqueId">The uniqueId value.</param>
+        /// <param name="ppResult">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT findInputAssemblyById(uint uniqueId, IDiaInputAssemblyFile** ppResult);
+
+        /// <summary>
+        ///  Get func mdtoken map size.
+        /// </summary>
+        /// <param name="pcb">Pointer to a variable that receives the number of bytes written to the buffer.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT getFuncMDTokenMapSize(uint* pcb);
+
+        /// <summary>
+        ///  Get func mdtoken map.
+        /// </summary>
+        /// <param name="cb">The size, in bytes, of the buffer.</param>
+        /// <param name="pcb">Pointer to a variable that receives the number of bytes written to the buffer.</param>
+        /// <param name="pb">Pointer to a caller-allocated buffer that receives the data.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT getFuncMDTokenMap(uint cb, uint* pcb, byte* pb);
+
+        /// <summary>
+        ///  Get type mdtoken map size.
+        /// </summary>
+        /// <param name="pcb">Pointer to a variable that receives the number of bytes written to the buffer.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT getTypeMDTokenMapSize(uint* pcb);
+
+        /// <summary>
+        ///  Get type mdtoken map.
+        /// </summary>
+        /// <param name="cb">The size, in bytes, of the buffer.</param>
+        /// <param name="pcb">Pointer to a variable that receives the number of bytes written to the buffer.</param>
+        /// <param name="pb">Pointer to a caller-allocated buffer that receives the data.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT getTypeMDTokenMap(uint cb, uint* pcb, byte* pb);
+
+        /// <summary>
+        ///  Get number of function fragments va.
+        /// </summary>
+        /// <param name="vaFunc">The vaFunc value.</param>
+        /// <param name="cbFunc">The size, in bytes, of the buffer.</param>
+        /// <param name="pNumFragments">Pointer to a variable that receives the requested value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT getNumberOfFunctionFragments_VA(ulong vaFunc, uint cbFunc, uint* pNumFragments);
+
+        /// <summary>
+        ///  Get number of function fragments rva.
+        /// </summary>
+        /// <param name="rvaFunc">The rvaFunc value.</param>
+        /// <param name="cbFunc">The size, in bytes, of the buffer.</param>
+        /// <param name="pNumFragments">Pointer to a variable that receives the requested value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT getNumberOfFunctionFragments_RVA(uint rvaFunc, uint cbFunc, uint* pNumFragments);
+
+        /// <summary>
+        ///  Get function fragments va.
+        /// </summary>
+        /// <param name="vaFunc">The vaFunc value.</param>
+        /// <param name="cbFunc">The size, in bytes, of the buffer.</param>
+        /// <param name="cFragments">The cFragments value.</param>
+        /// <param name="pVaFragment">Pointer to a caller-allocated buffer that receives the data.</param>
+        /// <param name="pLenFragment">Pointer to a caller-allocated buffer that receives the data.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT getFunctionFragments_VA(ulong vaFunc, uint cbFunc, uint cFragments, ulong* pVaFragment, uint* pLenFragment);
+
+        /// <summary>
+        ///  Get function fragments rva.
+        /// </summary>
+        /// <param name="rvaFunc">The rvaFunc value.</param>
+        /// <param name="cbFunc">The size, in bytes, of the buffer.</param>
+        /// <param name="cFragments">The cFragments value.</param>
+        /// <param name="pRvaFragment">Pointer to a caller-allocated buffer that receives the data.</param>
+        /// <param name="pLenFragment">Pointer to a caller-allocated buffer that receives the data.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT getFunctionFragments_RVA(uint rvaFunc, uint cbFunc, uint cFragments, uint* pRvaFragment, uint* pLenFragment);
+
+        /// <summary>
+        ///  Get exports.
+        /// </summary>
+        /// <param name="ppResult">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT getExports(IDiaEnumSymbols** ppResult);
+
+        /// <summary>
+        ///  Get heap allocation sites.
+        /// </summary>
+        /// <param name="ppResult">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT getHeapAllocationSites(IDiaEnumSymbols** ppResult);
+
+        /// <summary>
+        ///  Find input assembly file.
+        /// </summary>
+        /// <param name="pSymbol">The pSymbol value.</param>
+        /// <param name="ppResult">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT findInputAssemblyFile(IDiaSymbol* pSymbol, IDiaInputAssemblyFile** ppResult);
+    }
+}

--- a/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaSessionEx.cs
+++ b/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaSessionEx.cs
@@ -1,0 +1,539 @@
+﻿// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Runtime.InteropServices;
+
+// For some reason the XML comment refs for IUnknown can't be resolved on .NET Framework without
+// explicitly using the fully qualified name, which falls afoul of the simplify warning.
+using ComIUnknown = Windows.Win32.System.Com.IUnknown;
+
+namespace Microsoft.VisualStudio.Debugging.DebugInterfaceAccess;
+
+/// <inheritdoc cref="Interface"/>
+public unsafe struct IDiaSessionEx : IComIID
+{
+    /// <inheritdoc cref="IComIID.Guid"/>
+#pragma warning disable IDE1006 // Naming Styles
+    public static readonly Guid IID_Guid = new(0xCD24EED5, 0x5FEA, 0x4742, 0xA3, 0x20, 0x62, 0x54, 0xC9, 0x20, 0xE7, 0x8B);
+#pragma warning restore IDE1006
+
+#if NETFRAMEWORK
+    readonly ref readonly Guid IComIID.Guid => ref IID_Guid;
+#else
+    static ref readonly Guid IComIID.Guid
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get
+        {
+            ReadOnlySpan<byte> data =
+            [
+                0xD5, 0xEE, 0x24, 0xCD,
+                0xEA, 0x5F,
+                0x42, 0x47,
+                0xA3, 0x20, 0x62, 0x54, 0xC9, 0x20, 0xE7, 0x8B
+            ];
+
+            return ref Unsafe.As<byte, Guid>(ref MemoryMarshal.GetReference(data));
+        }
+    }
+#endif
+
+    private readonly void** _lpVtbl;
+
+    /// <inheritdoc cref="ComIUnknown.QueryInterface(Guid*, void**)"/>
+    public HRESULT QueryInterface(Guid* riid, void** ppvObject)
+    {
+        fixed (IDiaSessionEx* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSessionEx*, Guid*, void**, HRESULT>)_lpVtbl[0])(pThis, riid, ppvObject);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.AddRef"/>
+    public uint AddRef()
+    {
+        fixed (IDiaSessionEx* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSessionEx*, uint>)_lpVtbl[1])(pThis);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.Release"/>
+    public uint Release()
+    {
+        fixed (IDiaSessionEx* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSessionEx*, uint>)_lpVtbl[2])(pThis);
+    }
+
+    /// <inheritdoc cref="IDiaSession.Interface.get_loadAddress"/>
+    public HRESULT get_loadAddress(ulong* pRetVal)
+    {
+        fixed (IDiaSessionEx* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSessionEx*, ulong*, HRESULT>)_lpVtbl[3])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSession.Interface.put_loadAddress"/>
+    public HRESULT put_loadAddress(ulong NewVal)
+    {
+        fixed (IDiaSessionEx* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSessionEx*, ulong, HRESULT>)_lpVtbl[4])(pThis, NewVal);
+    }
+
+    /// <inheritdoc cref="IDiaSession.Interface.get_globalScope"/>
+    public HRESULT get_globalScope(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSessionEx* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSessionEx*, IDiaSymbol**, HRESULT>)_lpVtbl[5])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSession.Interface.getEnumTables"/>
+    public HRESULT getEnumTables(IDiaEnumTables** ppEnumTables)
+    {
+        fixed (IDiaSessionEx* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSessionEx*, IDiaEnumTables**, HRESULT>)_lpVtbl[6])(pThis, ppEnumTables);
+    }
+
+    /// <inheritdoc cref="IDiaSession.Interface.getSymbolsByAddr"/>
+    public HRESULT getSymbolsByAddr(IDiaEnumSymbolsByAddr** ppEnumbyAddr)
+    {
+        fixed (IDiaSessionEx* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSessionEx*, IDiaEnumSymbolsByAddr**, HRESULT>)_lpVtbl[7])(pThis, ppEnumbyAddr);
+    }
+
+    /// <inheritdoc cref="IDiaSession.Interface.findChildren"/>
+    public HRESULT findChildren(IDiaSymbol* parent, SymTagEnum symtag, PCWSTR name, uint compareFlags, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSessionEx* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSessionEx*, IDiaSymbol*, SymTagEnum, PCWSTR, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[8])(pThis, parent, symtag, name, compareFlags, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSession.Interface.findChildrenEx"/>
+    public HRESULT findChildrenEx(IDiaSymbol* parent, SymTagEnum symtag, PCWSTR name, uint compareFlags, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSessionEx* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSessionEx*, IDiaSymbol*, SymTagEnum, PCWSTR, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[9])(pThis, parent, symtag, name, compareFlags, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSession.Interface.findChildrenExByAddr"/>
+    public HRESULT findChildrenExByAddr(IDiaSymbol* parent, SymTagEnum symtag, PCWSTR name, uint compareFlags, uint isect, uint offset, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSessionEx* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSessionEx*, IDiaSymbol*, SymTagEnum, PCWSTR, uint, uint, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[10])(pThis, parent, symtag, name, compareFlags, isect, offset, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSession.Interface.findChildrenExByVA"/>
+    public HRESULT findChildrenExByVA(IDiaSymbol* parent, SymTagEnum symtag, PCWSTR name, uint compareFlags, ulong va, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSessionEx* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSessionEx*, IDiaSymbol*, SymTagEnum, PCWSTR, uint, ulong, IDiaEnumSymbols**, HRESULT>)_lpVtbl[11])(pThis, parent, symtag, name, compareFlags, va, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSession.Interface.findChildrenExByRVA"/>
+    public HRESULT findChildrenExByRVA(IDiaSymbol* parent, SymTagEnum symtag, PCWSTR name, uint compareFlags, uint rva, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSessionEx* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSessionEx*, IDiaSymbol*, SymTagEnum, PCWSTR, uint, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[12])(pThis, parent, symtag, name, compareFlags, rva, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSession.Interface.findSymbolByAddr"/>
+    public HRESULT findSymbolByAddr(uint isect, uint offset, SymTagEnum symtag, IDiaSymbol** ppSymbol)
+    {
+        fixed (IDiaSessionEx* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSessionEx*, uint, uint, SymTagEnum, IDiaSymbol**, HRESULT>)_lpVtbl[13])(pThis, isect, offset, symtag, ppSymbol);
+    }
+
+    /// <inheritdoc cref="IDiaSession.Interface.findSymbolByRVA"/>
+    public HRESULT findSymbolByRVA(uint rva, SymTagEnum symtag, IDiaSymbol** ppSymbol)
+    {
+        fixed (IDiaSessionEx* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSessionEx*, uint, SymTagEnum, IDiaSymbol**, HRESULT>)_lpVtbl[14])(pThis, rva, symtag, ppSymbol);
+    }
+
+    /// <inheritdoc cref="IDiaSession.Interface.findSymbolByVA"/>
+    public HRESULT findSymbolByVA(ulong va, SymTagEnum symtag, IDiaSymbol** ppSymbol)
+    {
+        fixed (IDiaSessionEx* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSessionEx*, ulong, SymTagEnum, IDiaSymbol**, HRESULT>)_lpVtbl[15])(pThis, va, symtag, ppSymbol);
+    }
+
+    /// <inheritdoc cref="IDiaSession.Interface.findSymbolByToken"/>
+    public HRESULT findSymbolByToken(uint token, SymTagEnum symtag, IDiaSymbol** ppSymbol)
+    {
+        fixed (IDiaSessionEx* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSessionEx*, uint, SymTagEnum, IDiaSymbol**, HRESULT>)_lpVtbl[16])(pThis, token, symtag, ppSymbol);
+    }
+
+    /// <inheritdoc cref="IDiaSession.Interface.symsAreEquiv"/>
+    public HRESULT symsAreEquiv(IDiaSymbol* symbolA, IDiaSymbol* symbolB)
+    {
+        fixed (IDiaSessionEx* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSessionEx*, IDiaSymbol*, IDiaSymbol*, HRESULT>)_lpVtbl[17])(pThis, symbolA, symbolB);
+    }
+
+    /// <inheritdoc cref="IDiaSession.Interface.symbolById"/>
+    public HRESULT symbolById(uint id, IDiaSymbol** ppSymbol)
+    {
+        fixed (IDiaSessionEx* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSessionEx*, uint, IDiaSymbol**, HRESULT>)_lpVtbl[18])(pThis, id, ppSymbol);
+    }
+
+    /// <inheritdoc cref="IDiaSession.Interface.findSymbolByRVAEx"/>
+    public HRESULT findSymbolByRVAEx(uint rva, SymTagEnum symtag, IDiaSymbol** ppSymbol, int* displacement)
+    {
+        fixed (IDiaSessionEx* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSessionEx*, uint, SymTagEnum, IDiaSymbol**, int*, HRESULT>)_lpVtbl[19])(pThis, rva, symtag, ppSymbol, displacement);
+    }
+
+    /// <inheritdoc cref="IDiaSession.Interface.findSymbolByVAEx"/>
+    public HRESULT findSymbolByVAEx(ulong va, SymTagEnum symtag, IDiaSymbol** ppSymbol, int* displacement)
+    {
+        fixed (IDiaSessionEx* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSessionEx*, ulong, SymTagEnum, IDiaSymbol**, int*, HRESULT>)_lpVtbl[20])(pThis, va, symtag, ppSymbol, displacement);
+    }
+
+    /// <inheritdoc cref="IDiaSession.Interface.findFile"/>
+    public HRESULT findFile(IDiaSymbol* pCompiland, PCWSTR name, uint compareFlags, IDiaEnumSourceFiles** ppResult)
+    {
+        fixed (IDiaSessionEx* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSessionEx*, IDiaSymbol*, PCWSTR, uint, IDiaEnumSourceFiles**, HRESULT>)_lpVtbl[21])(pThis, pCompiland, name, compareFlags, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSession.Interface.findFileById"/>
+    public HRESULT findFileById(uint uniqueId, IDiaSourceFile** ppResult)
+    {
+        fixed (IDiaSessionEx* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSessionEx*, uint, IDiaSourceFile**, HRESULT>)_lpVtbl[22])(pThis, uniqueId, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSession.Interface.findLines"/>
+    public HRESULT findLines(IDiaSymbol* compiland, IDiaSourceFile* file, IDiaEnumLineNumbers** ppResult)
+    {
+        fixed (IDiaSessionEx* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSessionEx*, IDiaSymbol*, IDiaSourceFile*, IDiaEnumLineNumbers**, HRESULT>)_lpVtbl[23])(pThis, compiland, file, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSession.Interface.findLinesByAddr"/>
+    public HRESULT findLinesByAddr(uint seg, uint offset, uint length, IDiaEnumLineNumbers** ppResult)
+    {
+        fixed (IDiaSessionEx* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSessionEx*, uint, uint, uint, IDiaEnumLineNumbers**, HRESULT>)_lpVtbl[24])(pThis, seg, offset, length, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSession.Interface.findLinesByRVA"/>
+    public HRESULT findLinesByRVA(uint rva, uint length, IDiaEnumLineNumbers** ppResult)
+    {
+        fixed (IDiaSessionEx* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSessionEx*, uint, uint, IDiaEnumLineNumbers**, HRESULT>)_lpVtbl[25])(pThis, rva, length, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSession.Interface.findLinesByVA"/>
+    public HRESULT findLinesByVA(ulong va, uint length, IDiaEnumLineNumbers** ppResult)
+    {
+        fixed (IDiaSessionEx* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSessionEx*, ulong, uint, IDiaEnumLineNumbers**, HRESULT>)_lpVtbl[26])(pThis, va, length, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSession.Interface.findLinesByLinenum"/>
+    public HRESULT findLinesByLinenum(IDiaSymbol* compiland, IDiaSourceFile* file, uint linenum, uint column, IDiaEnumLineNumbers** ppResult)
+    {
+        fixed (IDiaSessionEx* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSessionEx*, IDiaSymbol*, IDiaSourceFile*, uint, uint, IDiaEnumLineNumbers**, HRESULT>)_lpVtbl[27])(pThis, compiland, file, linenum, column, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSession.Interface.findInjectedSource"/>
+    public HRESULT findInjectedSource(PCWSTR srcFile, IDiaEnumInjectedSources** ppResult)
+    {
+        fixed (IDiaSessionEx* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSessionEx*, PCWSTR, IDiaEnumInjectedSources**, HRESULT>)_lpVtbl[28])(pThis, srcFile, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSession.Interface.getEnumDebugStreams"/>
+    public HRESULT getEnumDebugStreams(IDiaEnumDebugStreams** ppEnumDebugStreams)
+    {
+        fixed (IDiaSessionEx* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSessionEx*, IDiaEnumDebugStreams**, HRESULT>)_lpVtbl[29])(pThis, ppEnumDebugStreams);
+    }
+
+    /// <inheritdoc cref="IDiaSession.Interface.findInlineFramesByAddr"/>
+    public HRESULT findInlineFramesByAddr(IDiaSymbol* parent, uint isect, uint offset, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSessionEx* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSessionEx*, IDiaSymbol*, uint, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[30])(pThis, parent, isect, offset, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSession.Interface.findInlineFramesByRVA"/>
+    public HRESULT findInlineFramesByRVA(IDiaSymbol* parent, uint rva, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSessionEx* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSessionEx*, IDiaSymbol*, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[31])(pThis, parent, rva, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSession.Interface.findInlineFramesByVA"/>
+    public HRESULT findInlineFramesByVA(IDiaSymbol* parent, ulong va, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSessionEx* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSessionEx*, IDiaSymbol*, ulong, IDiaEnumSymbols**, HRESULT>)_lpVtbl[32])(pThis, parent, va, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSession.Interface.findInlineeLines"/>
+    public HRESULT findInlineeLines(IDiaSymbol* parent, IDiaEnumLineNumbers** ppResult)
+    {
+        fixed (IDiaSessionEx* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSessionEx*, IDiaSymbol*, IDiaEnumLineNumbers**, HRESULT>)_lpVtbl[33])(pThis, parent, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSession.Interface.findInlineeLinesByAddr"/>
+    public HRESULT findInlineeLinesByAddr(IDiaSymbol* parent, uint isect, uint offset, uint length, IDiaEnumLineNumbers** ppResult)
+    {
+        fixed (IDiaSessionEx* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSessionEx*, IDiaSymbol*, uint, uint, uint, IDiaEnumLineNumbers**, HRESULT>)_lpVtbl[34])(pThis, parent, isect, offset, length, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSession.Interface.findInlineeLinesByRVA"/>
+    public HRESULT findInlineeLinesByRVA(IDiaSymbol* parent, uint rva, uint length, IDiaEnumLineNumbers** ppResult)
+    {
+        fixed (IDiaSessionEx* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSessionEx*, IDiaSymbol*, uint, uint, IDiaEnumLineNumbers**, HRESULT>)_lpVtbl[35])(pThis, parent, rva, length, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSession.Interface.findInlineeLinesByVA"/>
+    public HRESULT findInlineeLinesByVA(IDiaSymbol* parent, ulong va, uint length, IDiaEnumLineNumbers** ppResult)
+    {
+        fixed (IDiaSessionEx* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSessionEx*, IDiaSymbol*, ulong, uint, IDiaEnumLineNumbers**, HRESULT>)_lpVtbl[36])(pThis, parent, va, length, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSession.Interface.findInlineeLinesByLinenum"/>
+    public HRESULT findInlineeLinesByLinenum(IDiaSymbol* compiland, IDiaSourceFile* file, uint linenum, uint column, IDiaEnumLineNumbers** ppResult)
+    {
+        fixed (IDiaSessionEx* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSessionEx*, IDiaSymbol*, IDiaSourceFile*, uint, uint, IDiaEnumLineNumbers**, HRESULT>)_lpVtbl[37])(pThis, compiland, file, linenum, column, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSession.Interface.findInlineesByName"/>
+    public HRESULT findInlineesByName(PCWSTR name, uint option, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSessionEx* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSessionEx*, PCWSTR, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[38])(pThis, name, option, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSession.Interface.findAcceleratorInlineeLinesByLinenum"/>
+    public HRESULT findAcceleratorInlineeLinesByLinenum(IDiaSymbol* parent, IDiaSourceFile* file, uint linenum, uint column, IDiaEnumLineNumbers** ppResult)
+    {
+        fixed (IDiaSessionEx* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSessionEx*, IDiaSymbol*, IDiaSourceFile*, uint, uint, IDiaEnumLineNumbers**, HRESULT>)_lpVtbl[39])(pThis, parent, file, linenum, column, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSession.Interface.findSymbolsForAcceleratorPointerTag"/>
+    public HRESULT findSymbolsForAcceleratorPointerTag(IDiaSymbol* parent, uint tagValue, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSessionEx* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSessionEx*, IDiaSymbol*, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[40])(pThis, parent, tagValue, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSession.Interface.findSymbolsByRVAForAcceleratorPointerTag"/>
+    public HRESULT findSymbolsByRVAForAcceleratorPointerTag(IDiaSymbol* parent, uint tagValue, uint rva, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSessionEx* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSessionEx*, IDiaSymbol*, uint, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[41])(pThis, parent, tagValue, rva, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSession.Interface.findAcceleratorInlineesByName"/>
+    public HRESULT findAcceleratorInlineesByName(PCWSTR name, uint option, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSessionEx* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSessionEx*, PCWSTR, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[42])(pThis, name, option, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSession.Interface.addressForVA"/>
+    public HRESULT addressForVA(ulong va, uint* pISect, uint* pOffset)
+    {
+        fixed (IDiaSessionEx* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSessionEx*, ulong, uint*, uint*, HRESULT>)_lpVtbl[43])(pThis, va, pISect, pOffset);
+    }
+
+    /// <inheritdoc cref="IDiaSession.Interface.addressForRVA"/>
+    public HRESULT addressForRVA(uint rva, uint* pISect, uint* pOffset)
+    {
+        fixed (IDiaSessionEx* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSessionEx*, uint, uint*, uint*, HRESULT>)_lpVtbl[44])(pThis, rva, pISect, pOffset);
+    }
+
+    /// <inheritdoc cref="IDiaSession.Interface.findILOffsetsByAddr"/>
+    public HRESULT findILOffsetsByAddr(uint isect, uint offset, uint length, IDiaEnumLineNumbers** ppResult)
+    {
+        fixed (IDiaSessionEx* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSessionEx*, uint, uint, uint, IDiaEnumLineNumbers**, HRESULT>)_lpVtbl[45])(pThis, isect, offset, length, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSession.Interface.findILOffsetsByRVA"/>
+    public HRESULT findILOffsetsByRVA(uint rva, uint length, IDiaEnumLineNumbers** ppResult)
+    {
+        fixed (IDiaSessionEx* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSessionEx*, uint, uint, IDiaEnumLineNumbers**, HRESULT>)_lpVtbl[46])(pThis, rva, length, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSession.Interface.findILOffsetsByVA"/>
+    public HRESULT findILOffsetsByVA(ulong va, uint length, IDiaEnumLineNumbers** ppResult)
+    {
+        fixed (IDiaSessionEx* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSessionEx*, ulong, uint, IDiaEnumLineNumbers**, HRESULT>)_lpVtbl[47])(pThis, va, length, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSession.Interface.findInputAssemblyFiles"/>
+    public HRESULT findInputAssemblyFiles(IDiaEnumInputAssemblyFiles** ppResult)
+    {
+        fixed (IDiaSessionEx* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSessionEx*, IDiaEnumInputAssemblyFiles**, HRESULT>)_lpVtbl[48])(pThis, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSession.Interface.findInputAssembly"/>
+    public HRESULT findInputAssembly(uint index, IDiaInputAssemblyFile** ppResult)
+    {
+        fixed (IDiaSessionEx* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSessionEx*, uint, IDiaInputAssemblyFile**, HRESULT>)_lpVtbl[49])(pThis, index, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSession.Interface.findInputAssemblyById"/>
+    public HRESULT findInputAssemblyById(uint uniqueId, IDiaInputAssemblyFile** ppResult)
+    {
+        fixed (IDiaSessionEx* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSessionEx*, uint, IDiaInputAssemblyFile**, HRESULT>)_lpVtbl[50])(pThis, uniqueId, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSession.Interface.getFuncMDTokenMapSize"/>
+    public HRESULT getFuncMDTokenMapSize(uint* pcb)
+    {
+        fixed (IDiaSessionEx* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSessionEx*, uint*, HRESULT>)_lpVtbl[51])(pThis, pcb);
+    }
+
+    /// <inheritdoc cref="IDiaSession.Interface.getFuncMDTokenMap"/>
+    public HRESULT getFuncMDTokenMap(uint cb, uint* pcb, byte* pb)
+    {
+        fixed (IDiaSessionEx* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSessionEx*, uint, uint*, byte*, HRESULT>)_lpVtbl[52])(pThis, cb, pcb, pb);
+    }
+
+    /// <inheritdoc cref="IDiaSession.Interface.getTypeMDTokenMapSize"/>
+    public HRESULT getTypeMDTokenMapSize(uint* pcb)
+    {
+        fixed (IDiaSessionEx* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSessionEx*, uint*, HRESULT>)_lpVtbl[53])(pThis, pcb);
+    }
+
+    /// <inheritdoc cref="IDiaSession.Interface.getTypeMDTokenMap"/>
+    public HRESULT getTypeMDTokenMap(uint cb, uint* pcb, byte* pb)
+    {
+        fixed (IDiaSessionEx* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSessionEx*, uint, uint*, byte*, HRESULT>)_lpVtbl[54])(pThis, cb, pcb, pb);
+    }
+
+    /// <inheritdoc cref="IDiaSession.Interface.getNumberOfFunctionFragments_VA"/>
+    public HRESULT getNumberOfFunctionFragments_VA(ulong vaFunc, uint cbFunc, uint* pNumFragments)
+    {
+        fixed (IDiaSessionEx* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSessionEx*, ulong, uint, uint*, HRESULT>)_lpVtbl[55])(pThis, vaFunc, cbFunc, pNumFragments);
+    }
+
+    /// <inheritdoc cref="IDiaSession.Interface.getNumberOfFunctionFragments_RVA"/>
+    public HRESULT getNumberOfFunctionFragments_RVA(uint rvaFunc, uint cbFunc, uint* pNumFragments)
+    {
+        fixed (IDiaSessionEx* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSessionEx*, uint, uint, uint*, HRESULT>)_lpVtbl[56])(pThis, rvaFunc, cbFunc, pNumFragments);
+    }
+
+    /// <inheritdoc cref="IDiaSession.Interface.getFunctionFragments_VA"/>
+    public HRESULT getFunctionFragments_VA(ulong vaFunc, uint cbFunc, uint cFragments, ulong* pVaFragment, uint* pLenFragment)
+    {
+        fixed (IDiaSessionEx* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSessionEx*, ulong, uint, uint, ulong*, uint*, HRESULT>)_lpVtbl[57])(pThis, vaFunc, cbFunc, cFragments, pVaFragment, pLenFragment);
+    }
+
+    /// <inheritdoc cref="IDiaSession.Interface.getFunctionFragments_RVA"/>
+    public HRESULT getFunctionFragments_RVA(uint rvaFunc, uint cbFunc, uint cFragments, uint* pRvaFragment, uint* pLenFragment)
+    {
+        fixed (IDiaSessionEx* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSessionEx*, uint, uint, uint, uint*, uint*, HRESULT>)_lpVtbl[58])(pThis, rvaFunc, cbFunc, cFragments, pRvaFragment, pLenFragment);
+    }
+
+    /// <inheritdoc cref="IDiaSession.Interface.getExports"/>
+    public HRESULT getExports(IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSessionEx* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSessionEx*, IDiaEnumSymbols**, HRESULT>)_lpVtbl[59])(pThis, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSession.Interface.getHeapAllocationSites"/>
+    public HRESULT getHeapAllocationSites(IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSessionEx* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSessionEx*, IDiaEnumSymbols**, HRESULT>)_lpVtbl[60])(pThis, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSession.Interface.findInputAssemblyFile"/>
+    public HRESULT findInputAssemblyFile(IDiaSymbol* pSymbol, IDiaInputAssemblyFile** ppResult)
+    {
+        fixed (IDiaSessionEx* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSessionEx*, IDiaSymbol*, IDiaInputAssemblyFile**, HRESULT>)_lpVtbl[61])(pThis, pSymbol, ppResult);
+    }
+
+    /// <inheritdoc cref="Interface.isFastLinkPDB"/>
+    public HRESULT isFastLinkPDB(BOOL* pfFastLinkPDB)
+    {
+        fixed (IDiaSessionEx* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSessionEx*, BOOL*, HRESULT>)_lpVtbl[62])(pThis, pfFastLinkPDB);
+    }
+
+    /// <inheritdoc cref="Interface.isPortablePDB"/>
+    public HRESULT isPortablePDB(BOOL* pfPortablePDB)
+    {
+        fixed (IDiaSessionEx* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSessionEx*, BOOL*, HRESULT>)_lpVtbl[63])(pThis, pfPortablePDB);
+    }
+
+    /// <inheritdoc cref="Interface.getSourceLinkInfo"/>
+    public HRESULT getSourceLinkInfo(IDiaSymbol* parent, IDiaEnumSourceLink** ppenum)
+    {
+        fixed (IDiaSessionEx* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSessionEx*, IDiaSymbol*, IDiaEnumSourceLink**, HRESULT>)_lpVtbl[64])(pThis, parent, ppenum);
+    }
+
+    /// <summary>
+    ///  Extends IDiaSession with additional query support for portable and fast-link PDBs.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/visualstudio/debugger/debug-interface-access/idiasessionex">
+    ///    Official documentation.
+    ///   </see>
+    ///  </para>
+    /// </remarks>
+    [ComImport]
+    [Guid("CD24EED5-5FEA-4742-A320-6254C920E78B")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    public unsafe interface Interface : IDiaSession.Interface
+    {
+        /// <summary>
+        ///  Is fast link pdb.
+        /// </summary>
+        /// <param name="pfFastLinkPDB">Pointer to a variable that receives the requested value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT isFastLinkPDB(BOOL* pfFastLinkPDB);
+
+        /// <summary>
+        ///  Is portable pdb.
+        /// </summary>
+        /// <param name="pfPortablePDB">Pointer to a variable that receives the requested value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT isPortablePDB(BOOL* pfPortablePDB);
+
+        /// <summary>
+        ///  Get source link info.
+        /// </summary>
+        /// <param name="parent">The parent value.</param>
+        /// <param name="ppenum">Pointer to a variable that receives the cloned enumerator.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT getSourceLinkInfo(IDiaSymbol* parent, IDiaEnumSourceLink** ppenum);
+    }
+}

--- a/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaSourceFile.cs
+++ b/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaSourceFile.cs
@@ -1,0 +1,157 @@
+﻿// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Runtime.InteropServices;
+
+// For some reason the XML comment refs for IUnknown can't be resolved on .NET Framework without
+// explicitly using the fully qualified name, which falls afoul of the simplify warning.
+using ComIUnknown = Windows.Win32.System.Com.IUnknown;
+
+namespace Microsoft.VisualStudio.Debugging.DebugInterfaceAccess;
+
+/// <inheritdoc cref="Interface"/>
+public unsafe struct IDiaSourceFile : IComIID
+{
+    /// <inheritdoc cref="IComIID.Guid"/>
+#pragma warning disable IDE1006 // Naming Styles
+    public static readonly Guid IID_Guid = new(0xA2EF5353, 0xF5A8, 0x4EB3, 0x90, 0xD2, 0xCB, 0x52, 0x6A, 0xCB, 0x3C, 0xDD);
+#pragma warning restore IDE1006
+
+#if NETFRAMEWORK
+    readonly ref readonly Guid IComIID.Guid => ref IID_Guid;
+#else
+    static ref readonly Guid IComIID.Guid
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get
+        {
+            ReadOnlySpan<byte> data =
+            [
+                0x53, 0x53, 0xEF, 0xA2,
+                0xA8, 0xF5,
+                0xB3, 0x4E,
+                0x90, 0xD2, 0xCB, 0x52, 0x6A, 0xCB, 0x3C, 0xDD
+            ];
+
+            return ref Unsafe.As<byte, Guid>(ref MemoryMarshal.GetReference(data));
+        }
+    }
+#endif
+
+    private readonly void** _lpVtbl;
+
+    /// <inheritdoc cref="ComIUnknown.QueryInterface(Guid*, void**)"/>
+    public HRESULT QueryInterface(Guid* riid, void** ppvObject)
+    {
+        fixed (IDiaSourceFile* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSourceFile*, Guid*, void**, HRESULT>)_lpVtbl[0])(pThis, riid, ppvObject);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.AddRef"/>
+    public uint AddRef()
+    {
+        fixed (IDiaSourceFile* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSourceFile*, uint>)_lpVtbl[1])(pThis);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.Release"/>
+    public uint Release()
+    {
+        fixed (IDiaSourceFile* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSourceFile*, uint>)_lpVtbl[2])(pThis);
+    }
+
+    /// <inheritdoc cref="Interface.get_uniqueId"/>
+    public HRESULT get_uniqueId(uint* pRetVal)
+    {
+        fixed (IDiaSourceFile* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSourceFile*, uint*, HRESULT>)_lpVtbl[3])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_fileName"/>
+    public HRESULT get_fileName(BSTR* pRetVal)
+    {
+        fixed (IDiaSourceFile* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSourceFile*, BSTR*, HRESULT>)_lpVtbl[4])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_checksumType"/>
+    public HRESULT get_checksumType(uint* pRetVal)
+    {
+        fixed (IDiaSourceFile* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSourceFile*, uint*, HRESULT>)_lpVtbl[5])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_compilands"/>
+    public HRESULT get_compilands(IDiaEnumSymbols** pRetVal)
+    {
+        fixed (IDiaSourceFile* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSourceFile*, IDiaEnumSymbols**, HRESULT>)_lpVtbl[6])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_checksum"/>
+    public HRESULT get_checksum(uint cbData, uint* pcbData, byte* pbData)
+    {
+        fixed (IDiaSourceFile* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSourceFile*, uint, uint*, byte*, HRESULT>)_lpVtbl[7])(pThis, cbData, pcbData, pbData);
+    }
+
+    /// <summary>
+    ///  Represents a source file.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/visualstudio/debugger/debug-interface-access/idiasourcefile">
+    ///    Official documentation.
+    ///   </see>
+    ///  </para>
+    /// </remarks>
+    [ComImport]
+    [Guid("A2EF5353-F5A8-4EB3-90D2-CB526ACB3CDD")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    public unsafe interface Interface
+    {
+        /// <summary>
+        ///  Unique id for the source file (in this data store).
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_uniqueId(uint* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the file name.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_fileName(BSTR* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the checksum type.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_checksumType(uint* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the compilands.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_compilands(IDiaEnumSymbols** pRetVal);
+
+        /// <summary>
+        ///  Retrieves the checksum.
+        /// </summary>
+        /// <param name="cbData">The size, in bytes, of the buffer.</param>
+        /// <param name="pcbData">Pointer to a variable that receives the number of bytes written to the buffer.</param>
+        /// <param name="pbData">Pointer to a caller-allocated buffer that receives the data.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_checksum(uint cbData, uint* pcbData, byte* pbData);
+    }
+}

--- a/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaStackFrame.cs
+++ b/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaStackFrame.cs
@@ -1,0 +1,306 @@
+﻿// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Runtime.InteropServices;
+
+// For some reason the XML comment refs for IUnknown can't be resolved on .NET Framework without
+// explicitly using the fully qualified name, which falls afoul of the simplify warning.
+using ComIUnknown = Windows.Win32.System.Com.IUnknown;
+
+namespace Microsoft.VisualStudio.Debugging.DebugInterfaceAccess;
+
+/// <inheritdoc cref="Interface"/>
+public unsafe struct IDiaStackFrame : IComIID
+{
+    /// <inheritdoc cref="IComIID.Guid"/>
+#pragma warning disable IDE1006 // Naming Styles
+    public static readonly Guid IID_Guid = new(0x5EDBC96D, 0xCDD6, 0x4792, 0xAF, 0xBE, 0xCC, 0x89, 0x00, 0x7D, 0x96, 0x10);
+#pragma warning restore IDE1006
+
+#if NETFRAMEWORK
+    readonly ref readonly Guid IComIID.Guid => ref IID_Guid;
+#else
+    static ref readonly Guid IComIID.Guid
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get
+        {
+            ReadOnlySpan<byte> data =
+            [
+                0x6D, 0xC9, 0xDB, 0x5E,
+                0xD6, 0xCD,
+                0x92, 0x47,
+                0xAF, 0xBE, 0xCC, 0x89, 0x00, 0x7D, 0x96, 0x10
+            ];
+
+            return ref Unsafe.As<byte, Guid>(ref MemoryMarshal.GetReference(data));
+        }
+    }
+#endif
+
+    private readonly void** _lpVtbl;
+
+    /// <inheritdoc cref="ComIUnknown.QueryInterface(Guid*, void**)"/>
+    public HRESULT QueryInterface(Guid* riid, void** ppvObject)
+    {
+        fixed (IDiaStackFrame* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaStackFrame*, Guid*, void**, HRESULT>)_lpVtbl[0])(pThis, riid, ppvObject);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.AddRef"/>
+    public uint AddRef()
+    {
+        fixed (IDiaStackFrame* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaStackFrame*, uint>)_lpVtbl[1])(pThis);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.Release"/>
+    public uint Release()
+    {
+        fixed (IDiaStackFrame* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaStackFrame*, uint>)_lpVtbl[2])(pThis);
+    }
+
+    /// <inheritdoc cref="Interface.get_type"/>
+    public HRESULT get_type(uint* pRetVal)
+    {
+        fixed (IDiaStackFrame* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaStackFrame*, uint*, HRESULT>)_lpVtbl[3])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_base"/>
+    public HRESULT get_base(ulong* pRetVal)
+    {
+        fixed (IDiaStackFrame* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaStackFrame*, ulong*, HRESULT>)_lpVtbl[4])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_size"/>
+    public HRESULT get_size(uint* pRetVal)
+    {
+        fixed (IDiaStackFrame* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaStackFrame*, uint*, HRESULT>)_lpVtbl[5])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_returnAddress"/>
+    public HRESULT get_returnAddress(ulong* pRetVal)
+    {
+        fixed (IDiaStackFrame* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaStackFrame*, ulong*, HRESULT>)_lpVtbl[6])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_localsBase"/>
+    public HRESULT get_localsBase(ulong* pRetVal)
+    {
+        fixed (IDiaStackFrame* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaStackFrame*, ulong*, HRESULT>)_lpVtbl[7])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_lengthLocals"/>
+    public HRESULT get_lengthLocals(uint* pRetVal)
+    {
+        fixed (IDiaStackFrame* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaStackFrame*, uint*, HRESULT>)_lpVtbl[8])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_lengthParams"/>
+    public HRESULT get_lengthParams(uint* pRetVal)
+    {
+        fixed (IDiaStackFrame* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaStackFrame*, uint*, HRESULT>)_lpVtbl[9])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_lengthProlog"/>
+    public HRESULT get_lengthProlog(uint* pRetVal)
+    {
+        fixed (IDiaStackFrame* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaStackFrame*, uint*, HRESULT>)_lpVtbl[10])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_lengthSavedRegisters"/>
+    public HRESULT get_lengthSavedRegisters(uint* pRetVal)
+    {
+        fixed (IDiaStackFrame* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaStackFrame*, uint*, HRESULT>)_lpVtbl[11])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_systemExceptionHandling"/>
+    public HRESULT get_systemExceptionHandling(BOOL* pRetVal)
+    {
+        fixed (IDiaStackFrame* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaStackFrame*, BOOL*, HRESULT>)_lpVtbl[12])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_cplusplusExceptionHandling"/>
+    public HRESULT get_cplusplusExceptionHandling(BOOL* pRetVal)
+    {
+        fixed (IDiaStackFrame* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaStackFrame*, BOOL*, HRESULT>)_lpVtbl[13])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_functionStart"/>
+    public HRESULT get_functionStart(BOOL* pRetVal)
+    {
+        fixed (IDiaStackFrame* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaStackFrame*, BOOL*, HRESULT>)_lpVtbl[14])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_allocatesBasePointer"/>
+    public HRESULT get_allocatesBasePointer(BOOL* pRetVal)
+    {
+        fixed (IDiaStackFrame* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaStackFrame*, BOOL*, HRESULT>)_lpVtbl[15])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_maxStack"/>
+    public HRESULT get_maxStack(uint* pRetVal)
+    {
+        fixed (IDiaStackFrame* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaStackFrame*, uint*, HRESULT>)_lpVtbl[16])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_registerValue"/>
+    public HRESULT get_registerValue(uint index, ulong* pRetVal)
+    {
+        fixed (IDiaStackFrame* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaStackFrame*, uint, ulong*, HRESULT>)_lpVtbl[17])(pThis, index, pRetVal);
+    }
+
+    /// <summary>
+    ///  Exposes the properties of a stack frame.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/visualstudio/debugger/debug-interface-access/idiastackframe">
+    ///    Official documentation.
+    ///   </see>
+    ///  </para>
+    /// </remarks>
+    [ComImport]
+    [Guid("5EDBC96D-CDD6-4792-AFBE-CC89007D9610")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    public unsafe interface Interface
+    {
+        /// <summary>
+        ///  Type.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_type(uint* pRetVal);
+
+        /// <summary>
+        ///  Base of the stack frame.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_base(ulong* pRetVal);
+
+        /// <summary>
+        ///  Size of frame in bytes.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_size(uint* pRetVal);
+
+        /// <summary>
+        ///  Return address of the frame.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_returnAddress(ulong* pRetVal);
+
+        /// <summary>
+        ///  Base of locals.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_localsBase(ulong* pRetVal);
+
+        /// <summary>
+        ///  CbLocals.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_lengthLocals(uint* pRetVal);
+
+        /// <summary>
+        ///  CbParams.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_lengthParams(uint* pRetVal);
+
+        /// <summary>
+        ///  CbProlog.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_lengthProlog(uint* pRetVal);
+
+        /// <summary>
+        ///  CbSavedRegs.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_lengthSavedRegisters(uint* pRetVal);
+
+        /// <summary>
+        ///  FHasSEH.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_systemExceptionHandling(BOOL* pRetVal);
+
+        /// <summary>
+        ///  FHasEH.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_cplusplusExceptionHandling(BOOL* pRetVal);
+
+        /// <summary>
+        ///  FuncStart.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_functionStart(BOOL* pRetVal);
+
+        /// <summary>
+        ///  FUsesBP.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_allocatesBasePointer(BOOL* pRetVal);
+
+        /// <summary>
+        ///  MaxStack.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_maxStack(uint* pRetVal);
+
+        /// <summary>
+        ///  Register value.
+        /// </summary>
+        /// <param name="index">The zero-based index of the item to retrieve.</param>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_registerValue(uint index, ulong* pRetVal);
+    }
+}

--- a/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaStackWalkFrame.cs
+++ b/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaStackWalkFrame.cs
@@ -1,0 +1,164 @@
+﻿// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Runtime.InteropServices;
+
+// For some reason the XML comment refs for IUnknown can't be resolved on .NET Framework without
+// explicitly using the fully qualified name, which falls afoul of the simplify warning.
+using ComIUnknown = Windows.Win32.System.Com.IUnknown;
+
+namespace Microsoft.VisualStudio.Debugging.DebugInterfaceAccess;
+
+/// <inheritdoc cref="Interface"/>
+public unsafe struct IDiaStackWalkFrame : IComIID
+{
+    /// <inheritdoc cref="IComIID.Guid"/>
+#pragma warning disable IDE1006 // Naming Styles
+    public static readonly Guid IID_Guid = new(0x07C590C1, 0x438D, 0x4F47, 0xBD, 0xCD, 0x43, 0x97, 0xBC, 0x81, 0xAD, 0x75);
+#pragma warning restore IDE1006
+
+#if NETFRAMEWORK
+    readonly ref readonly Guid IComIID.Guid => ref IID_Guid;
+#else
+    static ref readonly Guid IComIID.Guid
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get
+        {
+            ReadOnlySpan<byte> data =
+            [
+                0xC1, 0x90, 0xC5, 0x07,
+                0x8D, 0x43,
+                0x47, 0x4F,
+                0xBD, 0xCD, 0x43, 0x97, 0xBC, 0x81, 0xAD, 0x75
+            ];
+
+            return ref Unsafe.As<byte, Guid>(ref MemoryMarshal.GetReference(data));
+        }
+    }
+#endif
+
+    private readonly void** _lpVtbl;
+
+    /// <inheritdoc cref="ComIUnknown.QueryInterface(Guid*, void**)"/>
+    public HRESULT QueryInterface(Guid* riid, void** ppvObject)
+    {
+        fixed (IDiaStackWalkFrame* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaStackWalkFrame*, Guid*, void**, HRESULT>)_lpVtbl[0])(pThis, riid, ppvObject);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.AddRef"/>
+    public uint AddRef()
+    {
+        fixed (IDiaStackWalkFrame* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaStackWalkFrame*, uint>)_lpVtbl[1])(pThis);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.Release"/>
+    public uint Release()
+    {
+        fixed (IDiaStackWalkFrame* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaStackWalkFrame*, uint>)_lpVtbl[2])(pThis);
+    }
+
+    /// <inheritdoc cref="Interface.get_registerValue"/>
+    public HRESULT get_registerValue(uint index, ulong* pRetVal)
+    {
+        fixed (IDiaStackWalkFrame* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaStackWalkFrame*, uint, ulong*, HRESULT>)_lpVtbl[3])(pThis, index, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.put_registerValue"/>
+    public HRESULT put_registerValue(uint index, ulong NewVal)
+    {
+        fixed (IDiaStackWalkFrame* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaStackWalkFrame*, uint, ulong, HRESULT>)_lpVtbl[4])(pThis, index, NewVal);
+    }
+
+    /// <inheritdoc cref="Interface.readMemory"/>
+    public HRESULT readMemory(MemoryTypeEnum type, ulong va, uint cbData, uint* pcbData, byte* pbData)
+    {
+        fixed (IDiaStackWalkFrame* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaStackWalkFrame*, MemoryTypeEnum, ulong, uint, uint*, byte*, HRESULT>)_lpVtbl[5])(pThis, type, va, cbData, pcbData, pbData);
+    }
+
+    /// <inheritdoc cref="Interface.searchForReturnAddress"/>
+    public HRESULT searchForReturnAddress(IDiaFrameData* frame, ulong* returnAddress)
+    {
+        fixed (IDiaStackWalkFrame* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaStackWalkFrame*, IDiaFrameData*, ulong*, HRESULT>)_lpVtbl[6])(pThis, frame, returnAddress);
+    }
+
+    /// <inheritdoc cref="Interface.searchForReturnAddressStart"/>
+    public HRESULT searchForReturnAddressStart(IDiaFrameData* frame, ulong startAddress, ulong* returnAddress)
+    {
+        fixed (IDiaStackWalkFrame* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaStackWalkFrame*, IDiaFrameData*, ulong, ulong*, HRESULT>)_lpVtbl[7])(pThis, frame, startAddress, returnAddress);
+    }
+
+    /// <summary>
+    ///  Provides access to the state of a stack frame and registers during a stack walk.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/visualstudio/debugger/debug-interface-access/idiastackwalkframe">
+    ///    Official documentation.
+    ///   </see>
+    ///  </para>
+    /// </remarks>
+    [ComImport]
+    [Guid("07C590C1-438D-4F47-BDCD-4397BC81AD75")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    public unsafe interface Interface
+    {
+        /// <summary>
+        ///  Register value.
+        /// </summary>
+        /// <param name="index">The zero-based index of the item to retrieve.</param>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_registerValue(uint index, ulong* pRetVal);
+
+        /// <summary>
+        ///  Register value.
+        /// </summary>
+        /// <param name="index">The zero-based index of the item to retrieve.</param>
+        /// <param name="NewVal">The NewVal value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT put_registerValue(uint index, ulong NewVal);
+
+        /// <summary>
+        ///  Read memory.
+        /// </summary>
+        /// <param name="type">The type value.</param>
+        /// <param name="va">The virtual address (VA).</param>
+        /// <param name="cbData">The size, in bytes, of the buffer.</param>
+        /// <param name="pcbData">Pointer to a variable that receives the number of bytes written to the buffer.</param>
+        /// <param name="pbData">Pointer to a caller-allocated buffer that receives the data.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT readMemory(MemoryTypeEnum type, ulong va, uint cbData, uint* pcbData, byte* pbData);
+
+        /// <summary>
+        ///  Search for return address.
+        /// </summary>
+        /// <param name="frame">The frame value.</param>
+        /// <param name="returnAddress">Pointer to a variable that receives the requested value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT searchForReturnAddress(IDiaFrameData* frame, ulong* returnAddress);
+
+        /// <summary>
+        ///  Search for return address start.
+        /// </summary>
+        /// <param name="frame">The frame value.</param>
+        /// <param name="startAddress">The startAddress value.</param>
+        /// <param name="returnAddress">Pointer to a variable that receives the requested value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT searchForReturnAddressStart(IDiaFrameData* frame, ulong startAddress, ulong* returnAddress);
+    }
+}

--- a/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaStackWalkHelper.cs
+++ b/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaStackWalkHelper.cs
@@ -1,0 +1,283 @@
+﻿// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Runtime.InteropServices;
+
+// For some reason the XML comment refs for IUnknown can't be resolved on .NET Framework without
+// explicitly using the fully qualified name, which falls afoul of the simplify warning.
+using ComIUnknown = Windows.Win32.System.Com.IUnknown;
+
+namespace Microsoft.VisualStudio.Debugging.DebugInterfaceAccess;
+
+/// <inheritdoc cref="Interface"/>
+public unsafe struct IDiaStackWalkHelper : IComIID
+{
+    /// <inheritdoc cref="IComIID.Guid"/>
+#pragma warning disable IDE1006 // Naming Styles
+    public static readonly Guid IID_Guid = new(0x21F81B1B, 0xC5BB, 0x42A3, 0xBC, 0x4F, 0xCC, 0xBA, 0xA7, 0x5B, 0x9F, 0x19);
+#pragma warning restore IDE1006
+
+#if NETFRAMEWORK
+    readonly ref readonly Guid IComIID.Guid => ref IID_Guid;
+#else
+    static ref readonly Guid IComIID.Guid
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get
+        {
+            ReadOnlySpan<byte> data =
+            [
+                0x1B, 0x1B, 0xF8, 0x21,
+                0xBB, 0xC5,
+                0xA3, 0x42,
+                0xBC, 0x4F, 0xCC, 0xBA, 0xA7, 0x5B, 0x9F, 0x19
+            ];
+
+            return ref Unsafe.As<byte, Guid>(ref MemoryMarshal.GetReference(data));
+        }
+    }
+#endif
+
+    private readonly void** _lpVtbl;
+
+    /// <inheritdoc cref="ComIUnknown.QueryInterface(Guid*, void**)"/>
+    public HRESULT QueryInterface(Guid* riid, void** ppvObject)
+    {
+        fixed (IDiaStackWalkHelper* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaStackWalkHelper*, Guid*, void**, HRESULT>)_lpVtbl[0])(pThis, riid, ppvObject);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.AddRef"/>
+    public uint AddRef()
+    {
+        fixed (IDiaStackWalkHelper* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaStackWalkHelper*, uint>)_lpVtbl[1])(pThis);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.Release"/>
+    public uint Release()
+    {
+        fixed (IDiaStackWalkHelper* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaStackWalkHelper*, uint>)_lpVtbl[2])(pThis);
+    }
+
+    /// <inheritdoc cref="Interface.get_registerValue"/>
+    public HRESULT get_registerValue(uint index, ulong* pRetVal)
+    {
+        fixed (IDiaStackWalkHelper* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaStackWalkHelper*, uint, ulong*, HRESULT>)_lpVtbl[3])(pThis, index, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.put_registerValue"/>
+    public HRESULT put_registerValue(uint index, ulong NewVal)
+    {
+        fixed (IDiaStackWalkHelper* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaStackWalkHelper*, uint, ulong, HRESULT>)_lpVtbl[4])(pThis, index, NewVal);
+    }
+
+    /// <inheritdoc cref="Interface.readMemory"/>
+    public HRESULT readMemory(MemoryTypeEnum type, ulong va, uint cbData, uint* pcbData, byte* pbData)
+    {
+        fixed (IDiaStackWalkHelper* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaStackWalkHelper*, MemoryTypeEnum, ulong, uint, uint*, byte*, HRESULT>)_lpVtbl[5])(pThis, type, va, cbData, pcbData, pbData);
+    }
+
+    /// <inheritdoc cref="Interface.searchForReturnAddress"/>
+    public HRESULT searchForReturnAddress(IDiaFrameData* frame, ulong* returnAddress)
+    {
+        fixed (IDiaStackWalkHelper* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaStackWalkHelper*, IDiaFrameData*, ulong*, HRESULT>)_lpVtbl[6])(pThis, frame, returnAddress);
+    }
+
+    /// <inheritdoc cref="Interface.searchForReturnAddressStart"/>
+    public HRESULT searchForReturnAddressStart(IDiaFrameData* frame, ulong startAddress, ulong* returnAddress)
+    {
+        fixed (IDiaStackWalkHelper* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaStackWalkHelper*, IDiaFrameData*, ulong, ulong*, HRESULT>)_lpVtbl[7])(pThis, frame, startAddress, returnAddress);
+    }
+
+    /// <inheritdoc cref="Interface.frameForVA"/>
+    public HRESULT frameForVA(ulong va, IDiaFrameData** ppFrame)
+    {
+        fixed (IDiaStackWalkHelper* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaStackWalkHelper*, ulong, IDiaFrameData**, HRESULT>)_lpVtbl[8])(pThis, va, ppFrame);
+    }
+
+    /// <inheritdoc cref="Interface.symbolForVA"/>
+    public HRESULT symbolForVA(ulong va, IDiaSymbol** ppSymbol)
+    {
+        fixed (IDiaStackWalkHelper* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaStackWalkHelper*, ulong, IDiaSymbol**, HRESULT>)_lpVtbl[9])(pThis, va, ppSymbol);
+    }
+
+    /// <inheritdoc cref="Interface.pdataForVA"/>
+    public HRESULT pdataForVA(ulong va, uint cbData, uint* pcbData, byte* pbData)
+    {
+        fixed (IDiaStackWalkHelper* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaStackWalkHelper*, ulong, uint, uint*, byte*, HRESULT>)_lpVtbl[10])(pThis, va, cbData, pcbData, pbData);
+    }
+
+    /// <inheritdoc cref="Interface.imageForVA"/>
+    public HRESULT imageForVA(ulong vaContext, ulong* pvaImageStart)
+    {
+        fixed (IDiaStackWalkHelper* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaStackWalkHelper*, ulong, ulong*, HRESULT>)_lpVtbl[11])(pThis, vaContext, pvaImageStart);
+    }
+
+    /// <inheritdoc cref="Interface.addressForVA"/>
+    public HRESULT addressForVA(ulong va, uint* pISect, uint* pOffset)
+    {
+        fixed (IDiaStackWalkHelper* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaStackWalkHelper*, ulong, uint*, uint*, HRESULT>)_lpVtbl[12])(pThis, va, pISect, pOffset);
+    }
+
+    /// <inheritdoc cref="Interface.numberOfFunctionFragmentsForVA"/>
+    public HRESULT numberOfFunctionFragmentsForVA(ulong vaFunc, uint cbFunc, uint* pNumFragments)
+    {
+        fixed (IDiaStackWalkHelper* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaStackWalkHelper*, ulong, uint, uint*, HRESULT>)_lpVtbl[13])(pThis, vaFunc, cbFunc, pNumFragments);
+    }
+
+    /// <inheritdoc cref="Interface.functionFragmentsForVA"/>
+    public HRESULT functionFragmentsForVA(ulong vaFunc, uint cbFunc, uint cFragments, ulong* pVaFragment, uint* pLenFragment)
+    {
+        fixed (IDiaStackWalkHelper* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaStackWalkHelper*, ulong, uint, uint, ulong*, uint*, HRESULT>)_lpVtbl[14])(pThis, vaFunc, cbFunc, cFragments, pVaFragment, pLenFragment);
+    }
+
+    /// <summary>
+    ///  Facilitates walking the stack using the program debug database in the data source.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/visualstudio/debugger/debug-interface-access/idiastackwalkhelper">
+    ///    Official documentation.
+    ///   </see>
+    ///  </para>
+    /// </remarks>
+    [ComImport]
+    [Guid("21F81B1B-C5BB-42A3-BC4F-CCBAA75B9F19")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    public unsafe interface Interface
+    {
+        /// <summary>
+        ///  Register value.
+        /// </summary>
+        /// <param name="index">The zero-based index of the item to retrieve.</param>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_registerValue(uint index, ulong* pRetVal);
+
+        /// <summary>
+        ///  Register value.
+        /// </summary>
+        /// <param name="index">The zero-based index of the item to retrieve.</param>
+        /// <param name="NewVal">The NewVal value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT put_registerValue(uint index, ulong NewVal);
+
+        /// <summary>
+        ///  Read memory.
+        /// </summary>
+        /// <param name="type">The type value.</param>
+        /// <param name="va">The virtual address (VA).</param>
+        /// <param name="cbData">The size, in bytes, of the buffer.</param>
+        /// <param name="pcbData">Pointer to a variable that receives the number of bytes written to the buffer.</param>
+        /// <param name="pbData">Pointer to a caller-allocated buffer that receives the data.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT readMemory(MemoryTypeEnum type, ulong va, uint cbData, uint* pcbData, byte* pbData);
+
+        /// <summary>
+        ///  Search for return address.
+        /// </summary>
+        /// <param name="frame">The frame value.</param>
+        /// <param name="returnAddress">Pointer to a variable that receives the requested value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT searchForReturnAddress(IDiaFrameData* frame, ulong* returnAddress);
+
+        /// <summary>
+        ///  Search for return address start.
+        /// </summary>
+        /// <param name="frame">The frame value.</param>
+        /// <param name="startAddress">The startAddress value.</param>
+        /// <param name="returnAddress">Pointer to a variable that receives the requested value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT searchForReturnAddressStart(IDiaFrameData* frame, ulong startAddress, ulong* returnAddress);
+
+        /// <summary>
+        ///  Frame for va.
+        /// </summary>
+        /// <param name="va">The virtual address (VA).</param>
+        /// <param name="ppFrame">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT frameForVA(ulong va, IDiaFrameData** ppFrame);
+
+        /// <summary>
+        ///  Symbol for va.
+        /// </summary>
+        /// <param name="va">The virtual address (VA).</param>
+        /// <param name="ppSymbol">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT symbolForVA(ulong va, IDiaSymbol** ppSymbol);
+
+        /// <summary>
+        ///  Pdata for va.
+        /// </summary>
+        /// <param name="va">The virtual address (VA).</param>
+        /// <param name="cbData">The size, in bytes, of the buffer.</param>
+        /// <param name="pcbData">Pointer to a variable that receives the number of bytes written to the buffer.</param>
+        /// <param name="pbData">Pointer to a caller-allocated buffer that receives the data.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT pdataForVA(ulong va, uint cbData, uint* pcbData, byte* pbData);
+
+        /// <summary>
+        ///  Image for va.
+        /// </summary>
+        /// <param name="vaContext">The vaContext value.</param>
+        /// <param name="pvaImageStart">Pointer to a variable that receives the requested value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT imageForVA(ulong vaContext, ulong* pvaImageStart);
+
+        /// <summary>
+        ///  Address for va.
+        /// </summary>
+        /// <param name="va">The virtual address (VA).</param>
+        /// <param name="pISect">Pointer to a variable that receives the requested value.</param>
+        /// <param name="pOffset">Pointer to a variable that receives the requested value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT addressForVA(ulong va, uint* pISect, uint* pOffset);
+
+        /// <summary>
+        ///  Number of function fragments for va.
+        /// </summary>
+        /// <param name="vaFunc">The vaFunc value.</param>
+        /// <param name="cbFunc">The size, in bytes, of the buffer.</param>
+        /// <param name="pNumFragments">Pointer to a variable that receives the requested value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT numberOfFunctionFragmentsForVA(ulong vaFunc, uint cbFunc, uint* pNumFragments);
+
+        /// <summary>
+        ///  Function fragments for va.
+        /// </summary>
+        /// <param name="vaFunc">The vaFunc value.</param>
+        /// <param name="cbFunc">The size, in bytes, of the buffer.</param>
+        /// <param name="cFragments">The cFragments value.</param>
+        /// <param name="pVaFragment">Pointer to a variable that receives the requested value.</param>
+        /// <param name="pLenFragment">Pointer to a variable that receives the requested value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT functionFragmentsForVA(ulong vaFunc, uint cbFunc, uint cFragments, ulong* pVaFragment, uint* pLenFragment);
+    }
+}

--- a/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaStackWalkHelper2.cs
+++ b/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaStackWalkHelper2.cs
@@ -1,0 +1,180 @@
+﻿// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Runtime.InteropServices;
+
+// For some reason the XML comment refs for IUnknown can't be resolved on .NET Framework without
+// explicitly using the fully qualified name, which falls afoul of the simplify warning.
+using ComIUnknown = Windows.Win32.System.Com.IUnknown;
+
+namespace Microsoft.VisualStudio.Debugging.DebugInterfaceAccess;
+
+/// <inheritdoc cref="Interface"/>
+public unsafe struct IDiaStackWalkHelper2 : IComIID
+{
+    /// <inheritdoc cref="IComIID.Guid"/>
+#pragma warning disable IDE1006 // Naming Styles
+    public static readonly Guid IID_Guid = new(0x8222C490, 0x507B, 0x4BEF, 0xB3, 0xBD, 0x41, 0xDC, 0xA7, 0xB5, 0x93, 0x4C);
+#pragma warning restore IDE1006
+
+#if NETFRAMEWORK
+    readonly ref readonly Guid IComIID.Guid => ref IID_Guid;
+#else
+    static ref readonly Guid IComIID.Guid
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get
+        {
+            ReadOnlySpan<byte> data =
+            [
+                0x90, 0xC4, 0x22, 0x82,
+                0x7B, 0x50,
+                0xEF, 0x4B,
+                0xB3, 0xBD, 0x41, 0xDC, 0xA7, 0xB5, 0x93, 0x4C
+            ];
+
+            return ref Unsafe.As<byte, Guid>(ref MemoryMarshal.GetReference(data));
+        }
+    }
+#endif
+
+    private readonly void** _lpVtbl;
+
+    /// <inheritdoc cref="ComIUnknown.QueryInterface(Guid*, void**)"/>
+    public HRESULT QueryInterface(Guid* riid, void** ppvObject)
+    {
+        fixed (IDiaStackWalkHelper2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaStackWalkHelper2*, Guid*, void**, HRESULT>)_lpVtbl[0])(pThis, riid, ppvObject);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.AddRef"/>
+    public uint AddRef()
+    {
+        fixed (IDiaStackWalkHelper2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaStackWalkHelper2*, uint>)_lpVtbl[1])(pThis);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.Release"/>
+    public uint Release()
+    {
+        fixed (IDiaStackWalkHelper2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaStackWalkHelper2*, uint>)_lpVtbl[2])(pThis);
+    }
+
+    /// <inheritdoc cref="IDiaStackWalkHelper.Interface.get_registerValue"/>
+    public HRESULT get_registerValue(uint index, ulong* pRetVal)
+    {
+        fixed (IDiaStackWalkHelper2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaStackWalkHelper2*, uint, ulong*, HRESULT>)_lpVtbl[3])(pThis, index, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaStackWalkHelper.Interface.put_registerValue"/>
+    public HRESULT put_registerValue(uint index, ulong NewVal)
+    {
+        fixed (IDiaStackWalkHelper2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaStackWalkHelper2*, uint, ulong, HRESULT>)_lpVtbl[4])(pThis, index, NewVal);
+    }
+
+    /// <inheritdoc cref="IDiaStackWalkHelper.Interface.readMemory"/>
+    public HRESULT readMemory(MemoryTypeEnum type, ulong va, uint cbData, uint* pcbData, byte* pbData)
+    {
+        fixed (IDiaStackWalkHelper2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaStackWalkHelper2*, MemoryTypeEnum, ulong, uint, uint*, byte*, HRESULT>)_lpVtbl[5])(pThis, type, va, cbData, pcbData, pbData);
+    }
+
+    /// <inheritdoc cref="IDiaStackWalkHelper.Interface.searchForReturnAddress"/>
+    public HRESULT searchForReturnAddress(IDiaFrameData* frame, ulong* returnAddress)
+    {
+        fixed (IDiaStackWalkHelper2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaStackWalkHelper2*, IDiaFrameData*, ulong*, HRESULT>)_lpVtbl[6])(pThis, frame, returnAddress);
+    }
+
+    /// <inheritdoc cref="IDiaStackWalkHelper.Interface.searchForReturnAddressStart"/>
+    public HRESULT searchForReturnAddressStart(IDiaFrameData* frame, ulong startAddress, ulong* returnAddress)
+    {
+        fixed (IDiaStackWalkHelper2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaStackWalkHelper2*, IDiaFrameData*, ulong, ulong*, HRESULT>)_lpVtbl[7])(pThis, frame, startAddress, returnAddress);
+    }
+
+    /// <inheritdoc cref="IDiaStackWalkHelper.Interface.frameForVA"/>
+    public HRESULT frameForVA(ulong va, IDiaFrameData** ppFrame)
+    {
+        fixed (IDiaStackWalkHelper2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaStackWalkHelper2*, ulong, IDiaFrameData**, HRESULT>)_lpVtbl[8])(pThis, va, ppFrame);
+    }
+
+    /// <inheritdoc cref="IDiaStackWalkHelper.Interface.symbolForVA"/>
+    public HRESULT symbolForVA(ulong va, IDiaSymbol** ppSymbol)
+    {
+        fixed (IDiaStackWalkHelper2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaStackWalkHelper2*, ulong, IDiaSymbol**, HRESULT>)_lpVtbl[9])(pThis, va, ppSymbol);
+    }
+
+    /// <inheritdoc cref="IDiaStackWalkHelper.Interface.pdataForVA"/>
+    public HRESULT pdataForVA(ulong va, uint cbData, uint* pcbData, byte* pbData)
+    {
+        fixed (IDiaStackWalkHelper2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaStackWalkHelper2*, ulong, uint, uint*, byte*, HRESULT>)_lpVtbl[10])(pThis, va, cbData, pcbData, pbData);
+    }
+
+    /// <inheritdoc cref="IDiaStackWalkHelper.Interface.imageForVA"/>
+    public HRESULT imageForVA(ulong vaContext, ulong* pvaImageStart)
+    {
+        fixed (IDiaStackWalkHelper2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaStackWalkHelper2*, ulong, ulong*, HRESULT>)_lpVtbl[11])(pThis, vaContext, pvaImageStart);
+    }
+
+    /// <inheritdoc cref="IDiaStackWalkHelper.Interface.addressForVA"/>
+    public HRESULT addressForVA(ulong va, uint* pISect, uint* pOffset)
+    {
+        fixed (IDiaStackWalkHelper2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaStackWalkHelper2*, ulong, uint*, uint*, HRESULT>)_lpVtbl[12])(pThis, va, pISect, pOffset);
+    }
+
+    /// <inheritdoc cref="IDiaStackWalkHelper.Interface.numberOfFunctionFragmentsForVA"/>
+    public HRESULT numberOfFunctionFragmentsForVA(ulong vaFunc, uint cbFunc, uint* pNumFragments)
+    {
+        fixed (IDiaStackWalkHelper2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaStackWalkHelper2*, ulong, uint, uint*, HRESULT>)_lpVtbl[13])(pThis, vaFunc, cbFunc, pNumFragments);
+    }
+
+    /// <inheritdoc cref="IDiaStackWalkHelper.Interface.functionFragmentsForVA"/>
+    public HRESULT functionFragmentsForVA(ulong vaFunc, uint cbFunc, uint cFragments, ulong* pVaFragment, uint* pLenFragment)
+    {
+        fixed (IDiaStackWalkHelper2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaStackWalkHelper2*, ulong, uint, uint, ulong*, uint*, HRESULT>)_lpVtbl[14])(pThis, vaFunc, cbFunc, cFragments, pVaFragment, pLenFragment);
+    }
+
+    /// <inheritdoc cref="Interface.GetPointerAuthenticationMask"/>
+    public HRESULT GetPointerAuthenticationMask(ulong PtrVal, ulong* AuthMask)
+    {
+        fixed (IDiaStackWalkHelper2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaStackWalkHelper2*, ulong, ulong*, HRESULT>)_lpVtbl[15])(pThis, PtrVal, AuthMask);
+    }
+
+    /// <summary>
+    ///  Extends IDiaStackWalkHelper with pointer authentication support.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/visualstudio/debugger/debug-interface-access/idiastackwalkhelper2">
+    ///    Official documentation.
+    ///   </see>
+    ///  </para>
+    /// </remarks>
+    [ComImport]
+    [Guid("8222C490-507B-4BEF-B3BD-41DCA7B5934C")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    public unsafe interface Interface : IDiaStackWalkHelper.Interface
+    {
+        /// <summary>
+        ///  Get pointer authentication mask.
+        /// </summary>
+        /// <param name="PtrVal">The PtrVal value.</param>
+        /// <param name="AuthMask">Pointer to a variable that receives the requested value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT GetPointerAuthenticationMask(ulong PtrVal, ulong* AuthMask);
+    }
+}

--- a/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaStackWalker.cs
+++ b/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaStackWalker.cs
@@ -1,0 +1,113 @@
+﻿// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Runtime.InteropServices;
+
+// For some reason the XML comment refs for IUnknown can't be resolved on .NET Framework without
+// explicitly using the fully qualified name, which falls afoul of the simplify warning.
+using ComIUnknown = Windows.Win32.System.Com.IUnknown;
+
+namespace Microsoft.VisualStudio.Debugging.DebugInterfaceAccess;
+
+/// <inheritdoc cref="Interface"/>
+public unsafe struct IDiaStackWalker : IComIID
+{
+    /// <inheritdoc cref="IComIID.Guid"/>
+#pragma warning disable IDE1006 // Naming Styles
+    public static readonly Guid IID_Guid = new(0x5485216B, 0xA54C, 0x469F, 0x96, 0x70, 0x52, 0xB2, 0x4D, 0x52, 0x29, 0xBB);
+#pragma warning restore IDE1006
+
+#if NETFRAMEWORK
+    readonly ref readonly Guid IComIID.Guid => ref IID_Guid;
+#else
+    static ref readonly Guid IComIID.Guid
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get
+        {
+            ReadOnlySpan<byte> data =
+            [
+                0x6B, 0x21, 0x85, 0x54,
+                0x4C, 0xA5,
+                0x9F, 0x46,
+                0x96, 0x70, 0x52, 0xB2, 0x4D, 0x52, 0x29, 0xBB
+            ];
+
+            return ref Unsafe.As<byte, Guid>(ref MemoryMarshal.GetReference(data));
+        }
+    }
+#endif
+
+    private readonly void** _lpVtbl;
+
+    /// <inheritdoc cref="ComIUnknown.QueryInterface(Guid*, void**)"/>
+    public HRESULT QueryInterface(Guid* riid, void** ppvObject)
+    {
+        fixed (IDiaStackWalker* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaStackWalker*, Guid*, void**, HRESULT>)_lpVtbl[0])(pThis, riid, ppvObject);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.AddRef"/>
+    public uint AddRef()
+    {
+        fixed (IDiaStackWalker* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaStackWalker*, uint>)_lpVtbl[1])(pThis);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.Release"/>
+    public uint Release()
+    {
+        fixed (IDiaStackWalker* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaStackWalker*, uint>)_lpVtbl[2])(pThis);
+    }
+
+    /// <inheritdoc cref="Interface.getEnumFrames"/>
+    public HRESULT getEnumFrames(IDiaStackWalkHelper* pHelper, IDiaEnumStackFrames** ppEnum)
+    {
+        fixed (IDiaStackWalker* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaStackWalker*, IDiaStackWalkHelper*, IDiaEnumStackFrames**, HRESULT>)_lpVtbl[3])(pThis, pHelper, ppEnum);
+    }
+
+    /// <inheritdoc cref="Interface.getEnumFrames2"/>
+    public HRESULT getEnumFrames2(CV_CPU_TYPE_e cpuid, IDiaStackWalkHelper* pHelper, IDiaEnumStackFrames** ppEnum)
+    {
+        fixed (IDiaStackWalker* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaStackWalker*, CV_CPU_TYPE_e, IDiaStackWalkHelper*, IDiaEnumStackFrames**, HRESULT>)_lpVtbl[4])(pThis, cpuid, pHelper, ppEnum);
+    }
+
+    /// <summary>
+    ///  Walks a call stack using the supplied stack-walking helper.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/visualstudio/debugger/debug-interface-access/idiastackwalker">
+    ///    Official documentation.
+    ///   </see>
+    ///  </para>
+    /// </remarks>
+    [ComImport]
+    [Guid("5485216B-A54C-469F-9670-52B24D5229BB")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    public unsafe interface Interface
+    {
+        /// <summary>
+        ///  Get enum frames.
+        /// </summary>
+        /// <param name="pHelper">The pHelper value.</param>
+        /// <param name="ppEnum">Pointer to a variable that receives the cloned enumerator.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT getEnumFrames(IDiaStackWalkHelper* pHelper, IDiaEnumStackFrames** ppEnum);
+
+        /// <summary>
+        ///  Get enum frames2.
+        /// </summary>
+        /// <param name="cpuid">The cpuid value.</param>
+        /// <param name="pHelper">The pHelper value.</param>
+        /// <param name="ppEnum">Pointer to a variable that receives the cloned enumerator.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT getEnumFrames2(CV_CPU_TYPE_e cpuid, IDiaStackWalkHelper* pHelper, IDiaEnumStackFrames** ppEnum);
+    }
+}

--- a/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaStackWalker2.cs
+++ b/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaStackWalker2.cs
@@ -1,0 +1,95 @@
+﻿// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Runtime.InteropServices;
+
+// For some reason the XML comment refs for IUnknown can't be resolved on .NET Framework without
+// explicitly using the fully qualified name, which falls afoul of the simplify warning.
+using ComIUnknown = Windows.Win32.System.Com.IUnknown;
+
+namespace Microsoft.VisualStudio.Debugging.DebugInterfaceAccess;
+
+/// <inheritdoc cref="Interface"/>
+public unsafe struct IDiaStackWalker2 : IComIID
+{
+    /// <inheritdoc cref="IComIID.Guid"/>
+#pragma warning disable IDE1006 // Naming Styles
+    public static readonly Guid IID_Guid = new(0x7C185885, 0xA015, 0x4CAC, 0x94, 0x11, 0x0F, 0x4F, 0xB3, 0x9B, 0x1F, 0x3A);
+#pragma warning restore IDE1006
+
+#if NETFRAMEWORK
+    readonly ref readonly Guid IComIID.Guid => ref IID_Guid;
+#else
+    static ref readonly Guid IComIID.Guid
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get
+        {
+            ReadOnlySpan<byte> data =
+            [
+                0x85, 0x58, 0x18, 0x7C,
+                0x15, 0xA0,
+                0xAC, 0x4C,
+                0x94, 0x11, 0x0F, 0x4F, 0xB3, 0x9B, 0x1F, 0x3A
+            ];
+
+            return ref Unsafe.As<byte, Guid>(ref MemoryMarshal.GetReference(data));
+        }
+    }
+#endif
+
+    private readonly void** _lpVtbl;
+
+    /// <inheritdoc cref="ComIUnknown.QueryInterface(Guid*, void**)"/>
+    public HRESULT QueryInterface(Guid* riid, void** ppvObject)
+    {
+        fixed (IDiaStackWalker2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaStackWalker2*, Guid*, void**, HRESULT>)_lpVtbl[0])(pThis, riid, ppvObject);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.AddRef"/>
+    public uint AddRef()
+    {
+        fixed (IDiaStackWalker2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaStackWalker2*, uint>)_lpVtbl[1])(pThis);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.Release"/>
+    public uint Release()
+    {
+        fixed (IDiaStackWalker2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaStackWalker2*, uint>)_lpVtbl[2])(pThis);
+    }
+
+    /// <inheritdoc cref="IDiaStackWalker.Interface.getEnumFrames"/>
+    public HRESULT getEnumFrames(IDiaStackWalkHelper* pHelper, IDiaEnumStackFrames** ppEnum)
+    {
+        fixed (IDiaStackWalker2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaStackWalker2*, IDiaStackWalkHelper*, IDiaEnumStackFrames**, HRESULT>)_lpVtbl[3])(pThis, pHelper, ppEnum);
+    }
+
+    /// <inheritdoc cref="IDiaStackWalker.Interface.getEnumFrames2"/>
+    public HRESULT getEnumFrames2(CV_CPU_TYPE_e cpuid, IDiaStackWalkHelper* pHelper, IDiaEnumStackFrames** ppEnum)
+    {
+        fixed (IDiaStackWalker2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaStackWalker2*, CV_CPU_TYPE_e, IDiaStackWalkHelper*, IDiaEnumStackFrames**, HRESULT>)_lpVtbl[4])(pThis, cpuid, pHelper, ppEnum);
+    }
+
+    /// <summary>
+    ///  Extends IDiaStackWalker for additional stack walking scenarios.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/visualstudio/debugger/debug-interface-access/idiastackwalker2">
+    ///    Official documentation.
+    ///   </see>
+    ///  </para>
+    /// </remarks>
+    [ComImport]
+    [Guid("7C185885-A015-4CAC-9411-0F4FB39B1F3A")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    public interface Interface : IDiaStackWalker.Interface
+    {
+    }
+}

--- a/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaSymbol.cs
+++ b/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaSymbol.cs
@@ -1,0 +1,3667 @@
+﻿// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Runtime.InteropServices;
+using Windows.Win32.System.Variant;
+
+// For some reason the XML comment refs for IUnknown can't be resolved on .NET Framework without
+// explicitly using the fully qualified name, which falls afoul of the simplify warning.
+using ComIUnknown = Windows.Win32.System.Com.IUnknown;
+
+namespace Microsoft.VisualStudio.Debugging.DebugInterfaceAccess;
+
+/// <inheritdoc cref="Interface"/>
+public unsafe struct IDiaSymbol : IComIID
+{
+    /// <inheritdoc cref="IComIID.Guid"/>
+#pragma warning disable IDE1006 // Naming Styles
+    public static readonly Guid IID_Guid = new(0xCB787B2F, 0xBD6C, 0x4635, 0xBA, 0x52, 0x93, 0x31, 0x26, 0xBD, 0x2D, 0xCD);
+#pragma warning restore IDE1006
+
+#if NETFRAMEWORK
+    readonly ref readonly Guid IComIID.Guid => ref IID_Guid;
+#else
+    static ref readonly Guid IComIID.Guid
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get
+        {
+            ReadOnlySpan<byte> data =
+            [
+                0x2F, 0x7B, 0x78, 0xCB,
+                0x6C, 0xBD,
+                0x35, 0x46,
+                0xBA, 0x52, 0x93, 0x31, 0x26, 0xBD, 0x2D, 0xCD
+            ];
+
+            return ref Unsafe.As<byte, Guid>(ref MemoryMarshal.GetReference(data));
+        }
+    }
+#endif
+
+    private readonly void** _lpVtbl;
+
+    /// <inheritdoc cref="ComIUnknown.QueryInterface(Guid*, void**)"/>
+    public HRESULT QueryInterface(Guid* riid, void** ppvObject)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, Guid*, void**, HRESULT>)_lpVtbl[0])(pThis, riid, ppvObject);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.AddRef"/>
+    public uint AddRef()
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, uint>)_lpVtbl[1])(pThis);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.Release"/>
+    public uint Release()
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, uint>)_lpVtbl[2])(pThis);
+    }
+
+    /// <inheritdoc cref="Interface.get_symIndexId"/>
+    public HRESULT get_symIndexId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, uint*, HRESULT>)_lpVtbl[3])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_symTag"/>
+    public HRESULT get_symTag(uint* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, uint*, HRESULT>)_lpVtbl[4])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_name"/>
+    public HRESULT get_name(BSTR* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, BSTR*, HRESULT>)_lpVtbl[5])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_lexicalParent"/>
+    public HRESULT get_lexicalParent(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, IDiaSymbol**, HRESULT>)_lpVtbl[6])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_classParent"/>
+    public HRESULT get_classParent(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, IDiaSymbol**, HRESULT>)_lpVtbl[7])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_type"/>
+    public HRESULT get_type(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, IDiaSymbol**, HRESULT>)_lpVtbl[8])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_dataKind"/>
+    public HRESULT get_dataKind(uint* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, uint*, HRESULT>)_lpVtbl[9])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_locationType"/>
+    public HRESULT get_locationType(uint* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, uint*, HRESULT>)_lpVtbl[10])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_addressSection"/>
+    public HRESULT get_addressSection(uint* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, uint*, HRESULT>)_lpVtbl[11])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_addressOffset"/>
+    public HRESULT get_addressOffset(uint* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, uint*, HRESULT>)_lpVtbl[12])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_relativeVirtualAddress"/>
+    public HRESULT get_relativeVirtualAddress(uint* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, uint*, HRESULT>)_lpVtbl[13])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_virtualAddress"/>
+    public HRESULT get_virtualAddress(ulong* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, ulong*, HRESULT>)_lpVtbl[14])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_registerId"/>
+    public HRESULT get_registerId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, uint*, HRESULT>)_lpVtbl[15])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_offset"/>
+    public HRESULT get_offset(int* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, int*, HRESULT>)_lpVtbl[16])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_length"/>
+    public HRESULT get_length(ulong* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, ulong*, HRESULT>)_lpVtbl[17])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_slot"/>
+    public HRESULT get_slot(uint* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, uint*, HRESULT>)_lpVtbl[18])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_volatileType"/>
+    public HRESULT get_volatileType(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, BOOL*, HRESULT>)_lpVtbl[19])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_constType"/>
+    public HRESULT get_constType(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, BOOL*, HRESULT>)_lpVtbl[20])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_unalignedType"/>
+    public HRESULT get_unalignedType(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, BOOL*, HRESULT>)_lpVtbl[21])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_access"/>
+    public HRESULT get_access(uint* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, uint*, HRESULT>)_lpVtbl[22])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_libraryName"/>
+    public HRESULT get_libraryName(BSTR* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, BSTR*, HRESULT>)_lpVtbl[23])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_platform"/>
+    public HRESULT get_platform(uint* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, uint*, HRESULT>)_lpVtbl[24])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_language"/>
+    public HRESULT get_language(uint* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, uint*, HRESULT>)_lpVtbl[25])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_editAndContinueEnabled"/>
+    public HRESULT get_editAndContinueEnabled(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, BOOL*, HRESULT>)_lpVtbl[26])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_frontEndMajor"/>
+    public HRESULT get_frontEndMajor(uint* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, uint*, HRESULT>)_lpVtbl[27])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_frontEndMinor"/>
+    public HRESULT get_frontEndMinor(uint* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, uint*, HRESULT>)_lpVtbl[28])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_frontEndBuild"/>
+    public HRESULT get_frontEndBuild(uint* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, uint*, HRESULT>)_lpVtbl[29])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_backEndMajor"/>
+    public HRESULT get_backEndMajor(uint* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, uint*, HRESULT>)_lpVtbl[30])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_backEndMinor"/>
+    public HRESULT get_backEndMinor(uint* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, uint*, HRESULT>)_lpVtbl[31])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_backEndBuild"/>
+    public HRESULT get_backEndBuild(uint* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, uint*, HRESULT>)_lpVtbl[32])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_sourceFileName"/>
+    public HRESULT get_sourceFileName(BSTR* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, BSTR*, HRESULT>)_lpVtbl[33])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_unused"/>
+    public HRESULT get_unused(BSTR* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, BSTR*, HRESULT>)_lpVtbl[34])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_thunkOrdinal"/>
+    public HRESULT get_thunkOrdinal(uint* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, uint*, HRESULT>)_lpVtbl[35])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_thisAdjust"/>
+    public HRESULT get_thisAdjust(int* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, int*, HRESULT>)_lpVtbl[36])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_virtualBaseOffset"/>
+    public HRESULT get_virtualBaseOffset(uint* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, uint*, HRESULT>)_lpVtbl[37])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_virtual"/>
+    public HRESULT get_virtual(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, BOOL*, HRESULT>)_lpVtbl[38])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_intro"/>
+    public HRESULT get_intro(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, BOOL*, HRESULT>)_lpVtbl[39])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_pure"/>
+    public HRESULT get_pure(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, BOOL*, HRESULT>)_lpVtbl[40])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_callingConvention"/>
+    public HRESULT get_callingConvention(uint* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, uint*, HRESULT>)_lpVtbl[41])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_value"/>
+    public HRESULT get_value(VARIANT* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, VARIANT*, HRESULT>)_lpVtbl[42])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_baseType"/>
+    public HRESULT get_baseType(uint* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, uint*, HRESULT>)_lpVtbl[43])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_token"/>
+    public HRESULT get_token(uint* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, uint*, HRESULT>)_lpVtbl[44])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_timeStamp"/>
+    public HRESULT get_timeStamp(uint* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, uint*, HRESULT>)_lpVtbl[45])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_guid"/>
+    public HRESULT get_guid(Guid* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, Guid*, HRESULT>)_lpVtbl[46])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_symbolsFileName"/>
+    public HRESULT get_symbolsFileName(BSTR* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, BSTR*, HRESULT>)_lpVtbl[47])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_reference"/>
+    public HRESULT get_reference(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, BOOL*, HRESULT>)_lpVtbl[48])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_count"/>
+    public HRESULT get_count(uint* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, uint*, HRESULT>)_lpVtbl[49])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_bitPosition"/>
+    public HRESULT get_bitPosition(uint* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, uint*, HRESULT>)_lpVtbl[50])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_arrayIndexType"/>
+    public HRESULT get_arrayIndexType(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, IDiaSymbol**, HRESULT>)_lpVtbl[51])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_packed"/>
+    public HRESULT get_packed(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, BOOL*, HRESULT>)_lpVtbl[52])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_constructor"/>
+    public HRESULT get_constructor(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, BOOL*, HRESULT>)_lpVtbl[53])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_overloadedOperator"/>
+    public HRESULT get_overloadedOperator(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, BOOL*, HRESULT>)_lpVtbl[54])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_nested"/>
+    public HRESULT get_nested(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, BOOL*, HRESULT>)_lpVtbl[55])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_hasNestedTypes"/>
+    public HRESULT get_hasNestedTypes(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, BOOL*, HRESULT>)_lpVtbl[56])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_hasAssignmentOperator"/>
+    public HRESULT get_hasAssignmentOperator(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, BOOL*, HRESULT>)_lpVtbl[57])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_hasCastOperator"/>
+    public HRESULT get_hasCastOperator(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, BOOL*, HRESULT>)_lpVtbl[58])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_scoped"/>
+    public HRESULT get_scoped(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, BOOL*, HRESULT>)_lpVtbl[59])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_virtualBaseClass"/>
+    public HRESULT get_virtualBaseClass(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, BOOL*, HRESULT>)_lpVtbl[60])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_indirectVirtualBaseClass"/>
+    public HRESULT get_indirectVirtualBaseClass(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, BOOL*, HRESULT>)_lpVtbl[61])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_virtualBasePointerOffset"/>
+    public HRESULT get_virtualBasePointerOffset(int* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, int*, HRESULT>)_lpVtbl[62])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_virtualTableShape"/>
+    public HRESULT get_virtualTableShape(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, IDiaSymbol**, HRESULT>)_lpVtbl[63])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_lexicalParentId"/>
+    public HRESULT get_lexicalParentId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, uint*, HRESULT>)_lpVtbl[64])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_classParentId"/>
+    public HRESULT get_classParentId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, uint*, HRESULT>)_lpVtbl[65])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_typeId"/>
+    public HRESULT get_typeId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, uint*, HRESULT>)_lpVtbl[66])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_arrayIndexTypeId"/>
+    public HRESULT get_arrayIndexTypeId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, uint*, HRESULT>)_lpVtbl[67])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_virtualTableShapeId"/>
+    public HRESULT get_virtualTableShapeId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, uint*, HRESULT>)_lpVtbl[68])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_code"/>
+    public HRESULT get_code(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, BOOL*, HRESULT>)_lpVtbl[69])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_function"/>
+    public HRESULT get_function(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, BOOL*, HRESULT>)_lpVtbl[70])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_managed"/>
+    public HRESULT get_managed(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, BOOL*, HRESULT>)_lpVtbl[71])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_msil"/>
+    public HRESULT get_msil(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, BOOL*, HRESULT>)_lpVtbl[72])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_virtualBaseDispIndex"/>
+    public HRESULT get_virtualBaseDispIndex(uint* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, uint*, HRESULT>)_lpVtbl[73])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_undecoratedName"/>
+    public HRESULT get_undecoratedName(BSTR* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, BSTR*, HRESULT>)_lpVtbl[74])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_age"/>
+    public HRESULT get_age(uint* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, uint*, HRESULT>)_lpVtbl[75])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_signature"/>
+    public HRESULT get_signature(uint* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, uint*, HRESULT>)_lpVtbl[76])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_compilerGenerated"/>
+    public HRESULT get_compilerGenerated(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, BOOL*, HRESULT>)_lpVtbl[77])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_addressTaken"/>
+    public HRESULT get_addressTaken(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, BOOL*, HRESULT>)_lpVtbl[78])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_rank"/>
+    public HRESULT get_rank(uint* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, uint*, HRESULT>)_lpVtbl[79])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_lowerBound"/>
+    public HRESULT get_lowerBound(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, IDiaSymbol**, HRESULT>)_lpVtbl[80])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_upperBound"/>
+    public HRESULT get_upperBound(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, IDiaSymbol**, HRESULT>)_lpVtbl[81])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_lowerBoundId"/>
+    public HRESULT get_lowerBoundId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, uint*, HRESULT>)_lpVtbl[82])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_upperBoundId"/>
+    public HRESULT get_upperBoundId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, uint*, HRESULT>)_lpVtbl[83])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_dataBytes"/>
+    public HRESULT get_dataBytes(uint cbData, uint* pcbData, byte* pbData)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, uint, uint*, byte*, HRESULT>)_lpVtbl[84])(pThis, cbData, pcbData, pbData);
+    }
+
+    /// <inheritdoc cref="Interface.findChildren"/>
+    public HRESULT findChildren(SymTagEnum symtag, PCWSTR name, uint compareFlags, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, SymTagEnum, PCWSTR, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[85])(pThis, symtag, name, compareFlags, ppResult);
+    }
+
+    /// <inheritdoc cref="Interface.findChildrenEx"/>
+    public HRESULT findChildrenEx(SymTagEnum symtag, PCWSTR name, uint compareFlags, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, SymTagEnum, PCWSTR, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[86])(pThis, symtag, name, compareFlags, ppResult);
+    }
+
+    /// <inheritdoc cref="Interface.findChildrenExByAddr"/>
+    public HRESULT findChildrenExByAddr(SymTagEnum symtag, PCWSTR name, uint compareFlags, uint isect, uint offset, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, SymTagEnum, PCWSTR, uint, uint, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[87])(pThis, symtag, name, compareFlags, isect, offset, ppResult);
+    }
+
+    /// <inheritdoc cref="Interface.findChildrenExByVA"/>
+    public HRESULT findChildrenExByVA(SymTagEnum symtag, PCWSTR name, uint compareFlags, ulong va, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, SymTagEnum, PCWSTR, uint, ulong, IDiaEnumSymbols**, HRESULT>)_lpVtbl[88])(pThis, symtag, name, compareFlags, va, ppResult);
+    }
+
+    /// <inheritdoc cref="Interface.findChildrenExByRVA"/>
+    public HRESULT findChildrenExByRVA(SymTagEnum symtag, PCWSTR name, uint compareFlags, uint rva, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, SymTagEnum, PCWSTR, uint, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[89])(pThis, symtag, name, compareFlags, rva, ppResult);
+    }
+
+    /// <inheritdoc cref="Interface.get_targetSection"/>
+    public HRESULT get_targetSection(uint* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, uint*, HRESULT>)_lpVtbl[90])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_targetOffset"/>
+    public HRESULT get_targetOffset(uint* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, uint*, HRESULT>)_lpVtbl[91])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_targetRelativeVirtualAddress"/>
+    public HRESULT get_targetRelativeVirtualAddress(uint* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, uint*, HRESULT>)_lpVtbl[92])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_targetVirtualAddress"/>
+    public HRESULT get_targetVirtualAddress(ulong* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, ulong*, HRESULT>)_lpVtbl[93])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_machineType"/>
+    public HRESULT get_machineType(uint* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, uint*, HRESULT>)_lpVtbl[94])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_oemId"/>
+    public HRESULT get_oemId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, uint*, HRESULT>)_lpVtbl[95])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_oemSymbolId"/>
+    public HRESULT get_oemSymbolId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, uint*, HRESULT>)_lpVtbl[96])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_types"/>
+    public HRESULT get_types(uint cTypes, uint* pcTypes, IDiaSymbol** pTypes)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, uint, uint*, IDiaSymbol**, HRESULT>)_lpVtbl[97])(pThis, cTypes, pcTypes, pTypes);
+    }
+
+    /// <inheritdoc cref="Interface.get_typeIds"/>
+    public HRESULT get_typeIds(uint cTypeIds, uint* pcTypeIds, uint* pdwTypeIds)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, uint, uint*, uint*, HRESULT>)_lpVtbl[98])(pThis, cTypeIds, pcTypeIds, pdwTypeIds);
+    }
+
+    /// <inheritdoc cref="Interface.get_objectPointerType"/>
+    public HRESULT get_objectPointerType(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, IDiaSymbol**, HRESULT>)_lpVtbl[99])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_udtKind"/>
+    public HRESULT get_udtKind(uint* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, uint*, HRESULT>)_lpVtbl[100])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_undecoratedNameEx"/>
+    public HRESULT get_undecoratedNameEx(uint undecorateOptions, BSTR* name)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, uint, BSTR*, HRESULT>)_lpVtbl[101])(pThis, undecorateOptions, name);
+    }
+
+    /// <inheritdoc cref="Interface.get_noReturn"/>
+    public HRESULT get_noReturn(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, BOOL*, HRESULT>)_lpVtbl[102])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_customCallingConvention"/>
+    public HRESULT get_customCallingConvention(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, BOOL*, HRESULT>)_lpVtbl[103])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_noInline"/>
+    public HRESULT get_noInline(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, BOOL*, HRESULT>)_lpVtbl[104])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_optimizedCodeDebugInfo"/>
+    public HRESULT get_optimizedCodeDebugInfo(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, BOOL*, HRESULT>)_lpVtbl[105])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_notReached"/>
+    public HRESULT get_notReached(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, BOOL*, HRESULT>)_lpVtbl[106])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_interruptReturn"/>
+    public HRESULT get_interruptReturn(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, BOOL*, HRESULT>)_lpVtbl[107])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_farReturn"/>
+    public HRESULT get_farReturn(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, BOOL*, HRESULT>)_lpVtbl[108])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_isStatic"/>
+    public HRESULT get_isStatic(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, BOOL*, HRESULT>)_lpVtbl[109])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_hasDebugInfo"/>
+    public HRESULT get_hasDebugInfo(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, BOOL*, HRESULT>)_lpVtbl[110])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_isLTCG"/>
+    public HRESULT get_isLTCG(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, BOOL*, HRESULT>)_lpVtbl[111])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_isDataAligned"/>
+    public HRESULT get_isDataAligned(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, BOOL*, HRESULT>)_lpVtbl[112])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_hasSecurityChecks"/>
+    public HRESULT get_hasSecurityChecks(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, BOOL*, HRESULT>)_lpVtbl[113])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_compilerName"/>
+    public HRESULT get_compilerName(BSTR* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, BSTR*, HRESULT>)_lpVtbl[114])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_hasAlloca"/>
+    public HRESULT get_hasAlloca(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, BOOL*, HRESULT>)_lpVtbl[115])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_hasSetJump"/>
+    public HRESULT get_hasSetJump(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, BOOL*, HRESULT>)_lpVtbl[116])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_hasLongJump"/>
+    public HRESULT get_hasLongJump(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, BOOL*, HRESULT>)_lpVtbl[117])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_hasInlAsm"/>
+    public HRESULT get_hasInlAsm(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, BOOL*, HRESULT>)_lpVtbl[118])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_hasEH"/>
+    public HRESULT get_hasEH(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, BOOL*, HRESULT>)_lpVtbl[119])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_hasSEH"/>
+    public HRESULT get_hasSEH(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, BOOL*, HRESULT>)_lpVtbl[120])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_hasEHa"/>
+    public HRESULT get_hasEHa(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, BOOL*, HRESULT>)_lpVtbl[121])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_isNaked"/>
+    public HRESULT get_isNaked(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, BOOL*, HRESULT>)_lpVtbl[122])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_isAggregated"/>
+    public HRESULT get_isAggregated(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, BOOL*, HRESULT>)_lpVtbl[123])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_isSplitted"/>
+    public HRESULT get_isSplitted(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, BOOL*, HRESULT>)_lpVtbl[124])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_container"/>
+    public HRESULT get_container(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, IDiaSymbol**, HRESULT>)_lpVtbl[125])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_inlSpec"/>
+    public HRESULT get_inlSpec(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, BOOL*, HRESULT>)_lpVtbl[126])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_noStackOrdering"/>
+    public HRESULT get_noStackOrdering(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, BOOL*, HRESULT>)_lpVtbl[127])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_virtualBaseTableType"/>
+    public HRESULT get_virtualBaseTableType(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, IDiaSymbol**, HRESULT>)_lpVtbl[128])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_hasManagedCode"/>
+    public HRESULT get_hasManagedCode(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, BOOL*, HRESULT>)_lpVtbl[129])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_isHotpatchable"/>
+    public HRESULT get_isHotpatchable(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, BOOL*, HRESULT>)_lpVtbl[130])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_isCVTCIL"/>
+    public HRESULT get_isCVTCIL(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, BOOL*, HRESULT>)_lpVtbl[131])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_isMSILNetmodule"/>
+    public HRESULT get_isMSILNetmodule(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, BOOL*, HRESULT>)_lpVtbl[132])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_isCTypes"/>
+    public HRESULT get_isCTypes(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, BOOL*, HRESULT>)_lpVtbl[133])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_isStripped"/>
+    public HRESULT get_isStripped(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, BOOL*, HRESULT>)_lpVtbl[134])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_frontEndQFE"/>
+    public HRESULT get_frontEndQFE(uint* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, uint*, HRESULT>)_lpVtbl[135])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_backEndQFE"/>
+    public HRESULT get_backEndQFE(uint* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, uint*, HRESULT>)_lpVtbl[136])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_wasInlined"/>
+    public HRESULT get_wasInlined(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, BOOL*, HRESULT>)_lpVtbl[137])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_strictGSCheck"/>
+    public HRESULT get_strictGSCheck(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, BOOL*, HRESULT>)_lpVtbl[138])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_isCxxReturnUdt"/>
+    public HRESULT get_isCxxReturnUdt(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, BOOL*, HRESULT>)_lpVtbl[139])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_isConstructorVirtualBase"/>
+    public HRESULT get_isConstructorVirtualBase(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, BOOL*, HRESULT>)_lpVtbl[140])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_RValueReference"/>
+    public HRESULT get_RValueReference(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, BOOL*, HRESULT>)_lpVtbl[141])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_unmodifiedType"/>
+    public HRESULT get_unmodifiedType(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, IDiaSymbol**, HRESULT>)_lpVtbl[142])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_framePointerPresent"/>
+    public HRESULT get_framePointerPresent(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, BOOL*, HRESULT>)_lpVtbl[143])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_isSafeBuffers"/>
+    public HRESULT get_isSafeBuffers(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, BOOL*, HRESULT>)_lpVtbl[144])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_intrinsic"/>
+    public HRESULT get_intrinsic(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, BOOL*, HRESULT>)_lpVtbl[145])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_sealed"/>
+    public HRESULT get_sealed(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, BOOL*, HRESULT>)_lpVtbl[146])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_hfaFloat"/>
+    public HRESULT get_hfaFloat(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, BOOL*, HRESULT>)_lpVtbl[147])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_hfaDouble"/>
+    public HRESULT get_hfaDouble(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, BOOL*, HRESULT>)_lpVtbl[148])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_liveRangeStartAddressSection"/>
+    public HRESULT get_liveRangeStartAddressSection(uint* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, uint*, HRESULT>)_lpVtbl[149])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_liveRangeStartAddressOffset"/>
+    public HRESULT get_liveRangeStartAddressOffset(uint* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, uint*, HRESULT>)_lpVtbl[150])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_liveRangeStartRelativeVirtualAddress"/>
+    public HRESULT get_liveRangeStartRelativeVirtualAddress(uint* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, uint*, HRESULT>)_lpVtbl[151])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_countLiveRanges"/>
+    public HRESULT get_countLiveRanges(uint* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, uint*, HRESULT>)_lpVtbl[152])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_liveRangeLength"/>
+    public HRESULT get_liveRangeLength(ulong* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, ulong*, HRESULT>)_lpVtbl[153])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_offsetInUdt"/>
+    public HRESULT get_offsetInUdt(uint* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, uint*, HRESULT>)_lpVtbl[154])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_paramBasePointerRegisterId"/>
+    public HRESULT get_paramBasePointerRegisterId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, uint*, HRESULT>)_lpVtbl[155])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_localBasePointerRegisterId"/>
+    public HRESULT get_localBasePointerRegisterId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, uint*, HRESULT>)_lpVtbl[156])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_isLocationControlFlowDependent"/>
+    public HRESULT get_isLocationControlFlowDependent(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, BOOL*, HRESULT>)_lpVtbl[157])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_stride"/>
+    public HRESULT get_stride(uint* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, uint*, HRESULT>)_lpVtbl[158])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_numberOfRows"/>
+    public HRESULT get_numberOfRows(uint* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, uint*, HRESULT>)_lpVtbl[159])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_numberOfColumns"/>
+    public HRESULT get_numberOfColumns(uint* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, uint*, HRESULT>)_lpVtbl[160])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_isMatrixRowMajor"/>
+    public HRESULT get_isMatrixRowMajor(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, BOOL*, HRESULT>)_lpVtbl[161])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_numericProperties"/>
+    public HRESULT get_numericProperties(uint cnt, uint* pcnt, uint* pProperties)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, uint, uint*, uint*, HRESULT>)_lpVtbl[162])(pThis, cnt, pcnt, pProperties);
+    }
+
+    /// <inheritdoc cref="Interface.get_modifierValues"/>
+    public HRESULT get_modifierValues(uint cnt, uint* pcnt, ushort* pModifiers)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, uint, uint*, ushort*, HRESULT>)_lpVtbl[163])(pThis, cnt, pcnt, pModifiers);
+    }
+
+    /// <inheritdoc cref="Interface.get_isReturnValue"/>
+    public HRESULT get_isReturnValue(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, BOOL*, HRESULT>)_lpVtbl[164])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_isOptimizedAway"/>
+    public HRESULT get_isOptimizedAway(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, BOOL*, HRESULT>)_lpVtbl[165])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_builtInKind"/>
+    public HRESULT get_builtInKind(uint* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, uint*, HRESULT>)_lpVtbl[166])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_registerType"/>
+    public HRESULT get_registerType(uint* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, uint*, HRESULT>)_lpVtbl[167])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_baseDataSlot"/>
+    public HRESULT get_baseDataSlot(uint* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, uint*, HRESULT>)_lpVtbl[168])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_baseDataOffset"/>
+    public HRESULT get_baseDataOffset(uint* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, uint*, HRESULT>)_lpVtbl[169])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_textureSlot"/>
+    public HRESULT get_textureSlot(uint* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, uint*, HRESULT>)_lpVtbl[170])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_samplerSlot"/>
+    public HRESULT get_samplerSlot(uint* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, uint*, HRESULT>)_lpVtbl[171])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_uavSlot"/>
+    public HRESULT get_uavSlot(uint* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, uint*, HRESULT>)_lpVtbl[172])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_sizeInUdt"/>
+    public HRESULT get_sizeInUdt(uint* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, uint*, HRESULT>)_lpVtbl[173])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_memorySpaceKind"/>
+    public HRESULT get_memorySpaceKind(uint* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, uint*, HRESULT>)_lpVtbl[174])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_unmodifiedTypeId"/>
+    public HRESULT get_unmodifiedTypeId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, uint*, HRESULT>)_lpVtbl[175])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_subTypeId"/>
+    public HRESULT get_subTypeId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, uint*, HRESULT>)_lpVtbl[176])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_subType"/>
+    public HRESULT get_subType(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, IDiaSymbol**, HRESULT>)_lpVtbl[177])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_numberOfModifiers"/>
+    public HRESULT get_numberOfModifiers(uint* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, uint*, HRESULT>)_lpVtbl[178])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_numberOfRegisterIndices"/>
+    public HRESULT get_numberOfRegisterIndices(uint* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, uint*, HRESULT>)_lpVtbl[179])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_isHLSLData"/>
+    public HRESULT get_isHLSLData(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, BOOL*, HRESULT>)_lpVtbl[180])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_isPointerToDataMember"/>
+    public HRESULT get_isPointerToDataMember(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, BOOL*, HRESULT>)_lpVtbl[181])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_isPointerToMemberFunction"/>
+    public HRESULT get_isPointerToMemberFunction(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, BOOL*, HRESULT>)_lpVtbl[182])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_isSingleInheritance"/>
+    public HRESULT get_isSingleInheritance(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, BOOL*, HRESULT>)_lpVtbl[183])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_isMultipleInheritance"/>
+    public HRESULT get_isMultipleInheritance(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, BOOL*, HRESULT>)_lpVtbl[184])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_isVirtualInheritance"/>
+    public HRESULT get_isVirtualInheritance(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, BOOL*, HRESULT>)_lpVtbl[185])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_restrictedType"/>
+    public HRESULT get_restrictedType(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, BOOL*, HRESULT>)_lpVtbl[186])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_isPointerBasedOnSymbolValue"/>
+    public HRESULT get_isPointerBasedOnSymbolValue(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, BOOL*, HRESULT>)_lpVtbl[187])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_baseSymbol"/>
+    public HRESULT get_baseSymbol(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, IDiaSymbol**, HRESULT>)_lpVtbl[188])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_baseSymbolId"/>
+    public HRESULT get_baseSymbolId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, uint*, HRESULT>)_lpVtbl[189])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_objectFileName"/>
+    public HRESULT get_objectFileName(BSTR* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, BSTR*, HRESULT>)_lpVtbl[190])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_isAcceleratorGroupSharedLocal"/>
+    public HRESULT get_isAcceleratorGroupSharedLocal(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, BOOL*, HRESULT>)_lpVtbl[191])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_isAcceleratorPointerTagLiveRange"/>
+    public HRESULT get_isAcceleratorPointerTagLiveRange(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, BOOL*, HRESULT>)_lpVtbl[192])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_isAcceleratorStubFunction"/>
+    public HRESULT get_isAcceleratorStubFunction(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, BOOL*, HRESULT>)_lpVtbl[193])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_numberOfAcceleratorPointerTags"/>
+    public HRESULT get_numberOfAcceleratorPointerTags(uint* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, uint*, HRESULT>)_lpVtbl[194])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_isSdl"/>
+    public HRESULT get_isSdl(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, BOOL*, HRESULT>)_lpVtbl[195])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_isWinRTPointer"/>
+    public HRESULT get_isWinRTPointer(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, BOOL*, HRESULT>)_lpVtbl[196])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_isRefUdt"/>
+    public HRESULT get_isRefUdt(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, BOOL*, HRESULT>)_lpVtbl[197])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_isValueUdt"/>
+    public HRESULT get_isValueUdt(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, BOOL*, HRESULT>)_lpVtbl[198])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_isInterfaceUdt"/>
+    public HRESULT get_isInterfaceUdt(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, BOOL*, HRESULT>)_lpVtbl[199])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.findInlineFramesByAddr"/>
+    public HRESULT findInlineFramesByAddr(uint isect, uint offset, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, uint, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[200])(pThis, isect, offset, ppResult);
+    }
+
+    /// <inheritdoc cref="Interface.findInlineFramesByRVA"/>
+    public HRESULT findInlineFramesByRVA(uint rva, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[201])(pThis, rva, ppResult);
+    }
+
+    /// <inheritdoc cref="Interface.findInlineFramesByVA"/>
+    public HRESULT findInlineFramesByVA(ulong va, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, ulong, IDiaEnumSymbols**, HRESULT>)_lpVtbl[202])(pThis, va, ppResult);
+    }
+
+    /// <inheritdoc cref="Interface.findInlineeLines"/>
+    public HRESULT findInlineeLines(IDiaEnumLineNumbers** ppResult)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, IDiaEnumLineNumbers**, HRESULT>)_lpVtbl[203])(pThis, ppResult);
+    }
+
+    /// <inheritdoc cref="Interface.findInlineeLinesByAddr"/>
+    public HRESULT findInlineeLinesByAddr(uint isect, uint offset, uint length, IDiaEnumLineNumbers** ppResult)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, uint, uint, uint, IDiaEnumLineNumbers**, HRESULT>)_lpVtbl[204])(pThis, isect, offset, length, ppResult);
+    }
+
+    /// <inheritdoc cref="Interface.findInlineeLinesByRVA"/>
+    public HRESULT findInlineeLinesByRVA(uint rva, uint length, IDiaEnumLineNumbers** ppResult)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, uint, uint, IDiaEnumLineNumbers**, HRESULT>)_lpVtbl[205])(pThis, rva, length, ppResult);
+    }
+
+    /// <inheritdoc cref="Interface.findInlineeLinesByVA"/>
+    public HRESULT findInlineeLinesByVA(ulong va, uint length, IDiaEnumLineNumbers** ppResult)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, ulong, uint, IDiaEnumLineNumbers**, HRESULT>)_lpVtbl[206])(pThis, va, length, ppResult);
+    }
+
+    /// <inheritdoc cref="Interface.findSymbolsForAcceleratorPointerTag"/>
+    public HRESULT findSymbolsForAcceleratorPointerTag(uint tagValue, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[207])(pThis, tagValue, ppResult);
+    }
+
+    /// <inheritdoc cref="Interface.findSymbolsByRVAForAcceleratorPointerTag"/>
+    public HRESULT findSymbolsByRVAForAcceleratorPointerTag(uint tagValue, uint rva, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, uint, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[208])(pThis, tagValue, rva, ppResult);
+    }
+
+    /// <inheritdoc cref="Interface.get_acceleratorPointerTags"/>
+    public HRESULT get_acceleratorPointerTags(uint cnt, uint* pcnt, uint* pPointerTags)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, uint, uint*, uint*, HRESULT>)_lpVtbl[209])(pThis, cnt, pcnt, pPointerTags);
+    }
+
+    /// <inheritdoc cref="Interface.getSrcLineOnTypeDefn"/>
+    public HRESULT getSrcLineOnTypeDefn(IDiaLineNumber** ppResult)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, IDiaLineNumber**, HRESULT>)_lpVtbl[210])(pThis, ppResult);
+    }
+
+    /// <inheritdoc cref="Interface.get_isPGO"/>
+    public HRESULT get_isPGO(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, BOOL*, HRESULT>)_lpVtbl[211])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_hasValidPGOCounts"/>
+    public HRESULT get_hasValidPGOCounts(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, BOOL*, HRESULT>)_lpVtbl[212])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_isOptimizedForSpeed"/>
+    public HRESULT get_isOptimizedForSpeed(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, BOOL*, HRESULT>)_lpVtbl[213])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_PGOEntryCount"/>
+    public HRESULT get_PGOEntryCount(uint* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, uint*, HRESULT>)_lpVtbl[214])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_PGOEdgeCount"/>
+    public HRESULT get_PGOEdgeCount(uint* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, uint*, HRESULT>)_lpVtbl[215])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_PGODynamicInstructionCount"/>
+    public HRESULT get_PGODynamicInstructionCount(ulong* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, ulong*, HRESULT>)_lpVtbl[216])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_staticSize"/>
+    public HRESULT get_staticSize(uint* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, uint*, HRESULT>)_lpVtbl[217])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_finalLiveStaticSize"/>
+    public HRESULT get_finalLiveStaticSize(uint* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, uint*, HRESULT>)_lpVtbl[218])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_phaseName"/>
+    public HRESULT get_phaseName(BSTR* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, BSTR*, HRESULT>)_lpVtbl[219])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_hasControlFlowCheck"/>
+    public HRESULT get_hasControlFlowCheck(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, BOOL*, HRESULT>)_lpVtbl[220])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_constantExport"/>
+    public HRESULT get_constantExport(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, BOOL*, HRESULT>)_lpVtbl[221])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_dataExport"/>
+    public HRESULT get_dataExport(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, BOOL*, HRESULT>)_lpVtbl[222])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_privateExport"/>
+    public HRESULT get_privateExport(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, BOOL*, HRESULT>)_lpVtbl[223])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_noNameExport"/>
+    public HRESULT get_noNameExport(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, BOOL*, HRESULT>)_lpVtbl[224])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_exportHasExplicitlyAssignedOrdinal"/>
+    public HRESULT get_exportHasExplicitlyAssignedOrdinal(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, BOOL*, HRESULT>)_lpVtbl[225])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_exportIsForwarder"/>
+    public HRESULT get_exportIsForwarder(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, BOOL*, HRESULT>)_lpVtbl[226])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_ordinal"/>
+    public HRESULT get_ordinal(uint* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, uint*, HRESULT>)_lpVtbl[227])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_frameSize"/>
+    public HRESULT get_frameSize(uint* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, uint*, HRESULT>)_lpVtbl[228])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_exceptionHandlerAddressSection"/>
+    public HRESULT get_exceptionHandlerAddressSection(uint* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, uint*, HRESULT>)_lpVtbl[229])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_exceptionHandlerAddressOffset"/>
+    public HRESULT get_exceptionHandlerAddressOffset(uint* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, uint*, HRESULT>)_lpVtbl[230])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_exceptionHandlerRelativeVirtualAddress"/>
+    public HRESULT get_exceptionHandlerRelativeVirtualAddress(uint* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, uint*, HRESULT>)_lpVtbl[231])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_exceptionHandlerVirtualAddress"/>
+    public HRESULT get_exceptionHandlerVirtualAddress(ulong* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, ulong*, HRESULT>)_lpVtbl[232])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.findInputAssemblyFile"/>
+    public HRESULT findInputAssemblyFile(IDiaInputAssemblyFile** ppResult)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, IDiaInputAssemblyFile**, HRESULT>)_lpVtbl[233])(pThis, ppResult);
+    }
+
+    /// <inheritdoc cref="Interface.get_characteristics"/>
+    public HRESULT get_characteristics(uint* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, uint*, HRESULT>)_lpVtbl[234])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_coffGroup"/>
+    public HRESULT get_coffGroup(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, IDiaSymbol**, HRESULT>)_lpVtbl[235])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_bindID"/>
+    public HRESULT get_bindID(uint* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, uint*, HRESULT>)_lpVtbl[236])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_bindSpace"/>
+    public HRESULT get_bindSpace(uint* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, uint*, HRESULT>)_lpVtbl[237])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_bindSlot"/>
+    public HRESULT get_bindSlot(uint* pRetVal)
+    {
+        fixed (IDiaSymbol* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol*, uint*, HRESULT>)_lpVtbl[238])(pThis, pRetVal);
+    }
+
+    /// <summary>
+    ///  Represents one block, file, function, or any of the other types of symbol information.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/visualstudio/debugger/debug-interface-access/idiasymbol">
+    ///    Official documentation.
+    ///   </see>
+    ///  </para>
+    /// </remarks>
+    [ComImport]
+    [Guid("CB787B2F-BD6C-4635-BA52-933126BD2DCD")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    public unsafe interface Interface
+    {
+        /// <summary>
+        ///  Unique symbol identifier.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_symIndexId(uint* pRetVal);
+
+        /// <summary>
+        ///  Symbol kind tag.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_symTag(uint* pRetVal);
+
+        /// <summary>
+        ///  Name.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_name(BSTR* pRetVal);
+
+        /// <summary>
+        ///  Lexical parent symbol.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_lexicalParent(IDiaSymbol** pRetVal);
+
+        /// <summary>
+        ///  Retrieves the class parent.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_classParent(IDiaSymbol** pRetVal);
+
+        /// <summary>
+        ///  Retrieves the type.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_type(IDiaSymbol** pRetVal);
+
+        /// <summary>
+        ///  Retrieves the data kind.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_dataKind(uint* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the location type.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_locationType(uint* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the address section.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_addressSection(uint* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the address offset.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_addressOffset(uint* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the relative virtual address.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_relativeVirtualAddress(uint* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the virtual address.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_virtualAddress(ulong* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the register id.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_registerId(uint* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the offset.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_offset(int* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the length.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_length(ulong* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the slot.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_slot(uint* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the volatile type.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_volatileType(BOOL* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the const type.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_constType(BOOL* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the unaligned type.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_unalignedType(BOOL* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the access.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_access(uint* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the library name.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_libraryName(BSTR* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the platform.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_platform(uint* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the language.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_language(uint* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the edit and continue enabled.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_editAndContinueEnabled(BOOL* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the front end major.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_frontEndMajor(uint* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the front end minor.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_frontEndMinor(uint* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the front end build.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_frontEndBuild(uint* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the back end major.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_backEndMajor(uint* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the back end minor.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_backEndMinor(uint* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the back end build.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_backEndBuild(uint* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the source file name.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_sourceFileName(BSTR* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the unused.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_unused(BSTR* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the thunk ordinal.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_thunkOrdinal(uint* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the this adjust.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_thisAdjust(int* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the virtual base offset.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_virtualBaseOffset(uint* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the virtual.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_virtual(BOOL* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the intro.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_intro(BOOL* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the pure.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_pure(BOOL* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the calling convention.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_callingConvention(uint* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the value.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_value(VARIANT* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the base type.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_baseType(uint* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the token.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_token(uint* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the time stamp.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_timeStamp(uint* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the guid.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_guid(Guid* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the symbols file name.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_symbolsFileName(BSTR* pRetVal);
+
+        /// <summary>
+        ///  Retrieves a flag that specifies whether the pointer is a traditional (l-value) reference.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_reference(BOOL* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the count.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_count(uint* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the bit position.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_bitPosition(uint* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the array index type.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_arrayIndexType(IDiaSymbol** pRetVal);
+
+        /// <summary>
+        ///  Retrieves a flag that specifies whether the user-defined type (UDT) is packed.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_packed(BOOL* pRetVal);
+
+        /// <summary>
+        ///  UDT has constructor or destructor, or func is a constructor.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_constructor(BOOL* pRetVal);
+
+        /// <summary>
+        ///  Retrieves a flag that specifies whether the user-defined type (UDT) has overloaded operators.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_overloadedOperator(BOOL* pRetVal);
+
+        /// <summary>
+        ///  Retrieves a flag that specifies whether the user-defined type (UDT) is nested.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_nested(BOOL* pRetVal);
+
+        /// <summary>
+        ///  Retrieves a flag that specifies whether the user-defined type (UDT) has nested type definitions.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_hasNestedTypes(BOOL* pRetVal);
+
+        /// <summary>
+        ///  Retrieves a flag that specifies whether the user-defined type (UDT) has an overloaded assignment operator.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_hasAssignmentOperator(BOOL* pRetVal);
+
+        /// <summary>
+        ///  Retrieves a flag that specifies whether the user-defined type (UDT) has cast operators.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_hasCastOperator(BOOL* pRetVal);
+
+        /// <summary>
+        ///  Retrieves a flag that specifies whether the user-defined type (UDT) appears in a nonglobal lexical scope.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_scoped(BOOL* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the virtual base class.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_virtualBaseClass(BOOL* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the indirect virtual base class.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_indirectVirtualBaseClass(BOOL* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the virtual base pointer offset.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_virtualBasePointerOffset(int* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the virtual table shape.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_virtualTableShape(IDiaSymbol** pRetVal);
+
+        /// <summary>
+        ///  Lexical parent symbol.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_lexicalParentId(uint* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the class parent id.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_classParentId(uint* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the type id.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_typeId(uint* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the array index type id.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_arrayIndexTypeId(uint* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the virtual table shape id.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_virtualTableShapeId(uint* pRetVal);
+
+        /// <summary>
+        ///  Symbol refers to a code address.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_code(BOOL* pRetVal);
+
+        /// <summary>
+        ///  Symbol refers to a function.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_function(BOOL* pRetVal);
+
+        /// <summary>
+        ///  Symbol refers to managed code.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_managed(BOOL* pRetVal);
+
+        /// <summary>
+        ///  Symbol refers to MSIL code.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_msil(BOOL* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the virtual base disp index.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_virtualBaseDispIndex(uint* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the undecorated name.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_undecoratedName(BSTR* pRetVal);
+
+        /// <summary>
+        ///  PDB file age.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_age(uint* pRetVal);
+
+        /// <summary>
+        ///  Signature.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_signature(uint* pRetVal);
+
+        /// <summary>
+        ///  Symbol or function is compiler generated.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_compilerGenerated(BOOL* pRetVal);
+
+        /// <summary>
+        ///  Symbol is address taken.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_addressTaken(BOOL* pRetVal);
+
+        /// <summary>
+        ///  Rank of FORTRAN multi-dimension array.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_rank(uint* pRetVal);
+
+        /// <summary>
+        ///  Lower bound of a FORTRAN array dimension.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_lowerBound(IDiaSymbol** pRetVal);
+
+        /// <summary>
+        ///  Upper bound of a FORTRAN array dimension.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_upperBound(IDiaSymbol** pRetVal);
+
+        /// <summary>
+        ///  Symbol Id of the lower bound of a FORTRAN array dimension.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_lowerBoundId(uint* pRetVal);
+
+        /// <summary>
+        ///  Symbol Id of the upper bound of a FORTRAN array dimension.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_upperBoundId(uint* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the data bytes.
+        /// </summary>
+        /// <param name="cbData">The size, in bytes, of the buffer.</param>
+        /// <param name="pcbData">Pointer to a variable that receives the number of bytes written to the buffer.</param>
+        /// <param name="pbData">Pointer to a caller-allocated buffer that receives the data.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_dataBytes(uint cbData, uint* pcbData, byte* pbData);
+
+        /// <summary>
+        ///  Find children.
+        /// </summary>
+        /// <param name="symtag">The symbol tag that restricts the kinds of symbols returned, or SymTagNull to match all symbols.</param>
+        /// <param name="name">The name value.</param>
+        /// <param name="compareFlags">A combination of name-comparison flags that control how the name is matched.</param>
+        /// <param name="ppResult">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT findChildren(SymTagEnum symtag, PCWSTR name, uint compareFlags, IDiaEnumSymbols** ppResult);
+
+        /// <summary>
+        ///  Find children ex.
+        /// </summary>
+        /// <param name="symtag">The symbol tag that restricts the kinds of symbols returned, or SymTagNull to match all symbols.</param>
+        /// <param name="name">The name value.</param>
+        /// <param name="compareFlags">A combination of name-comparison flags that control how the name is matched.</param>
+        /// <param name="ppResult">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT findChildrenEx(SymTagEnum symtag, PCWSTR name, uint compareFlags, IDiaEnumSymbols** ppResult);
+
+        /// <summary>
+        ///  Find children ex by addr.
+        /// </summary>
+        /// <param name="symtag">The symbol tag that restricts the kinds of symbols returned, or SymTagNull to match all symbols.</param>
+        /// <param name="name">The name value.</param>
+        /// <param name="compareFlags">A combination of name-comparison flags that control how the name is matched.</param>
+        /// <param name="isect">The section index component of the address.</param>
+        /// <param name="offset">The offset component of the address within the section.</param>
+        /// <param name="ppResult">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT findChildrenExByAddr(SymTagEnum symtag, PCWSTR name, uint compareFlags, uint isect, uint offset, IDiaEnumSymbols** ppResult);
+
+        /// <summary>
+        ///  Find children ex by va.
+        /// </summary>
+        /// <param name="symtag">The symbol tag that restricts the kinds of symbols returned, or SymTagNull to match all symbols.</param>
+        /// <param name="name">The name value.</param>
+        /// <param name="compareFlags">A combination of name-comparison flags that control how the name is matched.</param>
+        /// <param name="va">The virtual address (VA).</param>
+        /// <param name="ppResult">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT findChildrenExByVA(SymTagEnum symtag, PCWSTR name, uint compareFlags, ulong va, IDiaEnumSymbols** ppResult);
+
+        /// <summary>
+        ///  Find children ex by rva.
+        /// </summary>
+        /// <param name="symtag">The symbol tag that restricts the kinds of symbols returned, or SymTagNull to match all symbols.</param>
+        /// <param name="name">The name value.</param>
+        /// <param name="compareFlags">A combination of name-comparison flags that control how the name is matched.</param>
+        /// <param name="rva">The relative virtual address (RVA).</param>
+        /// <param name="ppResult">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT findChildrenExByRVA(SymTagEnum symtag, PCWSTR name, uint compareFlags, uint rva, IDiaEnumSymbols** ppResult);
+
+        /// <summary>
+        ///  Thunk target address section.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_targetSection(uint* pRetVal);
+
+        /// <summary>
+        ///  Thunk target address offset.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_targetOffset(uint* pRetVal);
+
+        /// <summary>
+        ///  Thunk target RVA.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_targetRelativeVirtualAddress(uint* pRetVal);
+
+        /// <summary>
+        ///  Thunk target virtual address.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_targetVirtualAddress(ulong* pRetVal);
+
+        /// <summary>
+        ///  Target machine type.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_machineType(uint* pRetVal);
+
+        /// <summary>
+        ///  Identifier of manufacturer.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_oemId(uint* pRetVal);
+
+        /// <summary>
+        ///  Manufacturer defined custom symbol identifier.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_oemSymbolId(uint* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the types.
+        /// </summary>
+        /// <param name="cTypes">The cTypes value.</param>
+        /// <param name="pcTypes">Pointer to a variable that receives the requested value.</param>
+        /// <param name="pTypes">Pointer to a caller-allocated buffer that receives the data.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_types(uint cTypes, uint* pcTypes, IDiaSymbol** pTypes);
+
+        /// <summary>
+        ///  Retrieves the type ids.
+        /// </summary>
+        /// <param name="cTypeIds">The cTypeIds value.</param>
+        /// <param name="pcTypeIds">Pointer to a variable that receives the requested value.</param>
+        /// <param name="pdwTypeIds">Pointer to a caller-allocated buffer that receives the data.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_typeIds(uint cTypeIds, uint* pcTypeIds, uint* pdwTypeIds);
+
+        /// <summary>
+        ///  Type of method's object pointer.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_objectPointerType(IDiaSymbol** pRetVal);
+
+        /// <summary>
+        ///  Struct, union, class or interface.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_udtKind(uint* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the undecorated name ex.
+        /// </summary>
+        /// <param name="undecorateOptions">The undecorateOptions value.</param>
+        /// <param name="name">Pointer to a variable that receives the requested value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_undecoratedNameEx(uint undecorateOptions, BSTR* name);
+
+        /// <summary>
+        ///  NoReturn.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_noReturn(BOOL* pRetVal);
+
+        /// <summary>
+        ///  Uses custom calling convention.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_customCallingConvention(BOOL* pRetVal);
+
+        /// <summary>
+        ///  NoInline.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_noInline(BOOL* pRetVal);
+
+        /// <summary>
+        ///  Has debugging Info for optimized code.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_optimizedCodeDebugInfo(BOOL* pRetVal);
+
+        /// <summary>
+        ///  Unreachable.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_notReached(BOOL* pRetVal);
+
+        /// <summary>
+        ///  Return from interrupt.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_interruptReturn(BOOL* pRetVal);
+
+        /// <summary>
+        ///  Far return.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_farReturn(BOOL* pRetVal);
+
+        /// <summary>
+        ///  Static function.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_isStatic(BOOL* pRetVal);
+
+        /// <summary>
+        ///  HasDebugInfo.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_hasDebugInfo(BOOL* pRetVal);
+
+        /// <summary>
+        ///  Compiled With LTCG.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_isLTCG(BOOL* pRetVal);
+
+        /// <summary>
+        ///  Is it compiled with -Bzalign.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_isDataAligned(BOOL* pRetVal);
+
+        /// <summary>
+        ///  HasSecurityChecks.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_hasSecurityChecks(BOOL* pRetVal);
+
+        /// <summary>
+        ///  Compiler name.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_compilerName(BSTR* pRetVal);
+
+        /// <summary>
+        ///  HasAlloca.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_hasAlloca(BOOL* pRetVal);
+
+        /// <summary>
+        ///  HasSetJump.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_hasSetJump(BOOL* pRetVal);
+
+        /// <summary>
+        ///  HasLongJump.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_hasLongJump(BOOL* pRetVal);
+
+        /// <summary>
+        ///  HasInlineAssembly.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_hasInlAsm(BOOL* pRetVal);
+
+        /// <summary>
+        ///  HasC++EH.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_hasEH(BOOL* pRetVal);
+
+        /// <summary>
+        ///  HasStructuredEH.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_hasSEH(BOOL* pRetVal);
+
+        /// <summary>
+        ///  HasAsynchronousEH.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_hasEHa(BOOL* pRetVal);
+
+        /// <summary>
+        ///  IsNaked.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_isNaked(BOOL* pRetVal);
+
+        /// <summary>
+        ///  IsAggregated.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_isAggregated(BOOL* pRetVal);
+
+        /// <summary>
+        ///  IsSplitted.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_isSplitted(BOOL* pRetVal);
+
+        /// <summary>
+        ///  Container.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_container(IDiaSymbol** pRetVal);
+
+        /// <summary>
+        ///  WasSpecifiedAsInline.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_inlSpec(BOOL* pRetVal);
+
+        /// <summary>
+        ///  BufferChecksWithoutOrdering.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_noStackOrdering(BOOL* pRetVal);
+
+        /// <summary>
+        ///  Type of Virtual Base Offset Table.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_virtualBaseTableType(IDiaSymbol** pRetVal);
+
+        /// <summary>
+        ///  HasManagedCode.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_hasManagedCode(BOOL* pRetVal);
+
+        /// <summary>
+        ///  IsHotpatchable.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_isHotpatchable(BOOL* pRetVal);
+
+        /// <summary>
+        ///  IsCVTCIL.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_isCVTCIL(BOOL* pRetVal);
+
+        /// <summary>
+        ///  IsMSILNetmodule.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_isMSILNetmodule(BOOL* pRetVal);
+
+        /// <summary>
+        ///  IsCTypes.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_isCTypes(BOOL* pRetVal);
+
+        /// <summary>
+        ///  IsStripped.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_isStripped(BOOL* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the front end qfe.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_frontEndQFE(uint* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the back end qfe.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_backEndQFE(uint* pRetVal);
+
+        /// <summary>
+        ///  WasInlined.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_wasInlined(BOOL* pRetVal);
+
+        /// <summary>
+        ///  StrictGSCheck.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_strictGSCheck(BOOL* pRetVal);
+
+        /// <summary>
+        ///  Return C++ style UDT.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_isCxxReturnUdt(BOOL* pRetVal);
+
+        /// <summary>
+        ///  Instance constructor of a class with virtual base.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_isConstructorVirtualBase(BOOL* pRetVal);
+
+        /// <summary>
+        ///  Retrieves a flag that specifies whether the pointer is an r-value reference.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_RValueReference(BOOL* pRetVal);
+
+        /// <summary>
+        ///  Unmodified type.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_unmodifiedType(IDiaSymbol** pRetVal);
+
+        /// <summary>
+        ///  Frame pointer present.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_framePointerPresent(BOOL* pRetVal);
+
+        /// <summary>
+        ///  IsSafeBuffers.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_isSafeBuffers(BOOL* pRetVal);
+
+        /// <summary>
+        ///  Retrieves a flag that specifies whether the user-defined type (UDT) is an intrinsic type.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_intrinsic(BOOL* pRetVal);
+
+        /// <summary>
+        ///  Can't be base class, or method can't be overridden.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_sealed(BOOL* pRetVal);
+
+        /// <summary>
+        ///  HFA float.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_hfaFloat(BOOL* pRetVal);
+
+        /// <summary>
+        ///  HFA double.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_hfaDouble(BOOL* pRetVal);
+
+        /// <summary>
+        ///  LiveRangeStartAddressSection.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_liveRangeStartAddressSection(uint* pRetVal);
+
+        /// <summary>
+        ///  LiveRangeStartAddressOffset.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_liveRangeStartAddressOffset(uint* pRetVal);
+
+        /// <summary>
+        ///  LiveRangeStartRelativeVirtualAddress.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_liveRangeStartRelativeVirtualAddress(uint* pRetVal);
+
+        /// <summary>
+        ///  Number of live ranges.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_countLiveRanges(uint* pRetVal);
+
+        /// <summary>
+        ///  Length of live range.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_liveRangeLength(ulong* pRetVal);
+
+        /// <summary>
+        ///  Offset into UDT.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_offsetInUdt(uint* pRetVal);
+
+        /// <summary>
+        ///  ID of the register holding base pointer to parameters.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_paramBasePointerRegisterId(uint* pRetVal);
+
+        /// <summary>
+        ///  ID of the register holding base pointer to locals.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_localBasePointerRegisterId(uint* pRetVal);
+
+        /// <summary>
+        ///  Location is dependent on control flow.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_isLocationControlFlowDependent(BOOL* pRetVal);
+
+        /// <summary>
+        ///  Stride.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_stride(uint* pRetVal);
+
+        /// <summary>
+        ///  Number of rows in a matrix.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_numberOfRows(uint* pRetVal);
+
+        /// <summary>
+        ///  Number of columns in a matrix.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_numberOfColumns(uint* pRetVal);
+
+        /// <summary>
+        ///  Matrix is row major.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_isMatrixRowMajor(BOOL* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the numeric properties.
+        /// </summary>
+        /// <param name="cnt">The cnt value.</param>
+        /// <param name="pcnt">Pointer to a variable that receives the requested value.</param>
+        /// <param name="pProperties">Pointer to a caller-allocated buffer that receives the data.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_numericProperties(uint cnt, uint* pcnt, uint* pProperties);
+
+        /// <summary>
+        ///  Retrieves the modifier values.
+        /// </summary>
+        /// <param name="cnt">The cnt value.</param>
+        /// <param name="pcnt">Pointer to a variable that receives the requested value.</param>
+        /// <param name="pModifiers">Pointer to a caller-allocated buffer that receives the data.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_modifierValues(uint cnt, uint* pcnt, ushort* pModifiers);
+
+        /// <summary>
+        ///  This variable holds return value.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_isReturnValue(BOOL* pRetVal);
+
+        /// <summary>
+        ///  This variable is optimized away.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_isOptimizedAway(BOOL* pRetVal);
+
+        /// <summary>
+        ///  Built in type kind.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_builtInKind(uint* pRetVal);
+
+        /// <summary>
+        ///  Register type kind.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_registerType(uint* pRetVal);
+
+        /// <summary>
+        ///  Base data slot.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_baseDataSlot(uint* pRetVal);
+
+        /// <summary>
+        ///  Base data offset start.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_baseDataOffset(uint* pRetVal);
+
+        /// <summary>
+        ///  Texture slot start.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_textureSlot(uint* pRetVal);
+
+        /// <summary>
+        ///  Sampler slot start.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_samplerSlot(uint* pRetVal);
+
+        /// <summary>
+        ///  UAV slot start.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_uavSlot(uint* pRetVal);
+
+        /// <summary>
+        ///  Size in UDT.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_sizeInUdt(uint* pRetVal);
+
+        /// <summary>
+        ///  Memory space kind.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_memorySpaceKind(uint* pRetVal);
+
+        /// <summary>
+        ///  Unmodified type ID.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_unmodifiedTypeId(uint* pRetVal);
+
+        /// <summary>
+        ///  Sub type ID.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_subTypeId(uint* pRetVal);
+
+        /// <summary>
+        ///  Sub type.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_subType(IDiaSymbol** pRetVal);
+
+        /// <summary>
+        ///  Number of modifiers.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_numberOfModifiers(uint* pRetVal);
+
+        /// <summary>
+        ///  Number of HLSL register indices.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_numberOfRegisterIndices(uint* pRetVal);
+
+        /// <summary>
+        ///  Is HLSL data.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_isHLSLData(BOOL* pRetVal);
+
+        /// <summary>
+        ///  Is pointer to data member.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_isPointerToDataMember(BOOL* pRetVal);
+
+        /// <summary>
+        ///  Is pointer to member function.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_isPointerToMemberFunction(BOOL* pRetVal);
+
+        /// <summary>
+        ///  Is single inheritance.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_isSingleInheritance(BOOL* pRetVal);
+
+        /// <summary>
+        ///  Is multiple inheritance.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_isMultipleInheritance(BOOL* pRetVal);
+
+        /// <summary>
+        ///  Is virtual inheritance.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_isVirtualInheritance(BOOL* pRetVal);
+
+        /// <summary>
+        ///  Retrieves the restricted type.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_restrictedType(BOOL* pRetVal);
+
+        /// <summary>
+        ///  Pointer based on value of a symbol.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_isPointerBasedOnSymbolValue(BOOL* pRetVal);
+
+        /// <summary>
+        ///  Base symbol for base pointer.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_baseSymbol(IDiaSymbol** pRetVal);
+
+        /// <summary>
+        ///  ID of base symbol for base pointer.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_baseSymbolId(uint* pRetVal);
+
+        /// <summary>
+        ///  Object file name.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_objectFileName(BSTR* pRetVal);
+
+        /// <summary>
+        ///  Is Accelerator group shared local.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_isAcceleratorGroupSharedLocal(BOOL* pRetVal);
+
+        /// <summary>
+        ///  Is live range of Accelerator pointer tag.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_isAcceleratorPointerTagLiveRange(BOOL* pRetVal);
+
+        /// <summary>
+        ///  Is Accelerator stub function.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_isAcceleratorStubFunction(BOOL* pRetVal);
+
+        /// <summary>
+        ///  Number of Accelerator pointer tags.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_numberOfAcceleratorPointerTags(uint* pRetVal);
+
+        /// <summary>
+        ///  Compiled with /sdl.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_isSdl(BOOL* pRetVal);
+
+        /// <summary>
+        ///  Is WinRT pointer.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_isWinRTPointer(BOOL* pRetVal);
+
+        /// <summary>
+        ///  Is ref class/struct.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_isRefUdt(BOOL* pRetVal);
+
+        /// <summary>
+        ///  Is value class/struct.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_isValueUdt(BOOL* pRetVal);
+
+        /// <summary>
+        ///  Is interface class/struct.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_isInterfaceUdt(BOOL* pRetVal);
+
+        /// <summary>
+        ///  Find inline frames by addr.
+        /// </summary>
+        /// <param name="isect">The section index component of the address.</param>
+        /// <param name="offset">The offset component of the address within the section.</param>
+        /// <param name="ppResult">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT findInlineFramesByAddr(uint isect, uint offset, IDiaEnumSymbols** ppResult);
+
+        /// <summary>
+        ///  Find inline frames by rva.
+        /// </summary>
+        /// <param name="rva">The relative virtual address (RVA).</param>
+        /// <param name="ppResult">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT findInlineFramesByRVA(uint rva, IDiaEnumSymbols** ppResult);
+
+        /// <summary>
+        ///  Find inline frames by va.
+        /// </summary>
+        /// <param name="va">The virtual address (VA).</param>
+        /// <param name="ppResult">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT findInlineFramesByVA(ulong va, IDiaEnumSymbols** ppResult);
+
+        /// <summary>
+        ///  Find inlinee lines.
+        /// </summary>
+        /// <param name="ppResult">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT findInlineeLines(IDiaEnumLineNumbers** ppResult);
+
+        /// <summary>
+        ///  Find inlinee lines by addr.
+        /// </summary>
+        /// <param name="isect">The section index component of the address.</param>
+        /// <param name="offset">The offset component of the address within the section.</param>
+        /// <param name="length">The number of bytes in the address range.</param>
+        /// <param name="ppResult">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT findInlineeLinesByAddr(uint isect, uint offset, uint length, IDiaEnumLineNumbers** ppResult);
+
+        /// <summary>
+        ///  Find inlinee lines by rva.
+        /// </summary>
+        /// <param name="rva">The relative virtual address (RVA).</param>
+        /// <param name="length">The number of bytes in the address range.</param>
+        /// <param name="ppResult">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT findInlineeLinesByRVA(uint rva, uint length, IDiaEnumLineNumbers** ppResult);
+
+        /// <summary>
+        ///  Find inlinee lines by va.
+        /// </summary>
+        /// <param name="va">The virtual address (VA).</param>
+        /// <param name="length">The number of bytes in the address range.</param>
+        /// <param name="ppResult">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT findInlineeLinesByVA(ulong va, uint length, IDiaEnumLineNumbers** ppResult);
+
+        /// <summary>
+        ///  Find symbols for accelerator pointer tag.
+        /// </summary>
+        /// <param name="tagValue">The tagValue value.</param>
+        /// <param name="ppResult">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT findSymbolsForAcceleratorPointerTag(uint tagValue, IDiaEnumSymbols** ppResult);
+
+        /// <summary>
+        ///  Find symbols by rvafor accelerator pointer tag.
+        /// </summary>
+        /// <param name="tagValue">The tagValue value.</param>
+        /// <param name="rva">The relative virtual address (RVA).</param>
+        /// <param name="ppResult">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT findSymbolsByRVAForAcceleratorPointerTag(uint tagValue, uint rva, IDiaEnumSymbols** ppResult);
+
+        /// <summary>
+        ///  Retrieves the accelerator pointer tags.
+        /// </summary>
+        /// <param name="cnt">The cnt value.</param>
+        /// <param name="pcnt">Pointer to a variable that receives the requested value.</param>
+        /// <param name="pPointerTags">Pointer to a caller-allocated buffer that receives the data.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_acceleratorPointerTags(uint cnt, uint* pcnt, uint* pPointerTags);
+
+        /// <summary>
+        ///  Get src line on type defn.
+        /// </summary>
+        /// <param name="ppResult">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT getSrcLineOnTypeDefn(IDiaLineNumber** ppResult);
+
+        /// <summary>
+        ///  Is PGO enabled.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_isPGO(BOOL* pRetVal);
+
+        /// <summary>
+        ///  Has valid PGO counts.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_hasValidPGOCounts(BOOL* pRetVal);
+
+        /// <summary>
+        ///  Is the function optimized for speed.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_isOptimizedForSpeed(BOOL* pRetVal);
+
+        /// <summary>
+        ///  Total invocation count in PGO training.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_PGOEntryCount(uint* pRetVal);
+
+        /// <summary>
+        ///  Edge count between a caller/callee and it's parent.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_PGOEdgeCount(uint* pRetVal);
+
+        /// <summary>
+        ///  Dynamic instruction count calculated by training.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_PGODynamicInstructionCount(ulong* pRetVal);
+
+        /// <summary>
+        ///  Static instruction count.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_staticSize(uint* pRetVal);
+
+        /// <summary>
+        ///  Final static size of live function, after inlining.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_finalLiveStaticSize(uint* pRetVal);
+
+        /// <summary>
+        ///  Phase this function is a member of for PGO multiphased builds.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_phaseName(BSTR* pRetVal);
+
+        /// <summary>
+        ///  Does this function contain control flow check.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_hasControlFlowCheck(BOOL* pRetVal);
+
+        /// <summary>
+        ///  Export is CONSTANT.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_constantExport(BOOL* pRetVal);
+
+        /// <summary>
+        ///  Export is CONSTANT.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_dataExport(BOOL* pRetVal);
+
+        /// <summary>
+        ///  Export is PRIVATE.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_privateExport(BOOL* pRetVal);
+
+        /// <summary>
+        ///  Export is NONAME.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_noNameExport(BOOL* pRetVal);
+
+        /// <summary>
+        ///  Export has explicitly assigned ordinal.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_exportHasExplicitlyAssignedOrdinal(BOOL* pRetVal);
+
+        /// <summary>
+        ///  Export is forwarder.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_exportIsForwarder(BOOL* pRetVal);
+
+        /// <summary>
+        ///  Export ordinal.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_ordinal(uint* pRetVal);
+
+        /// <summary>
+        ///  Frame size.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_frameSize(uint* pRetVal);
+
+        /// <summary>
+        ///  Section number of exception handler.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_exceptionHandlerAddressSection(uint* pRetVal);
+
+        /// <summary>
+        ///  Offset of exception handler.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_exceptionHandlerAddressOffset(uint* pRetVal);
+
+        /// <summary>
+        ///  Relative virtual address of exception handler.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_exceptionHandlerRelativeVirtualAddress(uint* pRetVal);
+
+        /// <summary>
+        ///  Virtual address of exception handler.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_exceptionHandlerVirtualAddress(ulong* pRetVal);
+
+        /// <summary>
+        ///  Find input assembly file.
+        /// </summary>
+        /// <param name="ppResult">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT findInputAssemblyFile(IDiaInputAssemblyFile** ppResult);
+
+        /// <summary>
+        ///  Characteristics of a COFF group.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_characteristics(uint* pRetVal);
+
+        /// <summary>
+        ///  COFF group this symbol comes from.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_coffGroup(IDiaSymbol** pRetVal);
+
+        /// <summary>
+        ///  Binding register index.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_bindID(uint* pRetVal);
+
+        /// <summary>
+        ///  Binding space.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_bindSpace(uint* pRetVal);
+
+        /// <summary>
+        ///  Binding lower bound.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_bindSlot(uint* pRetVal);
+    }
+}

--- a/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaSymbol10.cs
+++ b/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaSymbol10.cs
@@ -1,0 +1,1876 @@
+﻿// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Runtime.InteropServices;
+using Windows.Win32.System.Variant;
+
+// For some reason the XML comment refs for IUnknown can't be resolved on .NET Framework without
+// explicitly using the fully qualified name, which falls afoul of the simplify warning.
+using ComIUnknown = Windows.Win32.System.Com.IUnknown;
+
+namespace Microsoft.VisualStudio.Debugging.DebugInterfaceAccess;
+
+/// <inheritdoc cref="Interface"/>
+public unsafe struct IDiaSymbol10 : IComIID
+{
+    /// <inheritdoc cref="IComIID.Guid"/>
+#pragma warning disable IDE1006 // Naming Styles
+    public static readonly Guid IID_Guid = new(0x9034A70B, 0xB0B7, 0x4605, 0x8A, 0x97, 0x33, 0x77, 0x2F, 0x3A, 0x7B, 0x8C);
+#pragma warning restore IDE1006
+
+#if NETFRAMEWORK
+    readonly ref readonly Guid IComIID.Guid => ref IID_Guid;
+#else
+    static ref readonly Guid IComIID.Guid
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get
+        {
+            ReadOnlySpan<byte> data =
+            [
+                0x0B, 0xA7, 0x34, 0x90,
+                0xB7, 0xB0,
+                0x05, 0x46,
+                0x8A, 0x97, 0x33, 0x77, 0x2F, 0x3A, 0x7B, 0x8C
+            ];
+
+            return ref Unsafe.As<byte, Guid>(ref MemoryMarshal.GetReference(data));
+        }
+    }
+#endif
+
+    private readonly void** _lpVtbl;
+
+    /// <inheritdoc cref="ComIUnknown.QueryInterface(Guid*, void**)"/>
+    public HRESULT QueryInterface(Guid* riid, void** ppvObject)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, Guid*, void**, HRESULT>)_lpVtbl[0])(pThis, riid, ppvObject);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.AddRef"/>
+    public uint AddRef()
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint>)_lpVtbl[1])(pThis);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.Release"/>
+    public uint Release()
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint>)_lpVtbl[2])(pThis);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_symIndexId"/>
+    public HRESULT get_symIndexId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint*, HRESULT>)_lpVtbl[3])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_symTag"/>
+    public HRESULT get_symTag(uint* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint*, HRESULT>)_lpVtbl[4])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_name"/>
+    public HRESULT get_name(BSTR* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BSTR*, HRESULT>)_lpVtbl[5])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_lexicalParent"/>
+    public HRESULT get_lexicalParent(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, IDiaSymbol**, HRESULT>)_lpVtbl[6])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_classParent"/>
+    public HRESULT get_classParent(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, IDiaSymbol**, HRESULT>)_lpVtbl[7])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_type"/>
+    public HRESULT get_type(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, IDiaSymbol**, HRESULT>)_lpVtbl[8])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_dataKind"/>
+    public HRESULT get_dataKind(uint* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint*, HRESULT>)_lpVtbl[9])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_locationType"/>
+    public HRESULT get_locationType(uint* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint*, HRESULT>)_lpVtbl[10])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_addressSection"/>
+    public HRESULT get_addressSection(uint* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint*, HRESULT>)_lpVtbl[11])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_addressOffset"/>
+    public HRESULT get_addressOffset(uint* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint*, HRESULT>)_lpVtbl[12])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_relativeVirtualAddress"/>
+    public HRESULT get_relativeVirtualAddress(uint* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint*, HRESULT>)_lpVtbl[13])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_virtualAddress"/>
+    public HRESULT get_virtualAddress(ulong* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, ulong*, HRESULT>)_lpVtbl[14])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_registerId"/>
+    public HRESULT get_registerId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint*, HRESULT>)_lpVtbl[15])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_offset"/>
+    public HRESULT get_offset(int* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, int*, HRESULT>)_lpVtbl[16])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_length"/>
+    public HRESULT get_length(ulong* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, ulong*, HRESULT>)_lpVtbl[17])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_slot"/>
+    public HRESULT get_slot(uint* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint*, HRESULT>)_lpVtbl[18])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_volatileType"/>
+    public HRESULT get_volatileType(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BOOL*, HRESULT>)_lpVtbl[19])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_constType"/>
+    public HRESULT get_constType(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BOOL*, HRESULT>)_lpVtbl[20])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_unalignedType"/>
+    public HRESULT get_unalignedType(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BOOL*, HRESULT>)_lpVtbl[21])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_access"/>
+    public HRESULT get_access(uint* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint*, HRESULT>)_lpVtbl[22])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_libraryName"/>
+    public HRESULT get_libraryName(BSTR* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BSTR*, HRESULT>)_lpVtbl[23])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_platform"/>
+    public HRESULT get_platform(uint* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint*, HRESULT>)_lpVtbl[24])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_language"/>
+    public HRESULT get_language(uint* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint*, HRESULT>)_lpVtbl[25])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_editAndContinueEnabled"/>
+    public HRESULT get_editAndContinueEnabled(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BOOL*, HRESULT>)_lpVtbl[26])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_frontEndMajor"/>
+    public HRESULT get_frontEndMajor(uint* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint*, HRESULT>)_lpVtbl[27])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_frontEndMinor"/>
+    public HRESULT get_frontEndMinor(uint* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint*, HRESULT>)_lpVtbl[28])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_frontEndBuild"/>
+    public HRESULT get_frontEndBuild(uint* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint*, HRESULT>)_lpVtbl[29])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_backEndMajor"/>
+    public HRESULT get_backEndMajor(uint* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint*, HRESULT>)_lpVtbl[30])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_backEndMinor"/>
+    public HRESULT get_backEndMinor(uint* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint*, HRESULT>)_lpVtbl[31])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_backEndBuild"/>
+    public HRESULT get_backEndBuild(uint* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint*, HRESULT>)_lpVtbl[32])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_sourceFileName"/>
+    public HRESULT get_sourceFileName(BSTR* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BSTR*, HRESULT>)_lpVtbl[33])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_unused"/>
+    public HRESULT get_unused(BSTR* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BSTR*, HRESULT>)_lpVtbl[34])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_thunkOrdinal"/>
+    public HRESULT get_thunkOrdinal(uint* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint*, HRESULT>)_lpVtbl[35])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_thisAdjust"/>
+    public HRESULT get_thisAdjust(int* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, int*, HRESULT>)_lpVtbl[36])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_virtualBaseOffset"/>
+    public HRESULT get_virtualBaseOffset(uint* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint*, HRESULT>)_lpVtbl[37])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_virtual"/>
+    public HRESULT get_virtual(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BOOL*, HRESULT>)_lpVtbl[38])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_intro"/>
+    public HRESULT get_intro(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BOOL*, HRESULT>)_lpVtbl[39])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_pure"/>
+    public HRESULT get_pure(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BOOL*, HRESULT>)_lpVtbl[40])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_callingConvention"/>
+    public HRESULT get_callingConvention(uint* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint*, HRESULT>)_lpVtbl[41])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_value"/>
+    public HRESULT get_value(VARIANT* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, VARIANT*, HRESULT>)_lpVtbl[42])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_baseType"/>
+    public HRESULT get_baseType(uint* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint*, HRESULT>)_lpVtbl[43])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_token"/>
+    public HRESULT get_token(uint* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint*, HRESULT>)_lpVtbl[44])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_timeStamp"/>
+    public HRESULT get_timeStamp(uint* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint*, HRESULT>)_lpVtbl[45])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_guid"/>
+    public HRESULT get_guid(Guid* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, Guid*, HRESULT>)_lpVtbl[46])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_symbolsFileName"/>
+    public HRESULT get_symbolsFileName(BSTR* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BSTR*, HRESULT>)_lpVtbl[47])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_reference"/>
+    public HRESULT get_reference(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BOOL*, HRESULT>)_lpVtbl[48])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_count"/>
+    public HRESULT get_count(uint* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint*, HRESULT>)_lpVtbl[49])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_bitPosition"/>
+    public HRESULT get_bitPosition(uint* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint*, HRESULT>)_lpVtbl[50])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_arrayIndexType"/>
+    public HRESULT get_arrayIndexType(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, IDiaSymbol**, HRESULT>)_lpVtbl[51])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_packed"/>
+    public HRESULT get_packed(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BOOL*, HRESULT>)_lpVtbl[52])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_constructor"/>
+    public HRESULT get_constructor(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BOOL*, HRESULT>)_lpVtbl[53])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_overloadedOperator"/>
+    public HRESULT get_overloadedOperator(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BOOL*, HRESULT>)_lpVtbl[54])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_nested"/>
+    public HRESULT get_nested(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BOOL*, HRESULT>)_lpVtbl[55])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasNestedTypes"/>
+    public HRESULT get_hasNestedTypes(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BOOL*, HRESULT>)_lpVtbl[56])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasAssignmentOperator"/>
+    public HRESULT get_hasAssignmentOperator(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BOOL*, HRESULT>)_lpVtbl[57])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasCastOperator"/>
+    public HRESULT get_hasCastOperator(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BOOL*, HRESULT>)_lpVtbl[58])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_scoped"/>
+    public HRESULT get_scoped(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BOOL*, HRESULT>)_lpVtbl[59])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_virtualBaseClass"/>
+    public HRESULT get_virtualBaseClass(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BOOL*, HRESULT>)_lpVtbl[60])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_indirectVirtualBaseClass"/>
+    public HRESULT get_indirectVirtualBaseClass(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BOOL*, HRESULT>)_lpVtbl[61])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_virtualBasePointerOffset"/>
+    public HRESULT get_virtualBasePointerOffset(int* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, int*, HRESULT>)_lpVtbl[62])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_virtualTableShape"/>
+    public HRESULT get_virtualTableShape(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, IDiaSymbol**, HRESULT>)_lpVtbl[63])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_lexicalParentId"/>
+    public HRESULT get_lexicalParentId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint*, HRESULT>)_lpVtbl[64])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_classParentId"/>
+    public HRESULT get_classParentId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint*, HRESULT>)_lpVtbl[65])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_typeId"/>
+    public HRESULT get_typeId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint*, HRESULT>)_lpVtbl[66])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_arrayIndexTypeId"/>
+    public HRESULT get_arrayIndexTypeId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint*, HRESULT>)_lpVtbl[67])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_virtualTableShapeId"/>
+    public HRESULT get_virtualTableShapeId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint*, HRESULT>)_lpVtbl[68])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_code"/>
+    public HRESULT get_code(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BOOL*, HRESULT>)_lpVtbl[69])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_function"/>
+    public HRESULT get_function(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BOOL*, HRESULT>)_lpVtbl[70])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_managed"/>
+    public HRESULT get_managed(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BOOL*, HRESULT>)_lpVtbl[71])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_msil"/>
+    public HRESULT get_msil(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BOOL*, HRESULT>)_lpVtbl[72])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_virtualBaseDispIndex"/>
+    public HRESULT get_virtualBaseDispIndex(uint* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint*, HRESULT>)_lpVtbl[73])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_undecoratedName"/>
+    public HRESULT get_undecoratedName(BSTR* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BSTR*, HRESULT>)_lpVtbl[74])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_age"/>
+    public HRESULT get_age(uint* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint*, HRESULT>)_lpVtbl[75])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_signature"/>
+    public HRESULT get_signature(uint* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint*, HRESULT>)_lpVtbl[76])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_compilerGenerated"/>
+    public HRESULT get_compilerGenerated(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BOOL*, HRESULT>)_lpVtbl[77])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_addressTaken"/>
+    public HRESULT get_addressTaken(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BOOL*, HRESULT>)_lpVtbl[78])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_rank"/>
+    public HRESULT get_rank(uint* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint*, HRESULT>)_lpVtbl[79])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_lowerBound"/>
+    public HRESULT get_lowerBound(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, IDiaSymbol**, HRESULT>)_lpVtbl[80])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_upperBound"/>
+    public HRESULT get_upperBound(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, IDiaSymbol**, HRESULT>)_lpVtbl[81])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_lowerBoundId"/>
+    public HRESULT get_lowerBoundId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint*, HRESULT>)_lpVtbl[82])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_upperBoundId"/>
+    public HRESULT get_upperBoundId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint*, HRESULT>)_lpVtbl[83])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_dataBytes"/>
+    public HRESULT get_dataBytes(uint cbData, uint* pcbData, byte* pbData)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint, uint*, byte*, HRESULT>)_lpVtbl[84])(pThis, cbData, pcbData, pbData);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findChildren"/>
+    public HRESULT findChildren(SymTagEnum symtag, PCWSTR name, uint compareFlags, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, SymTagEnum, PCWSTR, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[85])(pThis, symtag, name, compareFlags, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findChildrenEx"/>
+    public HRESULT findChildrenEx(SymTagEnum symtag, PCWSTR name, uint compareFlags, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, SymTagEnum, PCWSTR, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[86])(pThis, symtag, name, compareFlags, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findChildrenExByAddr"/>
+    public HRESULT findChildrenExByAddr(SymTagEnum symtag, PCWSTR name, uint compareFlags, uint isect, uint offset, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, SymTagEnum, PCWSTR, uint, uint, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[87])(pThis, symtag, name, compareFlags, isect, offset, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findChildrenExByVA"/>
+    public HRESULT findChildrenExByVA(SymTagEnum symtag, PCWSTR name, uint compareFlags, ulong va, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, SymTagEnum, PCWSTR, uint, ulong, IDiaEnumSymbols**, HRESULT>)_lpVtbl[88])(pThis, symtag, name, compareFlags, va, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findChildrenExByRVA"/>
+    public HRESULT findChildrenExByRVA(SymTagEnum symtag, PCWSTR name, uint compareFlags, uint rva, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, SymTagEnum, PCWSTR, uint, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[89])(pThis, symtag, name, compareFlags, rva, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_targetSection"/>
+    public HRESULT get_targetSection(uint* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint*, HRESULT>)_lpVtbl[90])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_targetOffset"/>
+    public HRESULT get_targetOffset(uint* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint*, HRESULT>)_lpVtbl[91])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_targetRelativeVirtualAddress"/>
+    public HRESULT get_targetRelativeVirtualAddress(uint* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint*, HRESULT>)_lpVtbl[92])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_targetVirtualAddress"/>
+    public HRESULT get_targetVirtualAddress(ulong* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, ulong*, HRESULT>)_lpVtbl[93])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_machineType"/>
+    public HRESULT get_machineType(uint* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint*, HRESULT>)_lpVtbl[94])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_oemId"/>
+    public HRESULT get_oemId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint*, HRESULT>)_lpVtbl[95])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_oemSymbolId"/>
+    public HRESULT get_oemSymbolId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint*, HRESULT>)_lpVtbl[96])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_types"/>
+    public HRESULT get_types(uint cTypes, uint* pcTypes, IDiaSymbol** pTypes)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint, uint*, IDiaSymbol**, HRESULT>)_lpVtbl[97])(pThis, cTypes, pcTypes, pTypes);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_typeIds"/>
+    public HRESULT get_typeIds(uint cTypeIds, uint* pcTypeIds, uint* pdwTypeIds)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint, uint*, uint*, HRESULT>)_lpVtbl[98])(pThis, cTypeIds, pcTypeIds, pdwTypeIds);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_objectPointerType"/>
+    public HRESULT get_objectPointerType(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, IDiaSymbol**, HRESULT>)_lpVtbl[99])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_udtKind"/>
+    public HRESULT get_udtKind(uint* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint*, HRESULT>)_lpVtbl[100])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_undecoratedNameEx"/>
+    public HRESULT get_undecoratedNameEx(uint undecorateOptions, BSTR* name)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint, BSTR*, HRESULT>)_lpVtbl[101])(pThis, undecorateOptions, name);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_noReturn"/>
+    public HRESULT get_noReturn(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BOOL*, HRESULT>)_lpVtbl[102])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_customCallingConvention"/>
+    public HRESULT get_customCallingConvention(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BOOL*, HRESULT>)_lpVtbl[103])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_noInline"/>
+    public HRESULT get_noInline(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BOOL*, HRESULT>)_lpVtbl[104])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_optimizedCodeDebugInfo"/>
+    public HRESULT get_optimizedCodeDebugInfo(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BOOL*, HRESULT>)_lpVtbl[105])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_notReached"/>
+    public HRESULT get_notReached(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BOOL*, HRESULT>)_lpVtbl[106])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_interruptReturn"/>
+    public HRESULT get_interruptReturn(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BOOL*, HRESULT>)_lpVtbl[107])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_farReturn"/>
+    public HRESULT get_farReturn(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BOOL*, HRESULT>)_lpVtbl[108])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isStatic"/>
+    public HRESULT get_isStatic(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BOOL*, HRESULT>)_lpVtbl[109])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasDebugInfo"/>
+    public HRESULT get_hasDebugInfo(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BOOL*, HRESULT>)_lpVtbl[110])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isLTCG"/>
+    public HRESULT get_isLTCG(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BOOL*, HRESULT>)_lpVtbl[111])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isDataAligned"/>
+    public HRESULT get_isDataAligned(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BOOL*, HRESULT>)_lpVtbl[112])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasSecurityChecks"/>
+    public HRESULT get_hasSecurityChecks(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BOOL*, HRESULT>)_lpVtbl[113])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_compilerName"/>
+    public HRESULT get_compilerName(BSTR* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BSTR*, HRESULT>)_lpVtbl[114])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasAlloca"/>
+    public HRESULT get_hasAlloca(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BOOL*, HRESULT>)_lpVtbl[115])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasSetJump"/>
+    public HRESULT get_hasSetJump(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BOOL*, HRESULT>)_lpVtbl[116])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasLongJump"/>
+    public HRESULT get_hasLongJump(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BOOL*, HRESULT>)_lpVtbl[117])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasInlAsm"/>
+    public HRESULT get_hasInlAsm(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BOOL*, HRESULT>)_lpVtbl[118])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasEH"/>
+    public HRESULT get_hasEH(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BOOL*, HRESULT>)_lpVtbl[119])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasSEH"/>
+    public HRESULT get_hasSEH(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BOOL*, HRESULT>)_lpVtbl[120])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasEHa"/>
+    public HRESULT get_hasEHa(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BOOL*, HRESULT>)_lpVtbl[121])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isNaked"/>
+    public HRESULT get_isNaked(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BOOL*, HRESULT>)_lpVtbl[122])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isAggregated"/>
+    public HRESULT get_isAggregated(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BOOL*, HRESULT>)_lpVtbl[123])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isSplitted"/>
+    public HRESULT get_isSplitted(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BOOL*, HRESULT>)_lpVtbl[124])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_container"/>
+    public HRESULT get_container(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, IDiaSymbol**, HRESULT>)_lpVtbl[125])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_inlSpec"/>
+    public HRESULT get_inlSpec(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BOOL*, HRESULT>)_lpVtbl[126])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_noStackOrdering"/>
+    public HRESULT get_noStackOrdering(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BOOL*, HRESULT>)_lpVtbl[127])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_virtualBaseTableType"/>
+    public HRESULT get_virtualBaseTableType(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, IDiaSymbol**, HRESULT>)_lpVtbl[128])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasManagedCode"/>
+    public HRESULT get_hasManagedCode(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BOOL*, HRESULT>)_lpVtbl[129])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isHotpatchable"/>
+    public HRESULT get_isHotpatchable(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BOOL*, HRESULT>)_lpVtbl[130])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isCVTCIL"/>
+    public HRESULT get_isCVTCIL(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BOOL*, HRESULT>)_lpVtbl[131])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isMSILNetmodule"/>
+    public HRESULT get_isMSILNetmodule(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BOOL*, HRESULT>)_lpVtbl[132])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isCTypes"/>
+    public HRESULT get_isCTypes(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BOOL*, HRESULT>)_lpVtbl[133])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isStripped"/>
+    public HRESULT get_isStripped(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BOOL*, HRESULT>)_lpVtbl[134])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_frontEndQFE"/>
+    public HRESULT get_frontEndQFE(uint* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint*, HRESULT>)_lpVtbl[135])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_backEndQFE"/>
+    public HRESULT get_backEndQFE(uint* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint*, HRESULT>)_lpVtbl[136])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_wasInlined"/>
+    public HRESULT get_wasInlined(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BOOL*, HRESULT>)_lpVtbl[137])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_strictGSCheck"/>
+    public HRESULT get_strictGSCheck(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BOOL*, HRESULT>)_lpVtbl[138])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isCxxReturnUdt"/>
+    public HRESULT get_isCxxReturnUdt(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BOOL*, HRESULT>)_lpVtbl[139])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isConstructorVirtualBase"/>
+    public HRESULT get_isConstructorVirtualBase(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BOOL*, HRESULT>)_lpVtbl[140])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_RValueReference"/>
+    public HRESULT get_RValueReference(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BOOL*, HRESULT>)_lpVtbl[141])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_unmodifiedType"/>
+    public HRESULT get_unmodifiedType(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, IDiaSymbol**, HRESULT>)_lpVtbl[142])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_framePointerPresent"/>
+    public HRESULT get_framePointerPresent(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BOOL*, HRESULT>)_lpVtbl[143])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isSafeBuffers"/>
+    public HRESULT get_isSafeBuffers(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BOOL*, HRESULT>)_lpVtbl[144])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_intrinsic"/>
+    public HRESULT get_intrinsic(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BOOL*, HRESULT>)_lpVtbl[145])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_sealed"/>
+    public HRESULT get_sealed(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BOOL*, HRESULT>)_lpVtbl[146])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hfaFloat"/>
+    public HRESULT get_hfaFloat(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BOOL*, HRESULT>)_lpVtbl[147])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hfaDouble"/>
+    public HRESULT get_hfaDouble(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BOOL*, HRESULT>)_lpVtbl[148])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_liveRangeStartAddressSection"/>
+    public HRESULT get_liveRangeStartAddressSection(uint* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint*, HRESULT>)_lpVtbl[149])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_liveRangeStartAddressOffset"/>
+    public HRESULT get_liveRangeStartAddressOffset(uint* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint*, HRESULT>)_lpVtbl[150])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_liveRangeStartRelativeVirtualAddress"/>
+    public HRESULT get_liveRangeStartRelativeVirtualAddress(uint* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint*, HRESULT>)_lpVtbl[151])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_countLiveRanges"/>
+    public HRESULT get_countLiveRanges(uint* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint*, HRESULT>)_lpVtbl[152])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_liveRangeLength"/>
+    public HRESULT get_liveRangeLength(ulong* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, ulong*, HRESULT>)_lpVtbl[153])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_offsetInUdt"/>
+    public HRESULT get_offsetInUdt(uint* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint*, HRESULT>)_lpVtbl[154])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_paramBasePointerRegisterId"/>
+    public HRESULT get_paramBasePointerRegisterId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint*, HRESULT>)_lpVtbl[155])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_localBasePointerRegisterId"/>
+    public HRESULT get_localBasePointerRegisterId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint*, HRESULT>)_lpVtbl[156])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isLocationControlFlowDependent"/>
+    public HRESULT get_isLocationControlFlowDependent(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BOOL*, HRESULT>)_lpVtbl[157])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_stride"/>
+    public HRESULT get_stride(uint* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint*, HRESULT>)_lpVtbl[158])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_numberOfRows"/>
+    public HRESULT get_numberOfRows(uint* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint*, HRESULT>)_lpVtbl[159])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_numberOfColumns"/>
+    public HRESULT get_numberOfColumns(uint* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint*, HRESULT>)_lpVtbl[160])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isMatrixRowMajor"/>
+    public HRESULT get_isMatrixRowMajor(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BOOL*, HRESULT>)_lpVtbl[161])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_numericProperties"/>
+    public HRESULT get_numericProperties(uint cnt, uint* pcnt, uint* pProperties)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint, uint*, uint*, HRESULT>)_lpVtbl[162])(pThis, cnt, pcnt, pProperties);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_modifierValues"/>
+    public HRESULT get_modifierValues(uint cnt, uint* pcnt, ushort* pModifiers)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint, uint*, ushort*, HRESULT>)_lpVtbl[163])(pThis, cnt, pcnt, pModifiers);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isReturnValue"/>
+    public HRESULT get_isReturnValue(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BOOL*, HRESULT>)_lpVtbl[164])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isOptimizedAway"/>
+    public HRESULT get_isOptimizedAway(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BOOL*, HRESULT>)_lpVtbl[165])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_builtInKind"/>
+    public HRESULT get_builtInKind(uint* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint*, HRESULT>)_lpVtbl[166])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_registerType"/>
+    public HRESULT get_registerType(uint* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint*, HRESULT>)_lpVtbl[167])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_baseDataSlot"/>
+    public HRESULT get_baseDataSlot(uint* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint*, HRESULT>)_lpVtbl[168])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_baseDataOffset"/>
+    public HRESULT get_baseDataOffset(uint* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint*, HRESULT>)_lpVtbl[169])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_textureSlot"/>
+    public HRESULT get_textureSlot(uint* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint*, HRESULT>)_lpVtbl[170])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_samplerSlot"/>
+    public HRESULT get_samplerSlot(uint* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint*, HRESULT>)_lpVtbl[171])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_uavSlot"/>
+    public HRESULT get_uavSlot(uint* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint*, HRESULT>)_lpVtbl[172])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_sizeInUdt"/>
+    public HRESULT get_sizeInUdt(uint* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint*, HRESULT>)_lpVtbl[173])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_memorySpaceKind"/>
+    public HRESULT get_memorySpaceKind(uint* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint*, HRESULT>)_lpVtbl[174])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_unmodifiedTypeId"/>
+    public HRESULT get_unmodifiedTypeId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint*, HRESULT>)_lpVtbl[175])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_subTypeId"/>
+    public HRESULT get_subTypeId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint*, HRESULT>)_lpVtbl[176])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_subType"/>
+    public HRESULT get_subType(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, IDiaSymbol**, HRESULT>)_lpVtbl[177])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_numberOfModifiers"/>
+    public HRESULT get_numberOfModifiers(uint* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint*, HRESULT>)_lpVtbl[178])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_numberOfRegisterIndices"/>
+    public HRESULT get_numberOfRegisterIndices(uint* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint*, HRESULT>)_lpVtbl[179])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isHLSLData"/>
+    public HRESULT get_isHLSLData(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BOOL*, HRESULT>)_lpVtbl[180])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isPointerToDataMember"/>
+    public HRESULT get_isPointerToDataMember(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BOOL*, HRESULT>)_lpVtbl[181])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isPointerToMemberFunction"/>
+    public HRESULT get_isPointerToMemberFunction(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BOOL*, HRESULT>)_lpVtbl[182])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isSingleInheritance"/>
+    public HRESULT get_isSingleInheritance(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BOOL*, HRESULT>)_lpVtbl[183])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isMultipleInheritance"/>
+    public HRESULT get_isMultipleInheritance(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BOOL*, HRESULT>)_lpVtbl[184])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isVirtualInheritance"/>
+    public HRESULT get_isVirtualInheritance(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BOOL*, HRESULT>)_lpVtbl[185])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_restrictedType"/>
+    public HRESULT get_restrictedType(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BOOL*, HRESULT>)_lpVtbl[186])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isPointerBasedOnSymbolValue"/>
+    public HRESULT get_isPointerBasedOnSymbolValue(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BOOL*, HRESULT>)_lpVtbl[187])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_baseSymbol"/>
+    public HRESULT get_baseSymbol(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, IDiaSymbol**, HRESULT>)_lpVtbl[188])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_baseSymbolId"/>
+    public HRESULT get_baseSymbolId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint*, HRESULT>)_lpVtbl[189])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_objectFileName"/>
+    public HRESULT get_objectFileName(BSTR* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BSTR*, HRESULT>)_lpVtbl[190])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isAcceleratorGroupSharedLocal"/>
+    public HRESULT get_isAcceleratorGroupSharedLocal(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BOOL*, HRESULT>)_lpVtbl[191])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isAcceleratorPointerTagLiveRange"/>
+    public HRESULT get_isAcceleratorPointerTagLiveRange(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BOOL*, HRESULT>)_lpVtbl[192])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isAcceleratorStubFunction"/>
+    public HRESULT get_isAcceleratorStubFunction(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BOOL*, HRESULT>)_lpVtbl[193])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_numberOfAcceleratorPointerTags"/>
+    public HRESULT get_numberOfAcceleratorPointerTags(uint* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint*, HRESULT>)_lpVtbl[194])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isSdl"/>
+    public HRESULT get_isSdl(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BOOL*, HRESULT>)_lpVtbl[195])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isWinRTPointer"/>
+    public HRESULT get_isWinRTPointer(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BOOL*, HRESULT>)_lpVtbl[196])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isRefUdt"/>
+    public HRESULT get_isRefUdt(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BOOL*, HRESULT>)_lpVtbl[197])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isValueUdt"/>
+    public HRESULT get_isValueUdt(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BOOL*, HRESULT>)_lpVtbl[198])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isInterfaceUdt"/>
+    public HRESULT get_isInterfaceUdt(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BOOL*, HRESULT>)_lpVtbl[199])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findInlineFramesByAddr"/>
+    public HRESULT findInlineFramesByAddr(uint isect, uint offset, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[200])(pThis, isect, offset, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findInlineFramesByRVA"/>
+    public HRESULT findInlineFramesByRVA(uint rva, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[201])(pThis, rva, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findInlineFramesByVA"/>
+    public HRESULT findInlineFramesByVA(ulong va, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, ulong, IDiaEnumSymbols**, HRESULT>)_lpVtbl[202])(pThis, va, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findInlineeLines"/>
+    public HRESULT findInlineeLines(IDiaEnumLineNumbers** ppResult)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, IDiaEnumLineNumbers**, HRESULT>)_lpVtbl[203])(pThis, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findInlineeLinesByAddr"/>
+    public HRESULT findInlineeLinesByAddr(uint isect, uint offset, uint length, IDiaEnumLineNumbers** ppResult)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint, uint, uint, IDiaEnumLineNumbers**, HRESULT>)_lpVtbl[204])(pThis, isect, offset, length, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findInlineeLinesByRVA"/>
+    public HRESULT findInlineeLinesByRVA(uint rva, uint length, IDiaEnumLineNumbers** ppResult)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint, uint, IDiaEnumLineNumbers**, HRESULT>)_lpVtbl[205])(pThis, rva, length, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findInlineeLinesByVA"/>
+    public HRESULT findInlineeLinesByVA(ulong va, uint length, IDiaEnumLineNumbers** ppResult)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, ulong, uint, IDiaEnumLineNumbers**, HRESULT>)_lpVtbl[206])(pThis, va, length, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findSymbolsForAcceleratorPointerTag"/>
+    public HRESULT findSymbolsForAcceleratorPointerTag(uint tagValue, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[207])(pThis, tagValue, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findSymbolsByRVAForAcceleratorPointerTag"/>
+    public HRESULT findSymbolsByRVAForAcceleratorPointerTag(uint tagValue, uint rva, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[208])(pThis, tagValue, rva, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_acceleratorPointerTags"/>
+    public HRESULT get_acceleratorPointerTags(uint cnt, uint* pcnt, uint* pPointerTags)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint, uint*, uint*, HRESULT>)_lpVtbl[209])(pThis, cnt, pcnt, pPointerTags);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.getSrcLineOnTypeDefn"/>
+    public HRESULT getSrcLineOnTypeDefn(IDiaLineNumber** ppResult)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, IDiaLineNumber**, HRESULT>)_lpVtbl[210])(pThis, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isPGO"/>
+    public HRESULT get_isPGO(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BOOL*, HRESULT>)_lpVtbl[211])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasValidPGOCounts"/>
+    public HRESULT get_hasValidPGOCounts(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BOOL*, HRESULT>)_lpVtbl[212])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isOptimizedForSpeed"/>
+    public HRESULT get_isOptimizedForSpeed(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BOOL*, HRESULT>)_lpVtbl[213])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_PGOEntryCount"/>
+    public HRESULT get_PGOEntryCount(uint* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint*, HRESULT>)_lpVtbl[214])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_PGOEdgeCount"/>
+    public HRESULT get_PGOEdgeCount(uint* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint*, HRESULT>)_lpVtbl[215])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_PGODynamicInstructionCount"/>
+    public HRESULT get_PGODynamicInstructionCount(ulong* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, ulong*, HRESULT>)_lpVtbl[216])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_staticSize"/>
+    public HRESULT get_staticSize(uint* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint*, HRESULT>)_lpVtbl[217])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_finalLiveStaticSize"/>
+    public HRESULT get_finalLiveStaticSize(uint* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint*, HRESULT>)_lpVtbl[218])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_phaseName"/>
+    public HRESULT get_phaseName(BSTR* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BSTR*, HRESULT>)_lpVtbl[219])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasControlFlowCheck"/>
+    public HRESULT get_hasControlFlowCheck(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BOOL*, HRESULT>)_lpVtbl[220])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_constantExport"/>
+    public HRESULT get_constantExport(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BOOL*, HRESULT>)_lpVtbl[221])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_dataExport"/>
+    public HRESULT get_dataExport(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BOOL*, HRESULT>)_lpVtbl[222])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_privateExport"/>
+    public HRESULT get_privateExport(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BOOL*, HRESULT>)_lpVtbl[223])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_noNameExport"/>
+    public HRESULT get_noNameExport(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BOOL*, HRESULT>)_lpVtbl[224])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_exportHasExplicitlyAssignedOrdinal"/>
+    public HRESULT get_exportHasExplicitlyAssignedOrdinal(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BOOL*, HRESULT>)_lpVtbl[225])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_exportIsForwarder"/>
+    public HRESULT get_exportIsForwarder(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BOOL*, HRESULT>)_lpVtbl[226])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_ordinal"/>
+    public HRESULT get_ordinal(uint* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint*, HRESULT>)_lpVtbl[227])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_frameSize"/>
+    public HRESULT get_frameSize(uint* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint*, HRESULT>)_lpVtbl[228])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_exceptionHandlerAddressSection"/>
+    public HRESULT get_exceptionHandlerAddressSection(uint* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint*, HRESULT>)_lpVtbl[229])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_exceptionHandlerAddressOffset"/>
+    public HRESULT get_exceptionHandlerAddressOffset(uint* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint*, HRESULT>)_lpVtbl[230])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_exceptionHandlerRelativeVirtualAddress"/>
+    public HRESULT get_exceptionHandlerRelativeVirtualAddress(uint* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint*, HRESULT>)_lpVtbl[231])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_exceptionHandlerVirtualAddress"/>
+    public HRESULT get_exceptionHandlerVirtualAddress(ulong* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, ulong*, HRESULT>)_lpVtbl[232])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findInputAssemblyFile"/>
+    public HRESULT findInputAssemblyFile(IDiaInputAssemblyFile** ppResult)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, IDiaInputAssemblyFile**, HRESULT>)_lpVtbl[233])(pThis, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_characteristics"/>
+    public HRESULT get_characteristics(uint* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint*, HRESULT>)_lpVtbl[234])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_coffGroup"/>
+    public HRESULT get_coffGroup(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, IDiaSymbol**, HRESULT>)_lpVtbl[235])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_bindID"/>
+    public HRESULT get_bindID(uint* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint*, HRESULT>)_lpVtbl[236])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_bindSpace"/>
+    public HRESULT get_bindSpace(uint* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint*, HRESULT>)_lpVtbl[237])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_bindSlot"/>
+    public HRESULT get_bindSlot(uint* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint*, HRESULT>)_lpVtbl[238])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol2.Interface.get_isObjCClass"/>
+    public HRESULT get_isObjCClass(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BOOL*, HRESULT>)_lpVtbl[239])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol2.Interface.get_isObjCCategory"/>
+    public HRESULT get_isObjCCategory(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BOOL*, HRESULT>)_lpVtbl[240])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol2.Interface.get_isObjCProtocol"/>
+    public HRESULT get_isObjCProtocol(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BOOL*, HRESULT>)_lpVtbl[241])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol3.Interface.get_inlinee"/>
+    public HRESULT get_inlinee(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, IDiaSymbol**, HRESULT>)_lpVtbl[242])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol3.Interface.get_inlineeId"/>
+    public HRESULT get_inlineeId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint*, HRESULT>)_lpVtbl[243])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol4.Interface.get_noexcept"/>
+    public HRESULT get_noexcept(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BOOL*, HRESULT>)_lpVtbl[244])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol5.Interface.get_hasAbsoluteAddress"/>
+    public HRESULT get_hasAbsoluteAddress(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BOOL*, HRESULT>)_lpVtbl[245])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol6.Interface.get_isStaticMemberFunc"/>
+    public HRESULT get_isStaticMemberFunc(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BOOL*, HRESULT>)_lpVtbl[246])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol7.Interface.get_isSignRet"/>
+    public HRESULT get_isSignRet(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BOOL*, HRESULT>)_lpVtbl[247])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol8.Interface.get_coroutineKind"/>
+    public HRESULT get_coroutineKind(uint* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint*, HRESULT>)_lpVtbl[248])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol8.Interface.get_associatedSymbolKind"/>
+    public HRESULT get_associatedSymbolKind(uint* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint*, HRESULT>)_lpVtbl[249])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol8.Interface.get_associatedSymbolSection"/>
+    public HRESULT get_associatedSymbolSection(uint* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint*, HRESULT>)_lpVtbl[250])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol8.Interface.get_associatedSymbolOffset"/>
+    public HRESULT get_associatedSymbolOffset(uint* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint*, HRESULT>)_lpVtbl[251])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol8.Interface.get_associatedSymbolRva"/>
+    public HRESULT get_associatedSymbolRva(uint* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint*, HRESULT>)_lpVtbl[252])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol8.Interface.get_associatedSymbolAddr"/>
+    public HRESULT get_associatedSymbolAddr(ulong* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, ulong*, HRESULT>)_lpVtbl[253])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol9.Interface.get_framePadSize"/>
+    public HRESULT get_framePadSize(uint* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint*, HRESULT>)_lpVtbl[254])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol9.Interface.get_framePadOffset"/>
+    public HRESULT get_framePadOffset(uint* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint*, HRESULT>)_lpVtbl[255])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol9.Interface.get_isRTCs"/>
+    public HRESULT get_isRTCs(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, BOOL*, HRESULT>)_lpVtbl[256])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_sourceLink"/>
+    public HRESULT get_sourceLink(uint cb, uint* pcb, byte* pb)
+    {
+        fixed (IDiaSymbol10* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol10*, uint, uint*, byte*, HRESULT>)_lpVtbl[257])(pThis, cb, pcb, pb);
+    }
+
+    /// <summary>
+    ///  Extends IDiaSymbol9 with access to source link information.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/visualstudio/debugger/debug-interface-access/idiasymbol10">
+    ///    Official documentation.
+    ///   </see>
+    ///  </para>
+    /// </remarks>
+    [ComImport]
+    [Guid("9034A70B-B0B7-4605-8A97-33772F3A7B8C")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    public unsafe interface Interface : IDiaSymbol9.Interface
+    {
+        /// <summary>
+        ///  Retrieves the source link.
+        /// </summary>
+        /// <param name="cb">The size, in bytes, of the buffer.</param>
+        /// <param name="pcb">Pointer to a variable that receives the number of bytes written to the buffer.</param>
+        /// <param name="pb">Pointer to a caller-allocated buffer that receives the data.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_sourceLink(uint cb, uint* pcb, byte* pb);
+    }
+}

--- a/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaSymbol11.cs
+++ b/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaSymbol11.cs
@@ -1,0 +1,1900 @@
+﻿// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Runtime.InteropServices;
+using Windows.Win32.System.Variant;
+
+// For some reason the XML comment refs for IUnknown can't be resolved on .NET Framework without
+// explicitly using the fully qualified name, which falls afoul of the simplify warning.
+using ComIUnknown = Windows.Win32.System.Com.IUnknown;
+
+namespace Microsoft.VisualStudio.Debugging.DebugInterfaceAccess;
+
+/// <inheritdoc cref="Interface"/>
+public unsafe struct IDiaSymbol11 : IComIID
+{
+    /// <inheritdoc cref="IComIID.Guid"/>
+#pragma warning disable IDE1006 // Naming Styles
+    public static readonly Guid IID_Guid = new(0xB6F54FCD, 0x05E3, 0x433D, 0xB3, 0x05, 0xB0, 0xC1, 0x43, 0x7D, 0x2D, 0x16);
+#pragma warning restore IDE1006
+
+#if NETFRAMEWORK
+    readonly ref readonly Guid IComIID.Guid => ref IID_Guid;
+#else
+    static ref readonly Guid IComIID.Guid
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get
+        {
+            ReadOnlySpan<byte> data =
+            [
+                0xCD, 0x4F, 0xF5, 0xB6,
+                0xE3, 0x05,
+                0x3D, 0x43,
+                0xB3, 0x05, 0xB0, 0xC1, 0x43, 0x7D, 0x2D, 0x16
+            ];
+
+            return ref Unsafe.As<byte, Guid>(ref MemoryMarshal.GetReference(data));
+        }
+    }
+#endif
+
+    private readonly void** _lpVtbl;
+
+    /// <inheritdoc cref="ComIUnknown.QueryInterface(Guid*, void**)"/>
+    public HRESULT QueryInterface(Guid* riid, void** ppvObject)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, Guid*, void**, HRESULT>)_lpVtbl[0])(pThis, riid, ppvObject);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.AddRef"/>
+    public uint AddRef()
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint>)_lpVtbl[1])(pThis);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.Release"/>
+    public uint Release()
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint>)_lpVtbl[2])(pThis);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_symIndexId"/>
+    public HRESULT get_symIndexId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint*, HRESULT>)_lpVtbl[3])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_symTag"/>
+    public HRESULT get_symTag(uint* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint*, HRESULT>)_lpVtbl[4])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_name"/>
+    public HRESULT get_name(BSTR* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BSTR*, HRESULT>)_lpVtbl[5])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_lexicalParent"/>
+    public HRESULT get_lexicalParent(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, IDiaSymbol**, HRESULT>)_lpVtbl[6])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_classParent"/>
+    public HRESULT get_classParent(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, IDiaSymbol**, HRESULT>)_lpVtbl[7])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_type"/>
+    public HRESULT get_type(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, IDiaSymbol**, HRESULT>)_lpVtbl[8])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_dataKind"/>
+    public HRESULT get_dataKind(uint* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint*, HRESULT>)_lpVtbl[9])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_locationType"/>
+    public HRESULT get_locationType(uint* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint*, HRESULT>)_lpVtbl[10])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_addressSection"/>
+    public HRESULT get_addressSection(uint* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint*, HRESULT>)_lpVtbl[11])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_addressOffset"/>
+    public HRESULT get_addressOffset(uint* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint*, HRESULT>)_lpVtbl[12])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_relativeVirtualAddress"/>
+    public HRESULT get_relativeVirtualAddress(uint* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint*, HRESULT>)_lpVtbl[13])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_virtualAddress"/>
+    public HRESULT get_virtualAddress(ulong* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, ulong*, HRESULT>)_lpVtbl[14])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_registerId"/>
+    public HRESULT get_registerId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint*, HRESULT>)_lpVtbl[15])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_offset"/>
+    public HRESULT get_offset(int* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, int*, HRESULT>)_lpVtbl[16])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_length"/>
+    public HRESULT get_length(ulong* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, ulong*, HRESULT>)_lpVtbl[17])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_slot"/>
+    public HRESULT get_slot(uint* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint*, HRESULT>)_lpVtbl[18])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_volatileType"/>
+    public HRESULT get_volatileType(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BOOL*, HRESULT>)_lpVtbl[19])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_constType"/>
+    public HRESULT get_constType(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BOOL*, HRESULT>)_lpVtbl[20])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_unalignedType"/>
+    public HRESULT get_unalignedType(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BOOL*, HRESULT>)_lpVtbl[21])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_access"/>
+    public HRESULT get_access(uint* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint*, HRESULT>)_lpVtbl[22])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_libraryName"/>
+    public HRESULT get_libraryName(BSTR* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BSTR*, HRESULT>)_lpVtbl[23])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_platform"/>
+    public HRESULT get_platform(uint* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint*, HRESULT>)_lpVtbl[24])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_language"/>
+    public HRESULT get_language(uint* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint*, HRESULT>)_lpVtbl[25])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_editAndContinueEnabled"/>
+    public HRESULT get_editAndContinueEnabled(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BOOL*, HRESULT>)_lpVtbl[26])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_frontEndMajor"/>
+    public HRESULT get_frontEndMajor(uint* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint*, HRESULT>)_lpVtbl[27])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_frontEndMinor"/>
+    public HRESULT get_frontEndMinor(uint* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint*, HRESULT>)_lpVtbl[28])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_frontEndBuild"/>
+    public HRESULT get_frontEndBuild(uint* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint*, HRESULT>)_lpVtbl[29])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_backEndMajor"/>
+    public HRESULT get_backEndMajor(uint* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint*, HRESULT>)_lpVtbl[30])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_backEndMinor"/>
+    public HRESULT get_backEndMinor(uint* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint*, HRESULT>)_lpVtbl[31])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_backEndBuild"/>
+    public HRESULT get_backEndBuild(uint* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint*, HRESULT>)_lpVtbl[32])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_sourceFileName"/>
+    public HRESULT get_sourceFileName(BSTR* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BSTR*, HRESULT>)_lpVtbl[33])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_unused"/>
+    public HRESULT get_unused(BSTR* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BSTR*, HRESULT>)_lpVtbl[34])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_thunkOrdinal"/>
+    public HRESULT get_thunkOrdinal(uint* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint*, HRESULT>)_lpVtbl[35])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_thisAdjust"/>
+    public HRESULT get_thisAdjust(int* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, int*, HRESULT>)_lpVtbl[36])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_virtualBaseOffset"/>
+    public HRESULT get_virtualBaseOffset(uint* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint*, HRESULT>)_lpVtbl[37])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_virtual"/>
+    public HRESULT get_virtual(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BOOL*, HRESULT>)_lpVtbl[38])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_intro"/>
+    public HRESULT get_intro(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BOOL*, HRESULT>)_lpVtbl[39])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_pure"/>
+    public HRESULT get_pure(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BOOL*, HRESULT>)_lpVtbl[40])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_callingConvention"/>
+    public HRESULT get_callingConvention(uint* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint*, HRESULT>)_lpVtbl[41])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_value"/>
+    public HRESULT get_value(VARIANT* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, VARIANT*, HRESULT>)_lpVtbl[42])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_baseType"/>
+    public HRESULT get_baseType(uint* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint*, HRESULT>)_lpVtbl[43])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_token"/>
+    public HRESULT get_token(uint* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint*, HRESULT>)_lpVtbl[44])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_timeStamp"/>
+    public HRESULT get_timeStamp(uint* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint*, HRESULT>)_lpVtbl[45])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_guid"/>
+    public HRESULT get_guid(Guid* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, Guid*, HRESULT>)_lpVtbl[46])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_symbolsFileName"/>
+    public HRESULT get_symbolsFileName(BSTR* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BSTR*, HRESULT>)_lpVtbl[47])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_reference"/>
+    public HRESULT get_reference(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BOOL*, HRESULT>)_lpVtbl[48])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_count"/>
+    public HRESULT get_count(uint* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint*, HRESULT>)_lpVtbl[49])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_bitPosition"/>
+    public HRESULT get_bitPosition(uint* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint*, HRESULT>)_lpVtbl[50])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_arrayIndexType"/>
+    public HRESULT get_arrayIndexType(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, IDiaSymbol**, HRESULT>)_lpVtbl[51])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_packed"/>
+    public HRESULT get_packed(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BOOL*, HRESULT>)_lpVtbl[52])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_constructor"/>
+    public HRESULT get_constructor(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BOOL*, HRESULT>)_lpVtbl[53])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_overloadedOperator"/>
+    public HRESULT get_overloadedOperator(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BOOL*, HRESULT>)_lpVtbl[54])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_nested"/>
+    public HRESULT get_nested(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BOOL*, HRESULT>)_lpVtbl[55])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasNestedTypes"/>
+    public HRESULT get_hasNestedTypes(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BOOL*, HRESULT>)_lpVtbl[56])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasAssignmentOperator"/>
+    public HRESULT get_hasAssignmentOperator(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BOOL*, HRESULT>)_lpVtbl[57])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasCastOperator"/>
+    public HRESULT get_hasCastOperator(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BOOL*, HRESULT>)_lpVtbl[58])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_scoped"/>
+    public HRESULT get_scoped(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BOOL*, HRESULT>)_lpVtbl[59])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_virtualBaseClass"/>
+    public HRESULT get_virtualBaseClass(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BOOL*, HRESULT>)_lpVtbl[60])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_indirectVirtualBaseClass"/>
+    public HRESULT get_indirectVirtualBaseClass(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BOOL*, HRESULT>)_lpVtbl[61])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_virtualBasePointerOffset"/>
+    public HRESULT get_virtualBasePointerOffset(int* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, int*, HRESULT>)_lpVtbl[62])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_virtualTableShape"/>
+    public HRESULT get_virtualTableShape(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, IDiaSymbol**, HRESULT>)_lpVtbl[63])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_lexicalParentId"/>
+    public HRESULT get_lexicalParentId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint*, HRESULT>)_lpVtbl[64])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_classParentId"/>
+    public HRESULT get_classParentId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint*, HRESULT>)_lpVtbl[65])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_typeId"/>
+    public HRESULT get_typeId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint*, HRESULT>)_lpVtbl[66])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_arrayIndexTypeId"/>
+    public HRESULT get_arrayIndexTypeId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint*, HRESULT>)_lpVtbl[67])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_virtualTableShapeId"/>
+    public HRESULT get_virtualTableShapeId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint*, HRESULT>)_lpVtbl[68])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_code"/>
+    public HRESULT get_code(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BOOL*, HRESULT>)_lpVtbl[69])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_function"/>
+    public HRESULT get_function(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BOOL*, HRESULT>)_lpVtbl[70])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_managed"/>
+    public HRESULT get_managed(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BOOL*, HRESULT>)_lpVtbl[71])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_msil"/>
+    public HRESULT get_msil(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BOOL*, HRESULT>)_lpVtbl[72])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_virtualBaseDispIndex"/>
+    public HRESULT get_virtualBaseDispIndex(uint* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint*, HRESULT>)_lpVtbl[73])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_undecoratedName"/>
+    public HRESULT get_undecoratedName(BSTR* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BSTR*, HRESULT>)_lpVtbl[74])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_age"/>
+    public HRESULT get_age(uint* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint*, HRESULT>)_lpVtbl[75])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_signature"/>
+    public HRESULT get_signature(uint* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint*, HRESULT>)_lpVtbl[76])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_compilerGenerated"/>
+    public HRESULT get_compilerGenerated(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BOOL*, HRESULT>)_lpVtbl[77])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_addressTaken"/>
+    public HRESULT get_addressTaken(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BOOL*, HRESULT>)_lpVtbl[78])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_rank"/>
+    public HRESULT get_rank(uint* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint*, HRESULT>)_lpVtbl[79])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_lowerBound"/>
+    public HRESULT get_lowerBound(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, IDiaSymbol**, HRESULT>)_lpVtbl[80])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_upperBound"/>
+    public HRESULT get_upperBound(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, IDiaSymbol**, HRESULT>)_lpVtbl[81])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_lowerBoundId"/>
+    public HRESULT get_lowerBoundId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint*, HRESULT>)_lpVtbl[82])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_upperBoundId"/>
+    public HRESULT get_upperBoundId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint*, HRESULT>)_lpVtbl[83])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_dataBytes"/>
+    public HRESULT get_dataBytes(uint cbData, uint* pcbData, byte* pbData)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint, uint*, byte*, HRESULT>)_lpVtbl[84])(pThis, cbData, pcbData, pbData);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findChildren"/>
+    public HRESULT findChildren(SymTagEnum symtag, PCWSTR name, uint compareFlags, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, SymTagEnum, PCWSTR, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[85])(pThis, symtag, name, compareFlags, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findChildrenEx"/>
+    public HRESULT findChildrenEx(SymTagEnum symtag, PCWSTR name, uint compareFlags, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, SymTagEnum, PCWSTR, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[86])(pThis, symtag, name, compareFlags, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findChildrenExByAddr"/>
+    public HRESULT findChildrenExByAddr(SymTagEnum symtag, PCWSTR name, uint compareFlags, uint isect, uint offset, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, SymTagEnum, PCWSTR, uint, uint, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[87])(pThis, symtag, name, compareFlags, isect, offset, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findChildrenExByVA"/>
+    public HRESULT findChildrenExByVA(SymTagEnum symtag, PCWSTR name, uint compareFlags, ulong va, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, SymTagEnum, PCWSTR, uint, ulong, IDiaEnumSymbols**, HRESULT>)_lpVtbl[88])(pThis, symtag, name, compareFlags, va, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findChildrenExByRVA"/>
+    public HRESULT findChildrenExByRVA(SymTagEnum symtag, PCWSTR name, uint compareFlags, uint rva, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, SymTagEnum, PCWSTR, uint, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[89])(pThis, symtag, name, compareFlags, rva, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_targetSection"/>
+    public HRESULT get_targetSection(uint* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint*, HRESULT>)_lpVtbl[90])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_targetOffset"/>
+    public HRESULT get_targetOffset(uint* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint*, HRESULT>)_lpVtbl[91])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_targetRelativeVirtualAddress"/>
+    public HRESULT get_targetRelativeVirtualAddress(uint* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint*, HRESULT>)_lpVtbl[92])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_targetVirtualAddress"/>
+    public HRESULT get_targetVirtualAddress(ulong* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, ulong*, HRESULT>)_lpVtbl[93])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_machineType"/>
+    public HRESULT get_machineType(uint* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint*, HRESULT>)_lpVtbl[94])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_oemId"/>
+    public HRESULT get_oemId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint*, HRESULT>)_lpVtbl[95])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_oemSymbolId"/>
+    public HRESULT get_oemSymbolId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint*, HRESULT>)_lpVtbl[96])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_types"/>
+    public HRESULT get_types(uint cTypes, uint* pcTypes, IDiaSymbol** pTypes)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint, uint*, IDiaSymbol**, HRESULT>)_lpVtbl[97])(pThis, cTypes, pcTypes, pTypes);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_typeIds"/>
+    public HRESULT get_typeIds(uint cTypeIds, uint* pcTypeIds, uint* pdwTypeIds)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint, uint*, uint*, HRESULT>)_lpVtbl[98])(pThis, cTypeIds, pcTypeIds, pdwTypeIds);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_objectPointerType"/>
+    public HRESULT get_objectPointerType(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, IDiaSymbol**, HRESULT>)_lpVtbl[99])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_udtKind"/>
+    public HRESULT get_udtKind(uint* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint*, HRESULT>)_lpVtbl[100])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_undecoratedNameEx"/>
+    public HRESULT get_undecoratedNameEx(uint undecorateOptions, BSTR* name)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint, BSTR*, HRESULT>)_lpVtbl[101])(pThis, undecorateOptions, name);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_noReturn"/>
+    public HRESULT get_noReturn(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BOOL*, HRESULT>)_lpVtbl[102])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_customCallingConvention"/>
+    public HRESULT get_customCallingConvention(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BOOL*, HRESULT>)_lpVtbl[103])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_noInline"/>
+    public HRESULT get_noInline(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BOOL*, HRESULT>)_lpVtbl[104])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_optimizedCodeDebugInfo"/>
+    public HRESULT get_optimizedCodeDebugInfo(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BOOL*, HRESULT>)_lpVtbl[105])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_notReached"/>
+    public HRESULT get_notReached(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BOOL*, HRESULT>)_lpVtbl[106])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_interruptReturn"/>
+    public HRESULT get_interruptReturn(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BOOL*, HRESULT>)_lpVtbl[107])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_farReturn"/>
+    public HRESULT get_farReturn(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BOOL*, HRESULT>)_lpVtbl[108])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isStatic"/>
+    public HRESULT get_isStatic(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BOOL*, HRESULT>)_lpVtbl[109])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasDebugInfo"/>
+    public HRESULT get_hasDebugInfo(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BOOL*, HRESULT>)_lpVtbl[110])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isLTCG"/>
+    public HRESULT get_isLTCG(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BOOL*, HRESULT>)_lpVtbl[111])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isDataAligned"/>
+    public HRESULT get_isDataAligned(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BOOL*, HRESULT>)_lpVtbl[112])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasSecurityChecks"/>
+    public HRESULT get_hasSecurityChecks(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BOOL*, HRESULT>)_lpVtbl[113])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_compilerName"/>
+    public HRESULT get_compilerName(BSTR* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BSTR*, HRESULT>)_lpVtbl[114])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasAlloca"/>
+    public HRESULT get_hasAlloca(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BOOL*, HRESULT>)_lpVtbl[115])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasSetJump"/>
+    public HRESULT get_hasSetJump(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BOOL*, HRESULT>)_lpVtbl[116])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasLongJump"/>
+    public HRESULT get_hasLongJump(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BOOL*, HRESULT>)_lpVtbl[117])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasInlAsm"/>
+    public HRESULT get_hasInlAsm(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BOOL*, HRESULT>)_lpVtbl[118])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasEH"/>
+    public HRESULT get_hasEH(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BOOL*, HRESULT>)_lpVtbl[119])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasSEH"/>
+    public HRESULT get_hasSEH(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BOOL*, HRESULT>)_lpVtbl[120])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasEHa"/>
+    public HRESULT get_hasEHa(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BOOL*, HRESULT>)_lpVtbl[121])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isNaked"/>
+    public HRESULT get_isNaked(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BOOL*, HRESULT>)_lpVtbl[122])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isAggregated"/>
+    public HRESULT get_isAggregated(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BOOL*, HRESULT>)_lpVtbl[123])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isSplitted"/>
+    public HRESULT get_isSplitted(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BOOL*, HRESULT>)_lpVtbl[124])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_container"/>
+    public HRESULT get_container(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, IDiaSymbol**, HRESULT>)_lpVtbl[125])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_inlSpec"/>
+    public HRESULT get_inlSpec(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BOOL*, HRESULT>)_lpVtbl[126])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_noStackOrdering"/>
+    public HRESULT get_noStackOrdering(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BOOL*, HRESULT>)_lpVtbl[127])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_virtualBaseTableType"/>
+    public HRESULT get_virtualBaseTableType(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, IDiaSymbol**, HRESULT>)_lpVtbl[128])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasManagedCode"/>
+    public HRESULT get_hasManagedCode(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BOOL*, HRESULT>)_lpVtbl[129])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isHotpatchable"/>
+    public HRESULT get_isHotpatchable(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BOOL*, HRESULT>)_lpVtbl[130])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isCVTCIL"/>
+    public HRESULT get_isCVTCIL(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BOOL*, HRESULT>)_lpVtbl[131])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isMSILNetmodule"/>
+    public HRESULT get_isMSILNetmodule(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BOOL*, HRESULT>)_lpVtbl[132])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isCTypes"/>
+    public HRESULT get_isCTypes(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BOOL*, HRESULT>)_lpVtbl[133])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isStripped"/>
+    public HRESULT get_isStripped(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BOOL*, HRESULT>)_lpVtbl[134])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_frontEndQFE"/>
+    public HRESULT get_frontEndQFE(uint* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint*, HRESULT>)_lpVtbl[135])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_backEndQFE"/>
+    public HRESULT get_backEndQFE(uint* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint*, HRESULT>)_lpVtbl[136])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_wasInlined"/>
+    public HRESULT get_wasInlined(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BOOL*, HRESULT>)_lpVtbl[137])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_strictGSCheck"/>
+    public HRESULT get_strictGSCheck(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BOOL*, HRESULT>)_lpVtbl[138])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isCxxReturnUdt"/>
+    public HRESULT get_isCxxReturnUdt(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BOOL*, HRESULT>)_lpVtbl[139])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isConstructorVirtualBase"/>
+    public HRESULT get_isConstructorVirtualBase(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BOOL*, HRESULT>)_lpVtbl[140])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_RValueReference"/>
+    public HRESULT get_RValueReference(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BOOL*, HRESULT>)_lpVtbl[141])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_unmodifiedType"/>
+    public HRESULT get_unmodifiedType(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, IDiaSymbol**, HRESULT>)_lpVtbl[142])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_framePointerPresent"/>
+    public HRESULT get_framePointerPresent(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BOOL*, HRESULT>)_lpVtbl[143])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isSafeBuffers"/>
+    public HRESULT get_isSafeBuffers(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BOOL*, HRESULT>)_lpVtbl[144])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_intrinsic"/>
+    public HRESULT get_intrinsic(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BOOL*, HRESULT>)_lpVtbl[145])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_sealed"/>
+    public HRESULT get_sealed(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BOOL*, HRESULT>)_lpVtbl[146])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hfaFloat"/>
+    public HRESULT get_hfaFloat(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BOOL*, HRESULT>)_lpVtbl[147])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hfaDouble"/>
+    public HRESULT get_hfaDouble(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BOOL*, HRESULT>)_lpVtbl[148])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_liveRangeStartAddressSection"/>
+    public HRESULT get_liveRangeStartAddressSection(uint* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint*, HRESULT>)_lpVtbl[149])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_liveRangeStartAddressOffset"/>
+    public HRESULT get_liveRangeStartAddressOffset(uint* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint*, HRESULT>)_lpVtbl[150])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_liveRangeStartRelativeVirtualAddress"/>
+    public HRESULT get_liveRangeStartRelativeVirtualAddress(uint* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint*, HRESULT>)_lpVtbl[151])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_countLiveRanges"/>
+    public HRESULT get_countLiveRanges(uint* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint*, HRESULT>)_lpVtbl[152])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_liveRangeLength"/>
+    public HRESULT get_liveRangeLength(ulong* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, ulong*, HRESULT>)_lpVtbl[153])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_offsetInUdt"/>
+    public HRESULT get_offsetInUdt(uint* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint*, HRESULT>)_lpVtbl[154])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_paramBasePointerRegisterId"/>
+    public HRESULT get_paramBasePointerRegisterId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint*, HRESULT>)_lpVtbl[155])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_localBasePointerRegisterId"/>
+    public HRESULT get_localBasePointerRegisterId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint*, HRESULT>)_lpVtbl[156])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isLocationControlFlowDependent"/>
+    public HRESULT get_isLocationControlFlowDependent(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BOOL*, HRESULT>)_lpVtbl[157])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_stride"/>
+    public HRESULT get_stride(uint* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint*, HRESULT>)_lpVtbl[158])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_numberOfRows"/>
+    public HRESULT get_numberOfRows(uint* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint*, HRESULT>)_lpVtbl[159])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_numberOfColumns"/>
+    public HRESULT get_numberOfColumns(uint* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint*, HRESULT>)_lpVtbl[160])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isMatrixRowMajor"/>
+    public HRESULT get_isMatrixRowMajor(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BOOL*, HRESULT>)_lpVtbl[161])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_numericProperties"/>
+    public HRESULT get_numericProperties(uint cnt, uint* pcnt, uint* pProperties)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint, uint*, uint*, HRESULT>)_lpVtbl[162])(pThis, cnt, pcnt, pProperties);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_modifierValues"/>
+    public HRESULT get_modifierValues(uint cnt, uint* pcnt, ushort* pModifiers)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint, uint*, ushort*, HRESULT>)_lpVtbl[163])(pThis, cnt, pcnt, pModifiers);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isReturnValue"/>
+    public HRESULT get_isReturnValue(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BOOL*, HRESULT>)_lpVtbl[164])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isOptimizedAway"/>
+    public HRESULT get_isOptimizedAway(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BOOL*, HRESULT>)_lpVtbl[165])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_builtInKind"/>
+    public HRESULT get_builtInKind(uint* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint*, HRESULT>)_lpVtbl[166])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_registerType"/>
+    public HRESULT get_registerType(uint* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint*, HRESULT>)_lpVtbl[167])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_baseDataSlot"/>
+    public HRESULT get_baseDataSlot(uint* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint*, HRESULT>)_lpVtbl[168])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_baseDataOffset"/>
+    public HRESULT get_baseDataOffset(uint* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint*, HRESULT>)_lpVtbl[169])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_textureSlot"/>
+    public HRESULT get_textureSlot(uint* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint*, HRESULT>)_lpVtbl[170])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_samplerSlot"/>
+    public HRESULT get_samplerSlot(uint* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint*, HRESULT>)_lpVtbl[171])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_uavSlot"/>
+    public HRESULT get_uavSlot(uint* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint*, HRESULT>)_lpVtbl[172])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_sizeInUdt"/>
+    public HRESULT get_sizeInUdt(uint* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint*, HRESULT>)_lpVtbl[173])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_memorySpaceKind"/>
+    public HRESULT get_memorySpaceKind(uint* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint*, HRESULT>)_lpVtbl[174])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_unmodifiedTypeId"/>
+    public HRESULT get_unmodifiedTypeId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint*, HRESULT>)_lpVtbl[175])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_subTypeId"/>
+    public HRESULT get_subTypeId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint*, HRESULT>)_lpVtbl[176])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_subType"/>
+    public HRESULT get_subType(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, IDiaSymbol**, HRESULT>)_lpVtbl[177])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_numberOfModifiers"/>
+    public HRESULT get_numberOfModifiers(uint* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint*, HRESULT>)_lpVtbl[178])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_numberOfRegisterIndices"/>
+    public HRESULT get_numberOfRegisterIndices(uint* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint*, HRESULT>)_lpVtbl[179])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isHLSLData"/>
+    public HRESULT get_isHLSLData(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BOOL*, HRESULT>)_lpVtbl[180])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isPointerToDataMember"/>
+    public HRESULT get_isPointerToDataMember(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BOOL*, HRESULT>)_lpVtbl[181])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isPointerToMemberFunction"/>
+    public HRESULT get_isPointerToMemberFunction(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BOOL*, HRESULT>)_lpVtbl[182])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isSingleInheritance"/>
+    public HRESULT get_isSingleInheritance(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BOOL*, HRESULT>)_lpVtbl[183])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isMultipleInheritance"/>
+    public HRESULT get_isMultipleInheritance(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BOOL*, HRESULT>)_lpVtbl[184])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isVirtualInheritance"/>
+    public HRESULT get_isVirtualInheritance(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BOOL*, HRESULT>)_lpVtbl[185])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_restrictedType"/>
+    public HRESULT get_restrictedType(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BOOL*, HRESULT>)_lpVtbl[186])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isPointerBasedOnSymbolValue"/>
+    public HRESULT get_isPointerBasedOnSymbolValue(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BOOL*, HRESULT>)_lpVtbl[187])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_baseSymbol"/>
+    public HRESULT get_baseSymbol(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, IDiaSymbol**, HRESULT>)_lpVtbl[188])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_baseSymbolId"/>
+    public HRESULT get_baseSymbolId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint*, HRESULT>)_lpVtbl[189])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_objectFileName"/>
+    public HRESULT get_objectFileName(BSTR* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BSTR*, HRESULT>)_lpVtbl[190])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isAcceleratorGroupSharedLocal"/>
+    public HRESULT get_isAcceleratorGroupSharedLocal(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BOOL*, HRESULT>)_lpVtbl[191])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isAcceleratorPointerTagLiveRange"/>
+    public HRESULT get_isAcceleratorPointerTagLiveRange(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BOOL*, HRESULT>)_lpVtbl[192])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isAcceleratorStubFunction"/>
+    public HRESULT get_isAcceleratorStubFunction(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BOOL*, HRESULT>)_lpVtbl[193])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_numberOfAcceleratorPointerTags"/>
+    public HRESULT get_numberOfAcceleratorPointerTags(uint* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint*, HRESULT>)_lpVtbl[194])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isSdl"/>
+    public HRESULT get_isSdl(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BOOL*, HRESULT>)_lpVtbl[195])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isWinRTPointer"/>
+    public HRESULT get_isWinRTPointer(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BOOL*, HRESULT>)_lpVtbl[196])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isRefUdt"/>
+    public HRESULT get_isRefUdt(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BOOL*, HRESULT>)_lpVtbl[197])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isValueUdt"/>
+    public HRESULT get_isValueUdt(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BOOL*, HRESULT>)_lpVtbl[198])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isInterfaceUdt"/>
+    public HRESULT get_isInterfaceUdt(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BOOL*, HRESULT>)_lpVtbl[199])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findInlineFramesByAddr"/>
+    public HRESULT findInlineFramesByAddr(uint isect, uint offset, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[200])(pThis, isect, offset, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findInlineFramesByRVA"/>
+    public HRESULT findInlineFramesByRVA(uint rva, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[201])(pThis, rva, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findInlineFramesByVA"/>
+    public HRESULT findInlineFramesByVA(ulong va, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, ulong, IDiaEnumSymbols**, HRESULT>)_lpVtbl[202])(pThis, va, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findInlineeLines"/>
+    public HRESULT findInlineeLines(IDiaEnumLineNumbers** ppResult)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, IDiaEnumLineNumbers**, HRESULT>)_lpVtbl[203])(pThis, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findInlineeLinesByAddr"/>
+    public HRESULT findInlineeLinesByAddr(uint isect, uint offset, uint length, IDiaEnumLineNumbers** ppResult)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint, uint, uint, IDiaEnumLineNumbers**, HRESULT>)_lpVtbl[204])(pThis, isect, offset, length, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findInlineeLinesByRVA"/>
+    public HRESULT findInlineeLinesByRVA(uint rva, uint length, IDiaEnumLineNumbers** ppResult)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint, uint, IDiaEnumLineNumbers**, HRESULT>)_lpVtbl[205])(pThis, rva, length, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findInlineeLinesByVA"/>
+    public HRESULT findInlineeLinesByVA(ulong va, uint length, IDiaEnumLineNumbers** ppResult)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, ulong, uint, IDiaEnumLineNumbers**, HRESULT>)_lpVtbl[206])(pThis, va, length, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findSymbolsForAcceleratorPointerTag"/>
+    public HRESULT findSymbolsForAcceleratorPointerTag(uint tagValue, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[207])(pThis, tagValue, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findSymbolsByRVAForAcceleratorPointerTag"/>
+    public HRESULT findSymbolsByRVAForAcceleratorPointerTag(uint tagValue, uint rva, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[208])(pThis, tagValue, rva, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_acceleratorPointerTags"/>
+    public HRESULT get_acceleratorPointerTags(uint cnt, uint* pcnt, uint* pPointerTags)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint, uint*, uint*, HRESULT>)_lpVtbl[209])(pThis, cnt, pcnt, pPointerTags);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.getSrcLineOnTypeDefn"/>
+    public HRESULT getSrcLineOnTypeDefn(IDiaLineNumber** ppResult)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, IDiaLineNumber**, HRESULT>)_lpVtbl[210])(pThis, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isPGO"/>
+    public HRESULT get_isPGO(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BOOL*, HRESULT>)_lpVtbl[211])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasValidPGOCounts"/>
+    public HRESULT get_hasValidPGOCounts(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BOOL*, HRESULT>)_lpVtbl[212])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isOptimizedForSpeed"/>
+    public HRESULT get_isOptimizedForSpeed(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BOOL*, HRESULT>)_lpVtbl[213])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_PGOEntryCount"/>
+    public HRESULT get_PGOEntryCount(uint* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint*, HRESULT>)_lpVtbl[214])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_PGOEdgeCount"/>
+    public HRESULT get_PGOEdgeCount(uint* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint*, HRESULT>)_lpVtbl[215])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_PGODynamicInstructionCount"/>
+    public HRESULT get_PGODynamicInstructionCount(ulong* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, ulong*, HRESULT>)_lpVtbl[216])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_staticSize"/>
+    public HRESULT get_staticSize(uint* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint*, HRESULT>)_lpVtbl[217])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_finalLiveStaticSize"/>
+    public HRESULT get_finalLiveStaticSize(uint* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint*, HRESULT>)_lpVtbl[218])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_phaseName"/>
+    public HRESULT get_phaseName(BSTR* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BSTR*, HRESULT>)_lpVtbl[219])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasControlFlowCheck"/>
+    public HRESULT get_hasControlFlowCheck(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BOOL*, HRESULT>)_lpVtbl[220])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_constantExport"/>
+    public HRESULT get_constantExport(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BOOL*, HRESULT>)_lpVtbl[221])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_dataExport"/>
+    public HRESULT get_dataExport(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BOOL*, HRESULT>)_lpVtbl[222])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_privateExport"/>
+    public HRESULT get_privateExport(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BOOL*, HRESULT>)_lpVtbl[223])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_noNameExport"/>
+    public HRESULT get_noNameExport(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BOOL*, HRESULT>)_lpVtbl[224])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_exportHasExplicitlyAssignedOrdinal"/>
+    public HRESULT get_exportHasExplicitlyAssignedOrdinal(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BOOL*, HRESULT>)_lpVtbl[225])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_exportIsForwarder"/>
+    public HRESULT get_exportIsForwarder(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BOOL*, HRESULT>)_lpVtbl[226])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_ordinal"/>
+    public HRESULT get_ordinal(uint* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint*, HRESULT>)_lpVtbl[227])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_frameSize"/>
+    public HRESULT get_frameSize(uint* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint*, HRESULT>)_lpVtbl[228])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_exceptionHandlerAddressSection"/>
+    public HRESULT get_exceptionHandlerAddressSection(uint* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint*, HRESULT>)_lpVtbl[229])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_exceptionHandlerAddressOffset"/>
+    public HRESULT get_exceptionHandlerAddressOffset(uint* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint*, HRESULT>)_lpVtbl[230])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_exceptionHandlerRelativeVirtualAddress"/>
+    public HRESULT get_exceptionHandlerRelativeVirtualAddress(uint* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint*, HRESULT>)_lpVtbl[231])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_exceptionHandlerVirtualAddress"/>
+    public HRESULT get_exceptionHandlerVirtualAddress(ulong* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, ulong*, HRESULT>)_lpVtbl[232])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findInputAssemblyFile"/>
+    public HRESULT findInputAssemblyFile(IDiaInputAssemblyFile** ppResult)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, IDiaInputAssemblyFile**, HRESULT>)_lpVtbl[233])(pThis, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_characteristics"/>
+    public HRESULT get_characteristics(uint* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint*, HRESULT>)_lpVtbl[234])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_coffGroup"/>
+    public HRESULT get_coffGroup(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, IDiaSymbol**, HRESULT>)_lpVtbl[235])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_bindID"/>
+    public HRESULT get_bindID(uint* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint*, HRESULT>)_lpVtbl[236])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_bindSpace"/>
+    public HRESULT get_bindSpace(uint* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint*, HRESULT>)_lpVtbl[237])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_bindSlot"/>
+    public HRESULT get_bindSlot(uint* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint*, HRESULT>)_lpVtbl[238])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol2.Interface.get_isObjCClass"/>
+    public HRESULT get_isObjCClass(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BOOL*, HRESULT>)_lpVtbl[239])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol2.Interface.get_isObjCCategory"/>
+    public HRESULT get_isObjCCategory(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BOOL*, HRESULT>)_lpVtbl[240])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol2.Interface.get_isObjCProtocol"/>
+    public HRESULT get_isObjCProtocol(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BOOL*, HRESULT>)_lpVtbl[241])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol3.Interface.get_inlinee"/>
+    public HRESULT get_inlinee(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, IDiaSymbol**, HRESULT>)_lpVtbl[242])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol3.Interface.get_inlineeId"/>
+    public HRESULT get_inlineeId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint*, HRESULT>)_lpVtbl[243])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol4.Interface.get_noexcept"/>
+    public HRESULT get_noexcept(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BOOL*, HRESULT>)_lpVtbl[244])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol5.Interface.get_hasAbsoluteAddress"/>
+    public HRESULT get_hasAbsoluteAddress(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BOOL*, HRESULT>)_lpVtbl[245])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol6.Interface.get_isStaticMemberFunc"/>
+    public HRESULT get_isStaticMemberFunc(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BOOL*, HRESULT>)_lpVtbl[246])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol7.Interface.get_isSignRet"/>
+    public HRESULT get_isSignRet(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BOOL*, HRESULT>)_lpVtbl[247])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol8.Interface.get_coroutineKind"/>
+    public HRESULT get_coroutineKind(uint* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint*, HRESULT>)_lpVtbl[248])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol8.Interface.get_associatedSymbolKind"/>
+    public HRESULT get_associatedSymbolKind(uint* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint*, HRESULT>)_lpVtbl[249])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol8.Interface.get_associatedSymbolSection"/>
+    public HRESULT get_associatedSymbolSection(uint* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint*, HRESULT>)_lpVtbl[250])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol8.Interface.get_associatedSymbolOffset"/>
+    public HRESULT get_associatedSymbolOffset(uint* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint*, HRESULT>)_lpVtbl[251])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol8.Interface.get_associatedSymbolRva"/>
+    public HRESULT get_associatedSymbolRva(uint* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint*, HRESULT>)_lpVtbl[252])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol8.Interface.get_associatedSymbolAddr"/>
+    public HRESULT get_associatedSymbolAddr(ulong* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, ulong*, HRESULT>)_lpVtbl[253])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol9.Interface.get_framePadSize"/>
+    public HRESULT get_framePadSize(uint* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint*, HRESULT>)_lpVtbl[254])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol9.Interface.get_framePadOffset"/>
+    public HRESULT get_framePadOffset(uint* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint*, HRESULT>)_lpVtbl[255])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol9.Interface.get_isRTCs"/>
+    public HRESULT get_isRTCs(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, BOOL*, HRESULT>)_lpVtbl[256])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol10.Interface.get_sourceLink"/>
+    public HRESULT get_sourceLink(uint cb, uint* pcb, byte* pb)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint, uint*, byte*, HRESULT>)_lpVtbl[257])(pThis, cb, pcb, pb);
+    }
+
+    /// <inheritdoc cref="Interface.get_discriminatedUnionTag"/>
+    public HRESULT get_discriminatedUnionTag(IDiaSymbol** ppTagType, uint* pTagOffset, DiaTagValue* pTagMask)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, IDiaSymbol**, uint*, DiaTagValue*, HRESULT>)_lpVtbl[258])(pThis, ppTagType, pTagOffset, pTagMask);
+    }
+
+    /// <inheritdoc cref="Interface.get_tagRanges"/>
+    public HRESULT get_tagRanges(uint count, uint* pcRangeValues, DiaTagValue* rangeValues)
+    {
+        fixed (IDiaSymbol11* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol11*, uint, uint*, DiaTagValue*, HRESULT>)_lpVtbl[259])(pThis, count, pcRangeValues, rangeValues);
+    }
+
+    /// <summary>
+    ///  Extends IDiaSymbol10 with discriminated union tag information.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/visualstudio/debugger/debug-interface-access/idiasymbol11">
+    ///    Official documentation.
+    ///   </see>
+    ///  </para>
+    /// </remarks>
+    [ComImport]
+    [Guid("B6F54FCD-05E3-433D-B305-B0C1437D2D16")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    public unsafe interface Interface : IDiaSymbol10.Interface
+    {
+        /// <summary>
+        ///  Retrieves the discriminated union tag.
+        /// </summary>
+        /// <param name="ppTagType">Pointer to a variable that receives the requested object.</param>
+        /// <param name="pTagOffset">Pointer to a variable that receives the requested value.</param>
+        /// <param name="pTagMask">Pointer to a variable that receives the requested value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_discriminatedUnionTag(IDiaSymbol** ppTagType, uint* pTagOffset, DiaTagValue* pTagMask);
+
+        /// <summary>
+        ///  Retrieves the tag ranges.
+        /// </summary>
+        /// <param name="count">The count value.</param>
+        /// <param name="pcRangeValues">Pointer to a variable that receives the requested value.</param>
+        /// <param name="rangeValues">Pointer to a caller-allocated buffer that receives the data.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_tagRanges(uint count, uint* pcRangeValues, DiaTagValue* rangeValues);
+    }
+}

--- a/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaSymbol2.cs
+++ b/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaSymbol2.cs
@@ -1,0 +1,1778 @@
+﻿// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Runtime.InteropServices;
+using Windows.Win32.System.Variant;
+
+// For some reason the XML comment refs for IUnknown can't be resolved on .NET Framework without
+// explicitly using the fully qualified name, which falls afoul of the simplify warning.
+using ComIUnknown = Windows.Win32.System.Com.IUnknown;
+
+namespace Microsoft.VisualStudio.Debugging.DebugInterfaceAccess;
+
+/// <inheritdoc cref="Interface"/>
+public unsafe struct IDiaSymbol2 : IComIID
+{
+    /// <inheritdoc cref="IComIID.Guid"/>
+#pragma warning disable IDE1006 // Naming Styles
+    public static readonly Guid IID_Guid = new(0x611E86CD, 0xB7D1, 0x4546, 0x8A, 0x15, 0x07, 0x0E, 0x2B, 0x07, 0xA4, 0x27);
+#pragma warning restore IDE1006
+
+#if NETFRAMEWORK
+    readonly ref readonly Guid IComIID.Guid => ref IID_Guid;
+#else
+    static ref readonly Guid IComIID.Guid
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get
+        {
+            ReadOnlySpan<byte> data =
+            [
+                0xCD, 0x86, 0x1E, 0x61,
+                0xD1, 0xB7,
+                0x46, 0x45,
+                0x8A, 0x15, 0x07, 0x0E, 0x2B, 0x07, 0xA4, 0x27
+            ];
+
+            return ref Unsafe.As<byte, Guid>(ref MemoryMarshal.GetReference(data));
+        }
+    }
+#endif
+
+    private readonly void** _lpVtbl;
+
+    /// <inheritdoc cref="ComIUnknown.QueryInterface(Guid*, void**)"/>
+    public HRESULT QueryInterface(Guid* riid, void** ppvObject)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, Guid*, void**, HRESULT>)_lpVtbl[0])(pThis, riid, ppvObject);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.AddRef"/>
+    public uint AddRef()
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, uint>)_lpVtbl[1])(pThis);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.Release"/>
+    public uint Release()
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, uint>)_lpVtbl[2])(pThis);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_symIndexId"/>
+    public HRESULT get_symIndexId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, uint*, HRESULT>)_lpVtbl[3])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_symTag"/>
+    public HRESULT get_symTag(uint* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, uint*, HRESULT>)_lpVtbl[4])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_name"/>
+    public HRESULT get_name(BSTR* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BSTR*, HRESULT>)_lpVtbl[5])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_lexicalParent"/>
+    public HRESULT get_lexicalParent(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, IDiaSymbol**, HRESULT>)_lpVtbl[6])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_classParent"/>
+    public HRESULT get_classParent(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, IDiaSymbol**, HRESULT>)_lpVtbl[7])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_type"/>
+    public HRESULT get_type(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, IDiaSymbol**, HRESULT>)_lpVtbl[8])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_dataKind"/>
+    public HRESULT get_dataKind(uint* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, uint*, HRESULT>)_lpVtbl[9])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_locationType"/>
+    public HRESULT get_locationType(uint* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, uint*, HRESULT>)_lpVtbl[10])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_addressSection"/>
+    public HRESULT get_addressSection(uint* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, uint*, HRESULT>)_lpVtbl[11])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_addressOffset"/>
+    public HRESULT get_addressOffset(uint* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, uint*, HRESULT>)_lpVtbl[12])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_relativeVirtualAddress"/>
+    public HRESULT get_relativeVirtualAddress(uint* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, uint*, HRESULT>)_lpVtbl[13])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_virtualAddress"/>
+    public HRESULT get_virtualAddress(ulong* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, ulong*, HRESULT>)_lpVtbl[14])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_registerId"/>
+    public HRESULT get_registerId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, uint*, HRESULT>)_lpVtbl[15])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_offset"/>
+    public HRESULT get_offset(int* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, int*, HRESULT>)_lpVtbl[16])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_length"/>
+    public HRESULT get_length(ulong* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, ulong*, HRESULT>)_lpVtbl[17])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_slot"/>
+    public HRESULT get_slot(uint* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, uint*, HRESULT>)_lpVtbl[18])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_volatileType"/>
+    public HRESULT get_volatileType(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BOOL*, HRESULT>)_lpVtbl[19])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_constType"/>
+    public HRESULT get_constType(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BOOL*, HRESULT>)_lpVtbl[20])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_unalignedType"/>
+    public HRESULT get_unalignedType(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BOOL*, HRESULT>)_lpVtbl[21])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_access"/>
+    public HRESULT get_access(uint* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, uint*, HRESULT>)_lpVtbl[22])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_libraryName"/>
+    public HRESULT get_libraryName(BSTR* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BSTR*, HRESULT>)_lpVtbl[23])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_platform"/>
+    public HRESULT get_platform(uint* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, uint*, HRESULT>)_lpVtbl[24])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_language"/>
+    public HRESULT get_language(uint* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, uint*, HRESULT>)_lpVtbl[25])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_editAndContinueEnabled"/>
+    public HRESULT get_editAndContinueEnabled(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BOOL*, HRESULT>)_lpVtbl[26])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_frontEndMajor"/>
+    public HRESULT get_frontEndMajor(uint* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, uint*, HRESULT>)_lpVtbl[27])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_frontEndMinor"/>
+    public HRESULT get_frontEndMinor(uint* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, uint*, HRESULT>)_lpVtbl[28])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_frontEndBuild"/>
+    public HRESULT get_frontEndBuild(uint* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, uint*, HRESULT>)_lpVtbl[29])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_backEndMajor"/>
+    public HRESULT get_backEndMajor(uint* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, uint*, HRESULT>)_lpVtbl[30])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_backEndMinor"/>
+    public HRESULT get_backEndMinor(uint* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, uint*, HRESULT>)_lpVtbl[31])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_backEndBuild"/>
+    public HRESULT get_backEndBuild(uint* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, uint*, HRESULT>)_lpVtbl[32])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_sourceFileName"/>
+    public HRESULT get_sourceFileName(BSTR* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BSTR*, HRESULT>)_lpVtbl[33])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_unused"/>
+    public HRESULT get_unused(BSTR* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BSTR*, HRESULT>)_lpVtbl[34])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_thunkOrdinal"/>
+    public HRESULT get_thunkOrdinal(uint* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, uint*, HRESULT>)_lpVtbl[35])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_thisAdjust"/>
+    public HRESULT get_thisAdjust(int* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, int*, HRESULT>)_lpVtbl[36])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_virtualBaseOffset"/>
+    public HRESULT get_virtualBaseOffset(uint* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, uint*, HRESULT>)_lpVtbl[37])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_virtual"/>
+    public HRESULT get_virtual(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BOOL*, HRESULT>)_lpVtbl[38])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_intro"/>
+    public HRESULT get_intro(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BOOL*, HRESULT>)_lpVtbl[39])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_pure"/>
+    public HRESULT get_pure(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BOOL*, HRESULT>)_lpVtbl[40])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_callingConvention"/>
+    public HRESULT get_callingConvention(uint* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, uint*, HRESULT>)_lpVtbl[41])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_value"/>
+    public HRESULT get_value(VARIANT* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, VARIANT*, HRESULT>)_lpVtbl[42])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_baseType"/>
+    public HRESULT get_baseType(uint* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, uint*, HRESULT>)_lpVtbl[43])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_token"/>
+    public HRESULT get_token(uint* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, uint*, HRESULT>)_lpVtbl[44])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_timeStamp"/>
+    public HRESULT get_timeStamp(uint* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, uint*, HRESULT>)_lpVtbl[45])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_guid"/>
+    public HRESULT get_guid(Guid* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, Guid*, HRESULT>)_lpVtbl[46])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_symbolsFileName"/>
+    public HRESULT get_symbolsFileName(BSTR* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BSTR*, HRESULT>)_lpVtbl[47])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_reference"/>
+    public HRESULT get_reference(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BOOL*, HRESULT>)_lpVtbl[48])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_count"/>
+    public HRESULT get_count(uint* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, uint*, HRESULT>)_lpVtbl[49])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_bitPosition"/>
+    public HRESULT get_bitPosition(uint* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, uint*, HRESULT>)_lpVtbl[50])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_arrayIndexType"/>
+    public HRESULT get_arrayIndexType(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, IDiaSymbol**, HRESULT>)_lpVtbl[51])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_packed"/>
+    public HRESULT get_packed(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BOOL*, HRESULT>)_lpVtbl[52])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_constructor"/>
+    public HRESULT get_constructor(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BOOL*, HRESULT>)_lpVtbl[53])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_overloadedOperator"/>
+    public HRESULT get_overloadedOperator(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BOOL*, HRESULT>)_lpVtbl[54])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_nested"/>
+    public HRESULT get_nested(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BOOL*, HRESULT>)_lpVtbl[55])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasNestedTypes"/>
+    public HRESULT get_hasNestedTypes(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BOOL*, HRESULT>)_lpVtbl[56])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasAssignmentOperator"/>
+    public HRESULT get_hasAssignmentOperator(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BOOL*, HRESULT>)_lpVtbl[57])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasCastOperator"/>
+    public HRESULT get_hasCastOperator(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BOOL*, HRESULT>)_lpVtbl[58])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_scoped"/>
+    public HRESULT get_scoped(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BOOL*, HRESULT>)_lpVtbl[59])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_virtualBaseClass"/>
+    public HRESULT get_virtualBaseClass(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BOOL*, HRESULT>)_lpVtbl[60])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_indirectVirtualBaseClass"/>
+    public HRESULT get_indirectVirtualBaseClass(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BOOL*, HRESULT>)_lpVtbl[61])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_virtualBasePointerOffset"/>
+    public HRESULT get_virtualBasePointerOffset(int* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, int*, HRESULT>)_lpVtbl[62])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_virtualTableShape"/>
+    public HRESULT get_virtualTableShape(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, IDiaSymbol**, HRESULT>)_lpVtbl[63])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_lexicalParentId"/>
+    public HRESULT get_lexicalParentId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, uint*, HRESULT>)_lpVtbl[64])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_classParentId"/>
+    public HRESULT get_classParentId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, uint*, HRESULT>)_lpVtbl[65])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_typeId"/>
+    public HRESULT get_typeId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, uint*, HRESULT>)_lpVtbl[66])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_arrayIndexTypeId"/>
+    public HRESULT get_arrayIndexTypeId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, uint*, HRESULT>)_lpVtbl[67])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_virtualTableShapeId"/>
+    public HRESULT get_virtualTableShapeId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, uint*, HRESULT>)_lpVtbl[68])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_code"/>
+    public HRESULT get_code(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BOOL*, HRESULT>)_lpVtbl[69])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_function"/>
+    public HRESULT get_function(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BOOL*, HRESULT>)_lpVtbl[70])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_managed"/>
+    public HRESULT get_managed(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BOOL*, HRESULT>)_lpVtbl[71])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_msil"/>
+    public HRESULT get_msil(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BOOL*, HRESULT>)_lpVtbl[72])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_virtualBaseDispIndex"/>
+    public HRESULT get_virtualBaseDispIndex(uint* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, uint*, HRESULT>)_lpVtbl[73])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_undecoratedName"/>
+    public HRESULT get_undecoratedName(BSTR* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BSTR*, HRESULT>)_lpVtbl[74])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_age"/>
+    public HRESULT get_age(uint* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, uint*, HRESULT>)_lpVtbl[75])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_signature"/>
+    public HRESULT get_signature(uint* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, uint*, HRESULT>)_lpVtbl[76])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_compilerGenerated"/>
+    public HRESULT get_compilerGenerated(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BOOL*, HRESULT>)_lpVtbl[77])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_addressTaken"/>
+    public HRESULT get_addressTaken(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BOOL*, HRESULT>)_lpVtbl[78])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_rank"/>
+    public HRESULT get_rank(uint* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, uint*, HRESULT>)_lpVtbl[79])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_lowerBound"/>
+    public HRESULT get_lowerBound(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, IDiaSymbol**, HRESULT>)_lpVtbl[80])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_upperBound"/>
+    public HRESULT get_upperBound(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, IDiaSymbol**, HRESULT>)_lpVtbl[81])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_lowerBoundId"/>
+    public HRESULT get_lowerBoundId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, uint*, HRESULT>)_lpVtbl[82])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_upperBoundId"/>
+    public HRESULT get_upperBoundId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, uint*, HRESULT>)_lpVtbl[83])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_dataBytes"/>
+    public HRESULT get_dataBytes(uint cbData, uint* pcbData, byte* pbData)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, uint, uint*, byte*, HRESULT>)_lpVtbl[84])(pThis, cbData, pcbData, pbData);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findChildren"/>
+    public HRESULT findChildren(SymTagEnum symtag, PCWSTR name, uint compareFlags, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, SymTagEnum, PCWSTR, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[85])(pThis, symtag, name, compareFlags, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findChildrenEx"/>
+    public HRESULT findChildrenEx(SymTagEnum symtag, PCWSTR name, uint compareFlags, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, SymTagEnum, PCWSTR, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[86])(pThis, symtag, name, compareFlags, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findChildrenExByAddr"/>
+    public HRESULT findChildrenExByAddr(SymTagEnum symtag, PCWSTR name, uint compareFlags, uint isect, uint offset, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, SymTagEnum, PCWSTR, uint, uint, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[87])(pThis, symtag, name, compareFlags, isect, offset, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findChildrenExByVA"/>
+    public HRESULT findChildrenExByVA(SymTagEnum symtag, PCWSTR name, uint compareFlags, ulong va, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, SymTagEnum, PCWSTR, uint, ulong, IDiaEnumSymbols**, HRESULT>)_lpVtbl[88])(pThis, symtag, name, compareFlags, va, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findChildrenExByRVA"/>
+    public HRESULT findChildrenExByRVA(SymTagEnum symtag, PCWSTR name, uint compareFlags, uint rva, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, SymTagEnum, PCWSTR, uint, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[89])(pThis, symtag, name, compareFlags, rva, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_targetSection"/>
+    public HRESULT get_targetSection(uint* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, uint*, HRESULT>)_lpVtbl[90])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_targetOffset"/>
+    public HRESULT get_targetOffset(uint* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, uint*, HRESULT>)_lpVtbl[91])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_targetRelativeVirtualAddress"/>
+    public HRESULT get_targetRelativeVirtualAddress(uint* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, uint*, HRESULT>)_lpVtbl[92])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_targetVirtualAddress"/>
+    public HRESULT get_targetVirtualAddress(ulong* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, ulong*, HRESULT>)_lpVtbl[93])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_machineType"/>
+    public HRESULT get_machineType(uint* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, uint*, HRESULT>)_lpVtbl[94])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_oemId"/>
+    public HRESULT get_oemId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, uint*, HRESULT>)_lpVtbl[95])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_oemSymbolId"/>
+    public HRESULT get_oemSymbolId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, uint*, HRESULT>)_lpVtbl[96])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_types"/>
+    public HRESULT get_types(uint cTypes, uint* pcTypes, IDiaSymbol** pTypes)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, uint, uint*, IDiaSymbol**, HRESULT>)_lpVtbl[97])(pThis, cTypes, pcTypes, pTypes);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_typeIds"/>
+    public HRESULT get_typeIds(uint cTypeIds, uint* pcTypeIds, uint* pdwTypeIds)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, uint, uint*, uint*, HRESULT>)_lpVtbl[98])(pThis, cTypeIds, pcTypeIds, pdwTypeIds);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_objectPointerType"/>
+    public HRESULT get_objectPointerType(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, IDiaSymbol**, HRESULT>)_lpVtbl[99])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_udtKind"/>
+    public HRESULT get_udtKind(uint* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, uint*, HRESULT>)_lpVtbl[100])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_undecoratedNameEx"/>
+    public HRESULT get_undecoratedNameEx(uint undecorateOptions, BSTR* name)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, uint, BSTR*, HRESULT>)_lpVtbl[101])(pThis, undecorateOptions, name);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_noReturn"/>
+    public HRESULT get_noReturn(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BOOL*, HRESULT>)_lpVtbl[102])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_customCallingConvention"/>
+    public HRESULT get_customCallingConvention(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BOOL*, HRESULT>)_lpVtbl[103])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_noInline"/>
+    public HRESULT get_noInline(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BOOL*, HRESULT>)_lpVtbl[104])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_optimizedCodeDebugInfo"/>
+    public HRESULT get_optimizedCodeDebugInfo(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BOOL*, HRESULT>)_lpVtbl[105])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_notReached"/>
+    public HRESULT get_notReached(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BOOL*, HRESULT>)_lpVtbl[106])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_interruptReturn"/>
+    public HRESULT get_interruptReturn(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BOOL*, HRESULT>)_lpVtbl[107])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_farReturn"/>
+    public HRESULT get_farReturn(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BOOL*, HRESULT>)_lpVtbl[108])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isStatic"/>
+    public HRESULT get_isStatic(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BOOL*, HRESULT>)_lpVtbl[109])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasDebugInfo"/>
+    public HRESULT get_hasDebugInfo(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BOOL*, HRESULT>)_lpVtbl[110])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isLTCG"/>
+    public HRESULT get_isLTCG(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BOOL*, HRESULT>)_lpVtbl[111])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isDataAligned"/>
+    public HRESULT get_isDataAligned(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BOOL*, HRESULT>)_lpVtbl[112])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasSecurityChecks"/>
+    public HRESULT get_hasSecurityChecks(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BOOL*, HRESULT>)_lpVtbl[113])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_compilerName"/>
+    public HRESULT get_compilerName(BSTR* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BSTR*, HRESULT>)_lpVtbl[114])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasAlloca"/>
+    public HRESULT get_hasAlloca(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BOOL*, HRESULT>)_lpVtbl[115])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasSetJump"/>
+    public HRESULT get_hasSetJump(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BOOL*, HRESULT>)_lpVtbl[116])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasLongJump"/>
+    public HRESULT get_hasLongJump(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BOOL*, HRESULT>)_lpVtbl[117])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasInlAsm"/>
+    public HRESULT get_hasInlAsm(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BOOL*, HRESULT>)_lpVtbl[118])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasEH"/>
+    public HRESULT get_hasEH(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BOOL*, HRESULT>)_lpVtbl[119])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasSEH"/>
+    public HRESULT get_hasSEH(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BOOL*, HRESULT>)_lpVtbl[120])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasEHa"/>
+    public HRESULT get_hasEHa(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BOOL*, HRESULT>)_lpVtbl[121])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isNaked"/>
+    public HRESULT get_isNaked(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BOOL*, HRESULT>)_lpVtbl[122])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isAggregated"/>
+    public HRESULT get_isAggregated(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BOOL*, HRESULT>)_lpVtbl[123])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isSplitted"/>
+    public HRESULT get_isSplitted(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BOOL*, HRESULT>)_lpVtbl[124])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_container"/>
+    public HRESULT get_container(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, IDiaSymbol**, HRESULT>)_lpVtbl[125])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_inlSpec"/>
+    public HRESULT get_inlSpec(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BOOL*, HRESULT>)_lpVtbl[126])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_noStackOrdering"/>
+    public HRESULT get_noStackOrdering(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BOOL*, HRESULT>)_lpVtbl[127])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_virtualBaseTableType"/>
+    public HRESULT get_virtualBaseTableType(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, IDiaSymbol**, HRESULT>)_lpVtbl[128])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasManagedCode"/>
+    public HRESULT get_hasManagedCode(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BOOL*, HRESULT>)_lpVtbl[129])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isHotpatchable"/>
+    public HRESULT get_isHotpatchable(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BOOL*, HRESULT>)_lpVtbl[130])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isCVTCIL"/>
+    public HRESULT get_isCVTCIL(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BOOL*, HRESULT>)_lpVtbl[131])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isMSILNetmodule"/>
+    public HRESULT get_isMSILNetmodule(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BOOL*, HRESULT>)_lpVtbl[132])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isCTypes"/>
+    public HRESULT get_isCTypes(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BOOL*, HRESULT>)_lpVtbl[133])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isStripped"/>
+    public HRESULT get_isStripped(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BOOL*, HRESULT>)_lpVtbl[134])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_frontEndQFE"/>
+    public HRESULT get_frontEndQFE(uint* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, uint*, HRESULT>)_lpVtbl[135])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_backEndQFE"/>
+    public HRESULT get_backEndQFE(uint* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, uint*, HRESULT>)_lpVtbl[136])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_wasInlined"/>
+    public HRESULT get_wasInlined(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BOOL*, HRESULT>)_lpVtbl[137])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_strictGSCheck"/>
+    public HRESULT get_strictGSCheck(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BOOL*, HRESULT>)_lpVtbl[138])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isCxxReturnUdt"/>
+    public HRESULT get_isCxxReturnUdt(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BOOL*, HRESULT>)_lpVtbl[139])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isConstructorVirtualBase"/>
+    public HRESULT get_isConstructorVirtualBase(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BOOL*, HRESULT>)_lpVtbl[140])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_RValueReference"/>
+    public HRESULT get_RValueReference(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BOOL*, HRESULT>)_lpVtbl[141])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_unmodifiedType"/>
+    public HRESULT get_unmodifiedType(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, IDiaSymbol**, HRESULT>)_lpVtbl[142])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_framePointerPresent"/>
+    public HRESULT get_framePointerPresent(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BOOL*, HRESULT>)_lpVtbl[143])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isSafeBuffers"/>
+    public HRESULT get_isSafeBuffers(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BOOL*, HRESULT>)_lpVtbl[144])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_intrinsic"/>
+    public HRESULT get_intrinsic(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BOOL*, HRESULT>)_lpVtbl[145])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_sealed"/>
+    public HRESULT get_sealed(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BOOL*, HRESULT>)_lpVtbl[146])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hfaFloat"/>
+    public HRESULT get_hfaFloat(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BOOL*, HRESULT>)_lpVtbl[147])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hfaDouble"/>
+    public HRESULT get_hfaDouble(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BOOL*, HRESULT>)_lpVtbl[148])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_liveRangeStartAddressSection"/>
+    public HRESULT get_liveRangeStartAddressSection(uint* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, uint*, HRESULT>)_lpVtbl[149])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_liveRangeStartAddressOffset"/>
+    public HRESULT get_liveRangeStartAddressOffset(uint* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, uint*, HRESULT>)_lpVtbl[150])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_liveRangeStartRelativeVirtualAddress"/>
+    public HRESULT get_liveRangeStartRelativeVirtualAddress(uint* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, uint*, HRESULT>)_lpVtbl[151])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_countLiveRanges"/>
+    public HRESULT get_countLiveRanges(uint* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, uint*, HRESULT>)_lpVtbl[152])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_liveRangeLength"/>
+    public HRESULT get_liveRangeLength(ulong* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, ulong*, HRESULT>)_lpVtbl[153])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_offsetInUdt"/>
+    public HRESULT get_offsetInUdt(uint* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, uint*, HRESULT>)_lpVtbl[154])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_paramBasePointerRegisterId"/>
+    public HRESULT get_paramBasePointerRegisterId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, uint*, HRESULT>)_lpVtbl[155])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_localBasePointerRegisterId"/>
+    public HRESULT get_localBasePointerRegisterId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, uint*, HRESULT>)_lpVtbl[156])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isLocationControlFlowDependent"/>
+    public HRESULT get_isLocationControlFlowDependent(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BOOL*, HRESULT>)_lpVtbl[157])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_stride"/>
+    public HRESULT get_stride(uint* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, uint*, HRESULT>)_lpVtbl[158])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_numberOfRows"/>
+    public HRESULT get_numberOfRows(uint* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, uint*, HRESULT>)_lpVtbl[159])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_numberOfColumns"/>
+    public HRESULT get_numberOfColumns(uint* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, uint*, HRESULT>)_lpVtbl[160])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isMatrixRowMajor"/>
+    public HRESULT get_isMatrixRowMajor(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BOOL*, HRESULT>)_lpVtbl[161])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_numericProperties"/>
+    public HRESULT get_numericProperties(uint cnt, uint* pcnt, uint* pProperties)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, uint, uint*, uint*, HRESULT>)_lpVtbl[162])(pThis, cnt, pcnt, pProperties);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_modifierValues"/>
+    public HRESULT get_modifierValues(uint cnt, uint* pcnt, ushort* pModifiers)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, uint, uint*, ushort*, HRESULT>)_lpVtbl[163])(pThis, cnt, pcnt, pModifiers);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isReturnValue"/>
+    public HRESULT get_isReturnValue(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BOOL*, HRESULT>)_lpVtbl[164])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isOptimizedAway"/>
+    public HRESULT get_isOptimizedAway(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BOOL*, HRESULT>)_lpVtbl[165])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_builtInKind"/>
+    public HRESULT get_builtInKind(uint* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, uint*, HRESULT>)_lpVtbl[166])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_registerType"/>
+    public HRESULT get_registerType(uint* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, uint*, HRESULT>)_lpVtbl[167])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_baseDataSlot"/>
+    public HRESULT get_baseDataSlot(uint* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, uint*, HRESULT>)_lpVtbl[168])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_baseDataOffset"/>
+    public HRESULT get_baseDataOffset(uint* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, uint*, HRESULT>)_lpVtbl[169])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_textureSlot"/>
+    public HRESULT get_textureSlot(uint* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, uint*, HRESULT>)_lpVtbl[170])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_samplerSlot"/>
+    public HRESULT get_samplerSlot(uint* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, uint*, HRESULT>)_lpVtbl[171])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_uavSlot"/>
+    public HRESULT get_uavSlot(uint* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, uint*, HRESULT>)_lpVtbl[172])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_sizeInUdt"/>
+    public HRESULT get_sizeInUdt(uint* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, uint*, HRESULT>)_lpVtbl[173])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_memorySpaceKind"/>
+    public HRESULT get_memorySpaceKind(uint* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, uint*, HRESULT>)_lpVtbl[174])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_unmodifiedTypeId"/>
+    public HRESULT get_unmodifiedTypeId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, uint*, HRESULT>)_lpVtbl[175])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_subTypeId"/>
+    public HRESULT get_subTypeId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, uint*, HRESULT>)_lpVtbl[176])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_subType"/>
+    public HRESULT get_subType(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, IDiaSymbol**, HRESULT>)_lpVtbl[177])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_numberOfModifiers"/>
+    public HRESULT get_numberOfModifiers(uint* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, uint*, HRESULT>)_lpVtbl[178])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_numberOfRegisterIndices"/>
+    public HRESULT get_numberOfRegisterIndices(uint* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, uint*, HRESULT>)_lpVtbl[179])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isHLSLData"/>
+    public HRESULT get_isHLSLData(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BOOL*, HRESULT>)_lpVtbl[180])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isPointerToDataMember"/>
+    public HRESULT get_isPointerToDataMember(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BOOL*, HRESULT>)_lpVtbl[181])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isPointerToMemberFunction"/>
+    public HRESULT get_isPointerToMemberFunction(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BOOL*, HRESULT>)_lpVtbl[182])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isSingleInheritance"/>
+    public HRESULT get_isSingleInheritance(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BOOL*, HRESULT>)_lpVtbl[183])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isMultipleInheritance"/>
+    public HRESULT get_isMultipleInheritance(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BOOL*, HRESULT>)_lpVtbl[184])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isVirtualInheritance"/>
+    public HRESULT get_isVirtualInheritance(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BOOL*, HRESULT>)_lpVtbl[185])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_restrictedType"/>
+    public HRESULT get_restrictedType(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BOOL*, HRESULT>)_lpVtbl[186])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isPointerBasedOnSymbolValue"/>
+    public HRESULT get_isPointerBasedOnSymbolValue(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BOOL*, HRESULT>)_lpVtbl[187])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_baseSymbol"/>
+    public HRESULT get_baseSymbol(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, IDiaSymbol**, HRESULT>)_lpVtbl[188])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_baseSymbolId"/>
+    public HRESULT get_baseSymbolId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, uint*, HRESULT>)_lpVtbl[189])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_objectFileName"/>
+    public HRESULT get_objectFileName(BSTR* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BSTR*, HRESULT>)_lpVtbl[190])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isAcceleratorGroupSharedLocal"/>
+    public HRESULT get_isAcceleratorGroupSharedLocal(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BOOL*, HRESULT>)_lpVtbl[191])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isAcceleratorPointerTagLiveRange"/>
+    public HRESULT get_isAcceleratorPointerTagLiveRange(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BOOL*, HRESULT>)_lpVtbl[192])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isAcceleratorStubFunction"/>
+    public HRESULT get_isAcceleratorStubFunction(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BOOL*, HRESULT>)_lpVtbl[193])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_numberOfAcceleratorPointerTags"/>
+    public HRESULT get_numberOfAcceleratorPointerTags(uint* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, uint*, HRESULT>)_lpVtbl[194])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isSdl"/>
+    public HRESULT get_isSdl(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BOOL*, HRESULT>)_lpVtbl[195])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isWinRTPointer"/>
+    public HRESULT get_isWinRTPointer(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BOOL*, HRESULT>)_lpVtbl[196])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isRefUdt"/>
+    public HRESULT get_isRefUdt(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BOOL*, HRESULT>)_lpVtbl[197])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isValueUdt"/>
+    public HRESULT get_isValueUdt(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BOOL*, HRESULT>)_lpVtbl[198])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isInterfaceUdt"/>
+    public HRESULT get_isInterfaceUdt(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BOOL*, HRESULT>)_lpVtbl[199])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findInlineFramesByAddr"/>
+    public HRESULT findInlineFramesByAddr(uint isect, uint offset, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, uint, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[200])(pThis, isect, offset, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findInlineFramesByRVA"/>
+    public HRESULT findInlineFramesByRVA(uint rva, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[201])(pThis, rva, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findInlineFramesByVA"/>
+    public HRESULT findInlineFramesByVA(ulong va, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, ulong, IDiaEnumSymbols**, HRESULT>)_lpVtbl[202])(pThis, va, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findInlineeLines"/>
+    public HRESULT findInlineeLines(IDiaEnumLineNumbers** ppResult)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, IDiaEnumLineNumbers**, HRESULT>)_lpVtbl[203])(pThis, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findInlineeLinesByAddr"/>
+    public HRESULT findInlineeLinesByAddr(uint isect, uint offset, uint length, IDiaEnumLineNumbers** ppResult)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, uint, uint, uint, IDiaEnumLineNumbers**, HRESULT>)_lpVtbl[204])(pThis, isect, offset, length, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findInlineeLinesByRVA"/>
+    public HRESULT findInlineeLinesByRVA(uint rva, uint length, IDiaEnumLineNumbers** ppResult)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, uint, uint, IDiaEnumLineNumbers**, HRESULT>)_lpVtbl[205])(pThis, rva, length, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findInlineeLinesByVA"/>
+    public HRESULT findInlineeLinesByVA(ulong va, uint length, IDiaEnumLineNumbers** ppResult)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, ulong, uint, IDiaEnumLineNumbers**, HRESULT>)_lpVtbl[206])(pThis, va, length, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findSymbolsForAcceleratorPointerTag"/>
+    public HRESULT findSymbolsForAcceleratorPointerTag(uint tagValue, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[207])(pThis, tagValue, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findSymbolsByRVAForAcceleratorPointerTag"/>
+    public HRESULT findSymbolsByRVAForAcceleratorPointerTag(uint tagValue, uint rva, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, uint, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[208])(pThis, tagValue, rva, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_acceleratorPointerTags"/>
+    public HRESULT get_acceleratorPointerTags(uint cnt, uint* pcnt, uint* pPointerTags)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, uint, uint*, uint*, HRESULT>)_lpVtbl[209])(pThis, cnt, pcnt, pPointerTags);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.getSrcLineOnTypeDefn"/>
+    public HRESULT getSrcLineOnTypeDefn(IDiaLineNumber** ppResult)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, IDiaLineNumber**, HRESULT>)_lpVtbl[210])(pThis, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isPGO"/>
+    public HRESULT get_isPGO(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BOOL*, HRESULT>)_lpVtbl[211])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasValidPGOCounts"/>
+    public HRESULT get_hasValidPGOCounts(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BOOL*, HRESULT>)_lpVtbl[212])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isOptimizedForSpeed"/>
+    public HRESULT get_isOptimizedForSpeed(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BOOL*, HRESULT>)_lpVtbl[213])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_PGOEntryCount"/>
+    public HRESULT get_PGOEntryCount(uint* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, uint*, HRESULT>)_lpVtbl[214])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_PGOEdgeCount"/>
+    public HRESULT get_PGOEdgeCount(uint* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, uint*, HRESULT>)_lpVtbl[215])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_PGODynamicInstructionCount"/>
+    public HRESULT get_PGODynamicInstructionCount(ulong* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, ulong*, HRESULT>)_lpVtbl[216])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_staticSize"/>
+    public HRESULT get_staticSize(uint* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, uint*, HRESULT>)_lpVtbl[217])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_finalLiveStaticSize"/>
+    public HRESULT get_finalLiveStaticSize(uint* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, uint*, HRESULT>)_lpVtbl[218])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_phaseName"/>
+    public HRESULT get_phaseName(BSTR* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BSTR*, HRESULT>)_lpVtbl[219])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasControlFlowCheck"/>
+    public HRESULT get_hasControlFlowCheck(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BOOL*, HRESULT>)_lpVtbl[220])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_constantExport"/>
+    public HRESULT get_constantExport(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BOOL*, HRESULT>)_lpVtbl[221])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_dataExport"/>
+    public HRESULT get_dataExport(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BOOL*, HRESULT>)_lpVtbl[222])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_privateExport"/>
+    public HRESULT get_privateExport(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BOOL*, HRESULT>)_lpVtbl[223])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_noNameExport"/>
+    public HRESULT get_noNameExport(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BOOL*, HRESULT>)_lpVtbl[224])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_exportHasExplicitlyAssignedOrdinal"/>
+    public HRESULT get_exportHasExplicitlyAssignedOrdinal(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BOOL*, HRESULT>)_lpVtbl[225])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_exportIsForwarder"/>
+    public HRESULT get_exportIsForwarder(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BOOL*, HRESULT>)_lpVtbl[226])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_ordinal"/>
+    public HRESULT get_ordinal(uint* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, uint*, HRESULT>)_lpVtbl[227])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_frameSize"/>
+    public HRESULT get_frameSize(uint* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, uint*, HRESULT>)_lpVtbl[228])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_exceptionHandlerAddressSection"/>
+    public HRESULT get_exceptionHandlerAddressSection(uint* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, uint*, HRESULT>)_lpVtbl[229])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_exceptionHandlerAddressOffset"/>
+    public HRESULT get_exceptionHandlerAddressOffset(uint* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, uint*, HRESULT>)_lpVtbl[230])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_exceptionHandlerRelativeVirtualAddress"/>
+    public HRESULT get_exceptionHandlerRelativeVirtualAddress(uint* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, uint*, HRESULT>)_lpVtbl[231])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_exceptionHandlerVirtualAddress"/>
+    public HRESULT get_exceptionHandlerVirtualAddress(ulong* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, ulong*, HRESULT>)_lpVtbl[232])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findInputAssemblyFile"/>
+    public HRESULT findInputAssemblyFile(IDiaInputAssemblyFile** ppResult)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, IDiaInputAssemblyFile**, HRESULT>)_lpVtbl[233])(pThis, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_characteristics"/>
+    public HRESULT get_characteristics(uint* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, uint*, HRESULT>)_lpVtbl[234])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_coffGroup"/>
+    public HRESULT get_coffGroup(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, IDiaSymbol**, HRESULT>)_lpVtbl[235])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_bindID"/>
+    public HRESULT get_bindID(uint* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, uint*, HRESULT>)_lpVtbl[236])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_bindSpace"/>
+    public HRESULT get_bindSpace(uint* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, uint*, HRESULT>)_lpVtbl[237])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_bindSlot"/>
+    public HRESULT get_bindSlot(uint* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, uint*, HRESULT>)_lpVtbl[238])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_isObjCClass"/>
+    public HRESULT get_isObjCClass(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BOOL*, HRESULT>)_lpVtbl[239])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_isObjCCategory"/>
+    public HRESULT get_isObjCCategory(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BOOL*, HRESULT>)_lpVtbl[240])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_isObjCProtocol"/>
+    public HRESULT get_isObjCProtocol(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol2* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol2*, BOOL*, HRESULT>)_lpVtbl[241])(pThis, pRetVal);
+    }
+
+    /// <summary>
+    ///  Extends IDiaSymbol with Objective-C related properties.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/visualstudio/debugger/debug-interface-access/idiasymbol2">
+    ///    Official documentation.
+    ///   </see>
+    ///  </para>
+    /// </remarks>
+    [ComImport]
+    [Guid("611E86CD-B7D1-4546-8A15-070E2B07A427")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    public unsafe interface Interface : IDiaSymbol.Interface
+    {
+        /// <summary>
+        ///  Retrieves a flag that specifies whether the symbol is an Objective-C class interface or implementation.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_isObjCClass(BOOL* pRetVal);
+
+        /// <summary>
+        ///  Retrieves a flag that specifies whether the symbol is an Objective-C category.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_isObjCCategory(BOOL* pRetVal);
+
+        /// <summary>
+        ///  Retrieves a flag that specifies whether the symbol is an Objective-C protocol.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_isObjCProtocol(BOOL* pRetVal);
+    }
+}

--- a/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaSymbol3.cs
+++ b/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaSymbol3.cs
@@ -1,0 +1,1784 @@
+﻿// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Runtime.InteropServices;
+using Windows.Win32.System.Variant;
+
+// For some reason the XML comment refs for IUnknown can't be resolved on .NET Framework without
+// explicitly using the fully qualified name, which falls afoul of the simplify warning.
+using ComIUnknown = Windows.Win32.System.Com.IUnknown;
+
+namespace Microsoft.VisualStudio.Debugging.DebugInterfaceAccess;
+
+/// <inheritdoc cref="Interface"/>
+public unsafe struct IDiaSymbol3 : IComIID
+{
+    /// <inheritdoc cref="IComIID.Guid"/>
+#pragma warning disable IDE1006 // Naming Styles
+    public static readonly Guid IID_Guid = new(0x99B665F7, 0xC1B2, 0x49D3, 0x89, 0xB2, 0xA3, 0x84, 0x36, 0x1A, 0xCA, 0xB5);
+#pragma warning restore IDE1006
+
+#if NETFRAMEWORK
+    readonly ref readonly Guid IComIID.Guid => ref IID_Guid;
+#else
+    static ref readonly Guid IComIID.Guid
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get
+        {
+            ReadOnlySpan<byte> data =
+            [
+                0xF7, 0x65, 0xB6, 0x99,
+                0xB2, 0xC1,
+                0xD3, 0x49,
+                0x89, 0xB2, 0xA3, 0x84, 0x36, 0x1A, 0xCA, 0xB5
+            ];
+
+            return ref Unsafe.As<byte, Guid>(ref MemoryMarshal.GetReference(data));
+        }
+    }
+#endif
+
+    private readonly void** _lpVtbl;
+
+    /// <inheritdoc cref="ComIUnknown.QueryInterface(Guid*, void**)"/>
+    public HRESULT QueryInterface(Guid* riid, void** ppvObject)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, Guid*, void**, HRESULT>)_lpVtbl[0])(pThis, riid, ppvObject);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.AddRef"/>
+    public uint AddRef()
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, uint>)_lpVtbl[1])(pThis);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.Release"/>
+    public uint Release()
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, uint>)_lpVtbl[2])(pThis);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_symIndexId"/>
+    public HRESULT get_symIndexId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, uint*, HRESULT>)_lpVtbl[3])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_symTag"/>
+    public HRESULT get_symTag(uint* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, uint*, HRESULT>)_lpVtbl[4])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_name"/>
+    public HRESULT get_name(BSTR* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BSTR*, HRESULT>)_lpVtbl[5])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_lexicalParent"/>
+    public HRESULT get_lexicalParent(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, IDiaSymbol**, HRESULT>)_lpVtbl[6])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_classParent"/>
+    public HRESULT get_classParent(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, IDiaSymbol**, HRESULT>)_lpVtbl[7])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_type"/>
+    public HRESULT get_type(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, IDiaSymbol**, HRESULT>)_lpVtbl[8])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_dataKind"/>
+    public HRESULT get_dataKind(uint* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, uint*, HRESULT>)_lpVtbl[9])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_locationType"/>
+    public HRESULT get_locationType(uint* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, uint*, HRESULT>)_lpVtbl[10])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_addressSection"/>
+    public HRESULT get_addressSection(uint* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, uint*, HRESULT>)_lpVtbl[11])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_addressOffset"/>
+    public HRESULT get_addressOffset(uint* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, uint*, HRESULT>)_lpVtbl[12])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_relativeVirtualAddress"/>
+    public HRESULT get_relativeVirtualAddress(uint* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, uint*, HRESULT>)_lpVtbl[13])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_virtualAddress"/>
+    public HRESULT get_virtualAddress(ulong* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, ulong*, HRESULT>)_lpVtbl[14])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_registerId"/>
+    public HRESULT get_registerId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, uint*, HRESULT>)_lpVtbl[15])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_offset"/>
+    public HRESULT get_offset(int* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, int*, HRESULT>)_lpVtbl[16])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_length"/>
+    public HRESULT get_length(ulong* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, ulong*, HRESULT>)_lpVtbl[17])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_slot"/>
+    public HRESULT get_slot(uint* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, uint*, HRESULT>)_lpVtbl[18])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_volatileType"/>
+    public HRESULT get_volatileType(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BOOL*, HRESULT>)_lpVtbl[19])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_constType"/>
+    public HRESULT get_constType(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BOOL*, HRESULT>)_lpVtbl[20])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_unalignedType"/>
+    public HRESULT get_unalignedType(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BOOL*, HRESULT>)_lpVtbl[21])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_access"/>
+    public HRESULT get_access(uint* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, uint*, HRESULT>)_lpVtbl[22])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_libraryName"/>
+    public HRESULT get_libraryName(BSTR* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BSTR*, HRESULT>)_lpVtbl[23])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_platform"/>
+    public HRESULT get_platform(uint* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, uint*, HRESULT>)_lpVtbl[24])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_language"/>
+    public HRESULT get_language(uint* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, uint*, HRESULT>)_lpVtbl[25])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_editAndContinueEnabled"/>
+    public HRESULT get_editAndContinueEnabled(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BOOL*, HRESULT>)_lpVtbl[26])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_frontEndMajor"/>
+    public HRESULT get_frontEndMajor(uint* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, uint*, HRESULT>)_lpVtbl[27])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_frontEndMinor"/>
+    public HRESULT get_frontEndMinor(uint* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, uint*, HRESULT>)_lpVtbl[28])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_frontEndBuild"/>
+    public HRESULT get_frontEndBuild(uint* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, uint*, HRESULT>)_lpVtbl[29])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_backEndMajor"/>
+    public HRESULT get_backEndMajor(uint* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, uint*, HRESULT>)_lpVtbl[30])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_backEndMinor"/>
+    public HRESULT get_backEndMinor(uint* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, uint*, HRESULT>)_lpVtbl[31])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_backEndBuild"/>
+    public HRESULT get_backEndBuild(uint* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, uint*, HRESULT>)_lpVtbl[32])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_sourceFileName"/>
+    public HRESULT get_sourceFileName(BSTR* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BSTR*, HRESULT>)_lpVtbl[33])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_unused"/>
+    public HRESULT get_unused(BSTR* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BSTR*, HRESULT>)_lpVtbl[34])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_thunkOrdinal"/>
+    public HRESULT get_thunkOrdinal(uint* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, uint*, HRESULT>)_lpVtbl[35])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_thisAdjust"/>
+    public HRESULT get_thisAdjust(int* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, int*, HRESULT>)_lpVtbl[36])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_virtualBaseOffset"/>
+    public HRESULT get_virtualBaseOffset(uint* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, uint*, HRESULT>)_lpVtbl[37])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_virtual"/>
+    public HRESULT get_virtual(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BOOL*, HRESULT>)_lpVtbl[38])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_intro"/>
+    public HRESULT get_intro(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BOOL*, HRESULT>)_lpVtbl[39])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_pure"/>
+    public HRESULT get_pure(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BOOL*, HRESULT>)_lpVtbl[40])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_callingConvention"/>
+    public HRESULT get_callingConvention(uint* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, uint*, HRESULT>)_lpVtbl[41])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_value"/>
+    public HRESULT get_value(VARIANT* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, VARIANT*, HRESULT>)_lpVtbl[42])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_baseType"/>
+    public HRESULT get_baseType(uint* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, uint*, HRESULT>)_lpVtbl[43])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_token"/>
+    public HRESULT get_token(uint* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, uint*, HRESULT>)_lpVtbl[44])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_timeStamp"/>
+    public HRESULT get_timeStamp(uint* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, uint*, HRESULT>)_lpVtbl[45])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_guid"/>
+    public HRESULT get_guid(Guid* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, Guid*, HRESULT>)_lpVtbl[46])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_symbolsFileName"/>
+    public HRESULT get_symbolsFileName(BSTR* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BSTR*, HRESULT>)_lpVtbl[47])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_reference"/>
+    public HRESULT get_reference(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BOOL*, HRESULT>)_lpVtbl[48])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_count"/>
+    public HRESULT get_count(uint* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, uint*, HRESULT>)_lpVtbl[49])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_bitPosition"/>
+    public HRESULT get_bitPosition(uint* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, uint*, HRESULT>)_lpVtbl[50])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_arrayIndexType"/>
+    public HRESULT get_arrayIndexType(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, IDiaSymbol**, HRESULT>)_lpVtbl[51])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_packed"/>
+    public HRESULT get_packed(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BOOL*, HRESULT>)_lpVtbl[52])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_constructor"/>
+    public HRESULT get_constructor(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BOOL*, HRESULT>)_lpVtbl[53])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_overloadedOperator"/>
+    public HRESULT get_overloadedOperator(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BOOL*, HRESULT>)_lpVtbl[54])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_nested"/>
+    public HRESULT get_nested(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BOOL*, HRESULT>)_lpVtbl[55])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasNestedTypes"/>
+    public HRESULT get_hasNestedTypes(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BOOL*, HRESULT>)_lpVtbl[56])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasAssignmentOperator"/>
+    public HRESULT get_hasAssignmentOperator(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BOOL*, HRESULT>)_lpVtbl[57])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasCastOperator"/>
+    public HRESULT get_hasCastOperator(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BOOL*, HRESULT>)_lpVtbl[58])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_scoped"/>
+    public HRESULT get_scoped(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BOOL*, HRESULT>)_lpVtbl[59])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_virtualBaseClass"/>
+    public HRESULT get_virtualBaseClass(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BOOL*, HRESULT>)_lpVtbl[60])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_indirectVirtualBaseClass"/>
+    public HRESULT get_indirectVirtualBaseClass(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BOOL*, HRESULT>)_lpVtbl[61])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_virtualBasePointerOffset"/>
+    public HRESULT get_virtualBasePointerOffset(int* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, int*, HRESULT>)_lpVtbl[62])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_virtualTableShape"/>
+    public HRESULT get_virtualTableShape(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, IDiaSymbol**, HRESULT>)_lpVtbl[63])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_lexicalParentId"/>
+    public HRESULT get_lexicalParentId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, uint*, HRESULT>)_lpVtbl[64])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_classParentId"/>
+    public HRESULT get_classParentId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, uint*, HRESULT>)_lpVtbl[65])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_typeId"/>
+    public HRESULT get_typeId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, uint*, HRESULT>)_lpVtbl[66])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_arrayIndexTypeId"/>
+    public HRESULT get_arrayIndexTypeId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, uint*, HRESULT>)_lpVtbl[67])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_virtualTableShapeId"/>
+    public HRESULT get_virtualTableShapeId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, uint*, HRESULT>)_lpVtbl[68])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_code"/>
+    public HRESULT get_code(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BOOL*, HRESULT>)_lpVtbl[69])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_function"/>
+    public HRESULT get_function(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BOOL*, HRESULT>)_lpVtbl[70])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_managed"/>
+    public HRESULT get_managed(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BOOL*, HRESULT>)_lpVtbl[71])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_msil"/>
+    public HRESULT get_msil(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BOOL*, HRESULT>)_lpVtbl[72])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_virtualBaseDispIndex"/>
+    public HRESULT get_virtualBaseDispIndex(uint* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, uint*, HRESULT>)_lpVtbl[73])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_undecoratedName"/>
+    public HRESULT get_undecoratedName(BSTR* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BSTR*, HRESULT>)_lpVtbl[74])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_age"/>
+    public HRESULT get_age(uint* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, uint*, HRESULT>)_lpVtbl[75])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_signature"/>
+    public HRESULT get_signature(uint* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, uint*, HRESULT>)_lpVtbl[76])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_compilerGenerated"/>
+    public HRESULT get_compilerGenerated(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BOOL*, HRESULT>)_lpVtbl[77])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_addressTaken"/>
+    public HRESULT get_addressTaken(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BOOL*, HRESULT>)_lpVtbl[78])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_rank"/>
+    public HRESULT get_rank(uint* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, uint*, HRESULT>)_lpVtbl[79])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_lowerBound"/>
+    public HRESULT get_lowerBound(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, IDiaSymbol**, HRESULT>)_lpVtbl[80])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_upperBound"/>
+    public HRESULT get_upperBound(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, IDiaSymbol**, HRESULT>)_lpVtbl[81])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_lowerBoundId"/>
+    public HRESULT get_lowerBoundId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, uint*, HRESULT>)_lpVtbl[82])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_upperBoundId"/>
+    public HRESULT get_upperBoundId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, uint*, HRESULT>)_lpVtbl[83])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_dataBytes"/>
+    public HRESULT get_dataBytes(uint cbData, uint* pcbData, byte* pbData)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, uint, uint*, byte*, HRESULT>)_lpVtbl[84])(pThis, cbData, pcbData, pbData);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findChildren"/>
+    public HRESULT findChildren(SymTagEnum symtag, PCWSTR name, uint compareFlags, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, SymTagEnum, PCWSTR, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[85])(pThis, symtag, name, compareFlags, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findChildrenEx"/>
+    public HRESULT findChildrenEx(SymTagEnum symtag, PCWSTR name, uint compareFlags, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, SymTagEnum, PCWSTR, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[86])(pThis, symtag, name, compareFlags, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findChildrenExByAddr"/>
+    public HRESULT findChildrenExByAddr(SymTagEnum symtag, PCWSTR name, uint compareFlags, uint isect, uint offset, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, SymTagEnum, PCWSTR, uint, uint, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[87])(pThis, symtag, name, compareFlags, isect, offset, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findChildrenExByVA"/>
+    public HRESULT findChildrenExByVA(SymTagEnum symtag, PCWSTR name, uint compareFlags, ulong va, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, SymTagEnum, PCWSTR, uint, ulong, IDiaEnumSymbols**, HRESULT>)_lpVtbl[88])(pThis, symtag, name, compareFlags, va, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findChildrenExByRVA"/>
+    public HRESULT findChildrenExByRVA(SymTagEnum symtag, PCWSTR name, uint compareFlags, uint rva, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, SymTagEnum, PCWSTR, uint, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[89])(pThis, symtag, name, compareFlags, rva, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_targetSection"/>
+    public HRESULT get_targetSection(uint* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, uint*, HRESULT>)_lpVtbl[90])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_targetOffset"/>
+    public HRESULT get_targetOffset(uint* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, uint*, HRESULT>)_lpVtbl[91])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_targetRelativeVirtualAddress"/>
+    public HRESULT get_targetRelativeVirtualAddress(uint* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, uint*, HRESULT>)_lpVtbl[92])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_targetVirtualAddress"/>
+    public HRESULT get_targetVirtualAddress(ulong* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, ulong*, HRESULT>)_lpVtbl[93])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_machineType"/>
+    public HRESULT get_machineType(uint* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, uint*, HRESULT>)_lpVtbl[94])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_oemId"/>
+    public HRESULT get_oemId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, uint*, HRESULT>)_lpVtbl[95])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_oemSymbolId"/>
+    public HRESULT get_oemSymbolId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, uint*, HRESULT>)_lpVtbl[96])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_types"/>
+    public HRESULT get_types(uint cTypes, uint* pcTypes, IDiaSymbol** pTypes)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, uint, uint*, IDiaSymbol**, HRESULT>)_lpVtbl[97])(pThis, cTypes, pcTypes, pTypes);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_typeIds"/>
+    public HRESULT get_typeIds(uint cTypeIds, uint* pcTypeIds, uint* pdwTypeIds)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, uint, uint*, uint*, HRESULT>)_lpVtbl[98])(pThis, cTypeIds, pcTypeIds, pdwTypeIds);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_objectPointerType"/>
+    public HRESULT get_objectPointerType(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, IDiaSymbol**, HRESULT>)_lpVtbl[99])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_udtKind"/>
+    public HRESULT get_udtKind(uint* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, uint*, HRESULT>)_lpVtbl[100])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_undecoratedNameEx"/>
+    public HRESULT get_undecoratedNameEx(uint undecorateOptions, BSTR* name)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, uint, BSTR*, HRESULT>)_lpVtbl[101])(pThis, undecorateOptions, name);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_noReturn"/>
+    public HRESULT get_noReturn(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BOOL*, HRESULT>)_lpVtbl[102])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_customCallingConvention"/>
+    public HRESULT get_customCallingConvention(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BOOL*, HRESULT>)_lpVtbl[103])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_noInline"/>
+    public HRESULT get_noInline(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BOOL*, HRESULT>)_lpVtbl[104])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_optimizedCodeDebugInfo"/>
+    public HRESULT get_optimizedCodeDebugInfo(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BOOL*, HRESULT>)_lpVtbl[105])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_notReached"/>
+    public HRESULT get_notReached(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BOOL*, HRESULT>)_lpVtbl[106])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_interruptReturn"/>
+    public HRESULT get_interruptReturn(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BOOL*, HRESULT>)_lpVtbl[107])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_farReturn"/>
+    public HRESULT get_farReturn(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BOOL*, HRESULT>)_lpVtbl[108])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isStatic"/>
+    public HRESULT get_isStatic(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BOOL*, HRESULT>)_lpVtbl[109])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasDebugInfo"/>
+    public HRESULT get_hasDebugInfo(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BOOL*, HRESULT>)_lpVtbl[110])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isLTCG"/>
+    public HRESULT get_isLTCG(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BOOL*, HRESULT>)_lpVtbl[111])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isDataAligned"/>
+    public HRESULT get_isDataAligned(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BOOL*, HRESULT>)_lpVtbl[112])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasSecurityChecks"/>
+    public HRESULT get_hasSecurityChecks(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BOOL*, HRESULT>)_lpVtbl[113])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_compilerName"/>
+    public HRESULT get_compilerName(BSTR* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BSTR*, HRESULT>)_lpVtbl[114])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasAlloca"/>
+    public HRESULT get_hasAlloca(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BOOL*, HRESULT>)_lpVtbl[115])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasSetJump"/>
+    public HRESULT get_hasSetJump(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BOOL*, HRESULT>)_lpVtbl[116])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasLongJump"/>
+    public HRESULT get_hasLongJump(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BOOL*, HRESULT>)_lpVtbl[117])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasInlAsm"/>
+    public HRESULT get_hasInlAsm(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BOOL*, HRESULT>)_lpVtbl[118])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasEH"/>
+    public HRESULT get_hasEH(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BOOL*, HRESULT>)_lpVtbl[119])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasSEH"/>
+    public HRESULT get_hasSEH(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BOOL*, HRESULT>)_lpVtbl[120])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasEHa"/>
+    public HRESULT get_hasEHa(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BOOL*, HRESULT>)_lpVtbl[121])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isNaked"/>
+    public HRESULT get_isNaked(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BOOL*, HRESULT>)_lpVtbl[122])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isAggregated"/>
+    public HRESULT get_isAggregated(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BOOL*, HRESULT>)_lpVtbl[123])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isSplitted"/>
+    public HRESULT get_isSplitted(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BOOL*, HRESULT>)_lpVtbl[124])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_container"/>
+    public HRESULT get_container(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, IDiaSymbol**, HRESULT>)_lpVtbl[125])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_inlSpec"/>
+    public HRESULT get_inlSpec(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BOOL*, HRESULT>)_lpVtbl[126])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_noStackOrdering"/>
+    public HRESULT get_noStackOrdering(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BOOL*, HRESULT>)_lpVtbl[127])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_virtualBaseTableType"/>
+    public HRESULT get_virtualBaseTableType(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, IDiaSymbol**, HRESULT>)_lpVtbl[128])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasManagedCode"/>
+    public HRESULT get_hasManagedCode(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BOOL*, HRESULT>)_lpVtbl[129])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isHotpatchable"/>
+    public HRESULT get_isHotpatchable(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BOOL*, HRESULT>)_lpVtbl[130])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isCVTCIL"/>
+    public HRESULT get_isCVTCIL(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BOOL*, HRESULT>)_lpVtbl[131])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isMSILNetmodule"/>
+    public HRESULT get_isMSILNetmodule(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BOOL*, HRESULT>)_lpVtbl[132])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isCTypes"/>
+    public HRESULT get_isCTypes(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BOOL*, HRESULT>)_lpVtbl[133])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isStripped"/>
+    public HRESULT get_isStripped(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BOOL*, HRESULT>)_lpVtbl[134])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_frontEndQFE"/>
+    public HRESULT get_frontEndQFE(uint* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, uint*, HRESULT>)_lpVtbl[135])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_backEndQFE"/>
+    public HRESULT get_backEndQFE(uint* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, uint*, HRESULT>)_lpVtbl[136])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_wasInlined"/>
+    public HRESULT get_wasInlined(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BOOL*, HRESULT>)_lpVtbl[137])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_strictGSCheck"/>
+    public HRESULT get_strictGSCheck(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BOOL*, HRESULT>)_lpVtbl[138])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isCxxReturnUdt"/>
+    public HRESULT get_isCxxReturnUdt(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BOOL*, HRESULT>)_lpVtbl[139])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isConstructorVirtualBase"/>
+    public HRESULT get_isConstructorVirtualBase(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BOOL*, HRESULT>)_lpVtbl[140])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_RValueReference"/>
+    public HRESULT get_RValueReference(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BOOL*, HRESULT>)_lpVtbl[141])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_unmodifiedType"/>
+    public HRESULT get_unmodifiedType(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, IDiaSymbol**, HRESULT>)_lpVtbl[142])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_framePointerPresent"/>
+    public HRESULT get_framePointerPresent(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BOOL*, HRESULT>)_lpVtbl[143])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isSafeBuffers"/>
+    public HRESULT get_isSafeBuffers(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BOOL*, HRESULT>)_lpVtbl[144])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_intrinsic"/>
+    public HRESULT get_intrinsic(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BOOL*, HRESULT>)_lpVtbl[145])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_sealed"/>
+    public HRESULT get_sealed(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BOOL*, HRESULT>)_lpVtbl[146])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hfaFloat"/>
+    public HRESULT get_hfaFloat(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BOOL*, HRESULT>)_lpVtbl[147])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hfaDouble"/>
+    public HRESULT get_hfaDouble(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BOOL*, HRESULT>)_lpVtbl[148])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_liveRangeStartAddressSection"/>
+    public HRESULT get_liveRangeStartAddressSection(uint* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, uint*, HRESULT>)_lpVtbl[149])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_liveRangeStartAddressOffset"/>
+    public HRESULT get_liveRangeStartAddressOffset(uint* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, uint*, HRESULT>)_lpVtbl[150])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_liveRangeStartRelativeVirtualAddress"/>
+    public HRESULT get_liveRangeStartRelativeVirtualAddress(uint* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, uint*, HRESULT>)_lpVtbl[151])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_countLiveRanges"/>
+    public HRESULT get_countLiveRanges(uint* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, uint*, HRESULT>)_lpVtbl[152])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_liveRangeLength"/>
+    public HRESULT get_liveRangeLength(ulong* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, ulong*, HRESULT>)_lpVtbl[153])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_offsetInUdt"/>
+    public HRESULT get_offsetInUdt(uint* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, uint*, HRESULT>)_lpVtbl[154])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_paramBasePointerRegisterId"/>
+    public HRESULT get_paramBasePointerRegisterId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, uint*, HRESULT>)_lpVtbl[155])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_localBasePointerRegisterId"/>
+    public HRESULT get_localBasePointerRegisterId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, uint*, HRESULT>)_lpVtbl[156])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isLocationControlFlowDependent"/>
+    public HRESULT get_isLocationControlFlowDependent(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BOOL*, HRESULT>)_lpVtbl[157])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_stride"/>
+    public HRESULT get_stride(uint* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, uint*, HRESULT>)_lpVtbl[158])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_numberOfRows"/>
+    public HRESULT get_numberOfRows(uint* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, uint*, HRESULT>)_lpVtbl[159])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_numberOfColumns"/>
+    public HRESULT get_numberOfColumns(uint* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, uint*, HRESULT>)_lpVtbl[160])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isMatrixRowMajor"/>
+    public HRESULT get_isMatrixRowMajor(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BOOL*, HRESULT>)_lpVtbl[161])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_numericProperties"/>
+    public HRESULT get_numericProperties(uint cnt, uint* pcnt, uint* pProperties)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, uint, uint*, uint*, HRESULT>)_lpVtbl[162])(pThis, cnt, pcnt, pProperties);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_modifierValues"/>
+    public HRESULT get_modifierValues(uint cnt, uint* pcnt, ushort* pModifiers)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, uint, uint*, ushort*, HRESULT>)_lpVtbl[163])(pThis, cnt, pcnt, pModifiers);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isReturnValue"/>
+    public HRESULT get_isReturnValue(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BOOL*, HRESULT>)_lpVtbl[164])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isOptimizedAway"/>
+    public HRESULT get_isOptimizedAway(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BOOL*, HRESULT>)_lpVtbl[165])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_builtInKind"/>
+    public HRESULT get_builtInKind(uint* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, uint*, HRESULT>)_lpVtbl[166])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_registerType"/>
+    public HRESULT get_registerType(uint* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, uint*, HRESULT>)_lpVtbl[167])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_baseDataSlot"/>
+    public HRESULT get_baseDataSlot(uint* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, uint*, HRESULT>)_lpVtbl[168])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_baseDataOffset"/>
+    public HRESULT get_baseDataOffset(uint* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, uint*, HRESULT>)_lpVtbl[169])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_textureSlot"/>
+    public HRESULT get_textureSlot(uint* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, uint*, HRESULT>)_lpVtbl[170])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_samplerSlot"/>
+    public HRESULT get_samplerSlot(uint* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, uint*, HRESULT>)_lpVtbl[171])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_uavSlot"/>
+    public HRESULT get_uavSlot(uint* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, uint*, HRESULT>)_lpVtbl[172])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_sizeInUdt"/>
+    public HRESULT get_sizeInUdt(uint* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, uint*, HRESULT>)_lpVtbl[173])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_memorySpaceKind"/>
+    public HRESULT get_memorySpaceKind(uint* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, uint*, HRESULT>)_lpVtbl[174])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_unmodifiedTypeId"/>
+    public HRESULT get_unmodifiedTypeId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, uint*, HRESULT>)_lpVtbl[175])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_subTypeId"/>
+    public HRESULT get_subTypeId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, uint*, HRESULT>)_lpVtbl[176])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_subType"/>
+    public HRESULT get_subType(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, IDiaSymbol**, HRESULT>)_lpVtbl[177])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_numberOfModifiers"/>
+    public HRESULT get_numberOfModifiers(uint* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, uint*, HRESULT>)_lpVtbl[178])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_numberOfRegisterIndices"/>
+    public HRESULT get_numberOfRegisterIndices(uint* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, uint*, HRESULT>)_lpVtbl[179])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isHLSLData"/>
+    public HRESULT get_isHLSLData(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BOOL*, HRESULT>)_lpVtbl[180])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isPointerToDataMember"/>
+    public HRESULT get_isPointerToDataMember(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BOOL*, HRESULT>)_lpVtbl[181])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isPointerToMemberFunction"/>
+    public HRESULT get_isPointerToMemberFunction(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BOOL*, HRESULT>)_lpVtbl[182])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isSingleInheritance"/>
+    public HRESULT get_isSingleInheritance(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BOOL*, HRESULT>)_lpVtbl[183])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isMultipleInheritance"/>
+    public HRESULT get_isMultipleInheritance(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BOOL*, HRESULT>)_lpVtbl[184])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isVirtualInheritance"/>
+    public HRESULT get_isVirtualInheritance(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BOOL*, HRESULT>)_lpVtbl[185])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_restrictedType"/>
+    public HRESULT get_restrictedType(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BOOL*, HRESULT>)_lpVtbl[186])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isPointerBasedOnSymbolValue"/>
+    public HRESULT get_isPointerBasedOnSymbolValue(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BOOL*, HRESULT>)_lpVtbl[187])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_baseSymbol"/>
+    public HRESULT get_baseSymbol(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, IDiaSymbol**, HRESULT>)_lpVtbl[188])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_baseSymbolId"/>
+    public HRESULT get_baseSymbolId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, uint*, HRESULT>)_lpVtbl[189])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_objectFileName"/>
+    public HRESULT get_objectFileName(BSTR* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BSTR*, HRESULT>)_lpVtbl[190])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isAcceleratorGroupSharedLocal"/>
+    public HRESULT get_isAcceleratorGroupSharedLocal(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BOOL*, HRESULT>)_lpVtbl[191])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isAcceleratorPointerTagLiveRange"/>
+    public HRESULT get_isAcceleratorPointerTagLiveRange(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BOOL*, HRESULT>)_lpVtbl[192])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isAcceleratorStubFunction"/>
+    public HRESULT get_isAcceleratorStubFunction(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BOOL*, HRESULT>)_lpVtbl[193])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_numberOfAcceleratorPointerTags"/>
+    public HRESULT get_numberOfAcceleratorPointerTags(uint* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, uint*, HRESULT>)_lpVtbl[194])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isSdl"/>
+    public HRESULT get_isSdl(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BOOL*, HRESULT>)_lpVtbl[195])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isWinRTPointer"/>
+    public HRESULT get_isWinRTPointer(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BOOL*, HRESULT>)_lpVtbl[196])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isRefUdt"/>
+    public HRESULT get_isRefUdt(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BOOL*, HRESULT>)_lpVtbl[197])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isValueUdt"/>
+    public HRESULT get_isValueUdt(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BOOL*, HRESULT>)_lpVtbl[198])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isInterfaceUdt"/>
+    public HRESULT get_isInterfaceUdt(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BOOL*, HRESULT>)_lpVtbl[199])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findInlineFramesByAddr"/>
+    public HRESULT findInlineFramesByAddr(uint isect, uint offset, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, uint, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[200])(pThis, isect, offset, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findInlineFramesByRVA"/>
+    public HRESULT findInlineFramesByRVA(uint rva, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[201])(pThis, rva, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findInlineFramesByVA"/>
+    public HRESULT findInlineFramesByVA(ulong va, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, ulong, IDiaEnumSymbols**, HRESULT>)_lpVtbl[202])(pThis, va, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findInlineeLines"/>
+    public HRESULT findInlineeLines(IDiaEnumLineNumbers** ppResult)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, IDiaEnumLineNumbers**, HRESULT>)_lpVtbl[203])(pThis, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findInlineeLinesByAddr"/>
+    public HRESULT findInlineeLinesByAddr(uint isect, uint offset, uint length, IDiaEnumLineNumbers** ppResult)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, uint, uint, uint, IDiaEnumLineNumbers**, HRESULT>)_lpVtbl[204])(pThis, isect, offset, length, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findInlineeLinesByRVA"/>
+    public HRESULT findInlineeLinesByRVA(uint rva, uint length, IDiaEnumLineNumbers** ppResult)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, uint, uint, IDiaEnumLineNumbers**, HRESULT>)_lpVtbl[205])(pThis, rva, length, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findInlineeLinesByVA"/>
+    public HRESULT findInlineeLinesByVA(ulong va, uint length, IDiaEnumLineNumbers** ppResult)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, ulong, uint, IDiaEnumLineNumbers**, HRESULT>)_lpVtbl[206])(pThis, va, length, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findSymbolsForAcceleratorPointerTag"/>
+    public HRESULT findSymbolsForAcceleratorPointerTag(uint tagValue, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[207])(pThis, tagValue, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findSymbolsByRVAForAcceleratorPointerTag"/>
+    public HRESULT findSymbolsByRVAForAcceleratorPointerTag(uint tagValue, uint rva, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, uint, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[208])(pThis, tagValue, rva, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_acceleratorPointerTags"/>
+    public HRESULT get_acceleratorPointerTags(uint cnt, uint* pcnt, uint* pPointerTags)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, uint, uint*, uint*, HRESULT>)_lpVtbl[209])(pThis, cnt, pcnt, pPointerTags);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.getSrcLineOnTypeDefn"/>
+    public HRESULT getSrcLineOnTypeDefn(IDiaLineNumber** ppResult)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, IDiaLineNumber**, HRESULT>)_lpVtbl[210])(pThis, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isPGO"/>
+    public HRESULT get_isPGO(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BOOL*, HRESULT>)_lpVtbl[211])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasValidPGOCounts"/>
+    public HRESULT get_hasValidPGOCounts(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BOOL*, HRESULT>)_lpVtbl[212])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isOptimizedForSpeed"/>
+    public HRESULT get_isOptimizedForSpeed(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BOOL*, HRESULT>)_lpVtbl[213])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_PGOEntryCount"/>
+    public HRESULT get_PGOEntryCount(uint* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, uint*, HRESULT>)_lpVtbl[214])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_PGOEdgeCount"/>
+    public HRESULT get_PGOEdgeCount(uint* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, uint*, HRESULT>)_lpVtbl[215])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_PGODynamicInstructionCount"/>
+    public HRESULT get_PGODynamicInstructionCount(ulong* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, ulong*, HRESULT>)_lpVtbl[216])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_staticSize"/>
+    public HRESULT get_staticSize(uint* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, uint*, HRESULT>)_lpVtbl[217])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_finalLiveStaticSize"/>
+    public HRESULT get_finalLiveStaticSize(uint* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, uint*, HRESULT>)_lpVtbl[218])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_phaseName"/>
+    public HRESULT get_phaseName(BSTR* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BSTR*, HRESULT>)_lpVtbl[219])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasControlFlowCheck"/>
+    public HRESULT get_hasControlFlowCheck(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BOOL*, HRESULT>)_lpVtbl[220])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_constantExport"/>
+    public HRESULT get_constantExport(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BOOL*, HRESULT>)_lpVtbl[221])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_dataExport"/>
+    public HRESULT get_dataExport(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BOOL*, HRESULT>)_lpVtbl[222])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_privateExport"/>
+    public HRESULT get_privateExport(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BOOL*, HRESULT>)_lpVtbl[223])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_noNameExport"/>
+    public HRESULT get_noNameExport(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BOOL*, HRESULT>)_lpVtbl[224])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_exportHasExplicitlyAssignedOrdinal"/>
+    public HRESULT get_exportHasExplicitlyAssignedOrdinal(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BOOL*, HRESULT>)_lpVtbl[225])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_exportIsForwarder"/>
+    public HRESULT get_exportIsForwarder(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BOOL*, HRESULT>)_lpVtbl[226])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_ordinal"/>
+    public HRESULT get_ordinal(uint* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, uint*, HRESULT>)_lpVtbl[227])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_frameSize"/>
+    public HRESULT get_frameSize(uint* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, uint*, HRESULT>)_lpVtbl[228])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_exceptionHandlerAddressSection"/>
+    public HRESULT get_exceptionHandlerAddressSection(uint* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, uint*, HRESULT>)_lpVtbl[229])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_exceptionHandlerAddressOffset"/>
+    public HRESULT get_exceptionHandlerAddressOffset(uint* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, uint*, HRESULT>)_lpVtbl[230])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_exceptionHandlerRelativeVirtualAddress"/>
+    public HRESULT get_exceptionHandlerRelativeVirtualAddress(uint* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, uint*, HRESULT>)_lpVtbl[231])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_exceptionHandlerVirtualAddress"/>
+    public HRESULT get_exceptionHandlerVirtualAddress(ulong* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, ulong*, HRESULT>)_lpVtbl[232])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findInputAssemblyFile"/>
+    public HRESULT findInputAssemblyFile(IDiaInputAssemblyFile** ppResult)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, IDiaInputAssemblyFile**, HRESULT>)_lpVtbl[233])(pThis, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_characteristics"/>
+    public HRESULT get_characteristics(uint* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, uint*, HRESULT>)_lpVtbl[234])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_coffGroup"/>
+    public HRESULT get_coffGroup(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, IDiaSymbol**, HRESULT>)_lpVtbl[235])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_bindID"/>
+    public HRESULT get_bindID(uint* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, uint*, HRESULT>)_lpVtbl[236])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_bindSpace"/>
+    public HRESULT get_bindSpace(uint* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, uint*, HRESULT>)_lpVtbl[237])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_bindSlot"/>
+    public HRESULT get_bindSlot(uint* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, uint*, HRESULT>)_lpVtbl[238])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol2.Interface.get_isObjCClass"/>
+    public HRESULT get_isObjCClass(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BOOL*, HRESULT>)_lpVtbl[239])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol2.Interface.get_isObjCCategory"/>
+    public HRESULT get_isObjCCategory(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BOOL*, HRESULT>)_lpVtbl[240])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol2.Interface.get_isObjCProtocol"/>
+    public HRESULT get_isObjCProtocol(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, BOOL*, HRESULT>)_lpVtbl[241])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_inlinee"/>
+    public HRESULT get_inlinee(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, IDiaSymbol**, HRESULT>)_lpVtbl[242])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_inlineeId"/>
+    public HRESULT get_inlineeId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol3* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol3*, uint*, HRESULT>)_lpVtbl[243])(pThis, pRetVal);
+    }
+
+    /// <summary>
+    ///  Extends IDiaSymbol2 with inlinee properties.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/visualstudio/debugger/debug-interface-access/idiasymbol3">
+    ///    Official documentation.
+    ///   </see>
+    ///  </para>
+    /// </remarks>
+    [ComImport]
+    [Guid("99B665F7-C1B2-49D3-89B2-A384361ACAB5")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    public unsafe interface Interface : IDiaSymbol2.Interface
+    {
+        /// <summary>
+        ///  Inlinee.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_inlinee(IDiaSymbol** pRetVal);
+
+        /// <summary>
+        ///  Inlinee ID.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_inlineeId(uint* pRetVal);
+    }
+}

--- a/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaSymbol4.cs
+++ b/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaSymbol4.cs
@@ -1,0 +1,1783 @@
+﻿// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Runtime.InteropServices;
+using Windows.Win32.System.Variant;
+
+// For some reason the XML comment refs for IUnknown can't be resolved on .NET Framework without
+// explicitly using the fully qualified name, which falls afoul of the simplify warning.
+using ComIUnknown = Windows.Win32.System.Com.IUnknown;
+
+namespace Microsoft.VisualStudio.Debugging.DebugInterfaceAccess;
+
+/// <inheritdoc cref="Interface"/>
+public unsafe struct IDiaSymbol4 : IComIID
+{
+    /// <inheritdoc cref="IComIID.Guid"/>
+#pragma warning disable IDE1006 // Naming Styles
+    public static readonly Guid IID_Guid = new(0xBF6C88A7, 0xE9D6, 0x4346, 0x99, 0xA1, 0xD0, 0x53, 0xDE, 0x5A, 0x78, 0x08);
+#pragma warning restore IDE1006
+
+#if NETFRAMEWORK
+    readonly ref readonly Guid IComIID.Guid => ref IID_Guid;
+#else
+    static ref readonly Guid IComIID.Guid
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get
+        {
+            ReadOnlySpan<byte> data =
+            [
+                0xA7, 0x88, 0x6C, 0xBF,
+                0xD6, 0xE9,
+                0x46, 0x43,
+                0x99, 0xA1, 0xD0, 0x53, 0xDE, 0x5A, 0x78, 0x08
+            ];
+
+            return ref Unsafe.As<byte, Guid>(ref MemoryMarshal.GetReference(data));
+        }
+    }
+#endif
+
+    private readonly void** _lpVtbl;
+
+    /// <inheritdoc cref="ComIUnknown.QueryInterface(Guid*, void**)"/>
+    public HRESULT QueryInterface(Guid* riid, void** ppvObject)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, Guid*, void**, HRESULT>)_lpVtbl[0])(pThis, riid, ppvObject);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.AddRef"/>
+    public uint AddRef()
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, uint>)_lpVtbl[1])(pThis);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.Release"/>
+    public uint Release()
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, uint>)_lpVtbl[2])(pThis);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_symIndexId"/>
+    public HRESULT get_symIndexId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, uint*, HRESULT>)_lpVtbl[3])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_symTag"/>
+    public HRESULT get_symTag(uint* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, uint*, HRESULT>)_lpVtbl[4])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_name"/>
+    public HRESULT get_name(BSTR* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BSTR*, HRESULT>)_lpVtbl[5])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_lexicalParent"/>
+    public HRESULT get_lexicalParent(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, IDiaSymbol**, HRESULT>)_lpVtbl[6])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_classParent"/>
+    public HRESULT get_classParent(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, IDiaSymbol**, HRESULT>)_lpVtbl[7])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_type"/>
+    public HRESULT get_type(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, IDiaSymbol**, HRESULT>)_lpVtbl[8])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_dataKind"/>
+    public HRESULT get_dataKind(uint* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, uint*, HRESULT>)_lpVtbl[9])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_locationType"/>
+    public HRESULT get_locationType(uint* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, uint*, HRESULT>)_lpVtbl[10])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_addressSection"/>
+    public HRESULT get_addressSection(uint* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, uint*, HRESULT>)_lpVtbl[11])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_addressOffset"/>
+    public HRESULT get_addressOffset(uint* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, uint*, HRESULT>)_lpVtbl[12])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_relativeVirtualAddress"/>
+    public HRESULT get_relativeVirtualAddress(uint* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, uint*, HRESULT>)_lpVtbl[13])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_virtualAddress"/>
+    public HRESULT get_virtualAddress(ulong* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, ulong*, HRESULT>)_lpVtbl[14])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_registerId"/>
+    public HRESULT get_registerId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, uint*, HRESULT>)_lpVtbl[15])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_offset"/>
+    public HRESULT get_offset(int* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, int*, HRESULT>)_lpVtbl[16])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_length"/>
+    public HRESULT get_length(ulong* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, ulong*, HRESULT>)_lpVtbl[17])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_slot"/>
+    public HRESULT get_slot(uint* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, uint*, HRESULT>)_lpVtbl[18])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_volatileType"/>
+    public HRESULT get_volatileType(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BOOL*, HRESULT>)_lpVtbl[19])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_constType"/>
+    public HRESULT get_constType(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BOOL*, HRESULT>)_lpVtbl[20])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_unalignedType"/>
+    public HRESULT get_unalignedType(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BOOL*, HRESULT>)_lpVtbl[21])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_access"/>
+    public HRESULT get_access(uint* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, uint*, HRESULT>)_lpVtbl[22])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_libraryName"/>
+    public HRESULT get_libraryName(BSTR* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BSTR*, HRESULT>)_lpVtbl[23])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_platform"/>
+    public HRESULT get_platform(uint* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, uint*, HRESULT>)_lpVtbl[24])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_language"/>
+    public HRESULT get_language(uint* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, uint*, HRESULT>)_lpVtbl[25])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_editAndContinueEnabled"/>
+    public HRESULT get_editAndContinueEnabled(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BOOL*, HRESULT>)_lpVtbl[26])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_frontEndMajor"/>
+    public HRESULT get_frontEndMajor(uint* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, uint*, HRESULT>)_lpVtbl[27])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_frontEndMinor"/>
+    public HRESULT get_frontEndMinor(uint* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, uint*, HRESULT>)_lpVtbl[28])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_frontEndBuild"/>
+    public HRESULT get_frontEndBuild(uint* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, uint*, HRESULT>)_lpVtbl[29])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_backEndMajor"/>
+    public HRESULT get_backEndMajor(uint* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, uint*, HRESULT>)_lpVtbl[30])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_backEndMinor"/>
+    public HRESULT get_backEndMinor(uint* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, uint*, HRESULT>)_lpVtbl[31])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_backEndBuild"/>
+    public HRESULT get_backEndBuild(uint* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, uint*, HRESULT>)_lpVtbl[32])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_sourceFileName"/>
+    public HRESULT get_sourceFileName(BSTR* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BSTR*, HRESULT>)_lpVtbl[33])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_unused"/>
+    public HRESULT get_unused(BSTR* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BSTR*, HRESULT>)_lpVtbl[34])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_thunkOrdinal"/>
+    public HRESULT get_thunkOrdinal(uint* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, uint*, HRESULT>)_lpVtbl[35])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_thisAdjust"/>
+    public HRESULT get_thisAdjust(int* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, int*, HRESULT>)_lpVtbl[36])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_virtualBaseOffset"/>
+    public HRESULT get_virtualBaseOffset(uint* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, uint*, HRESULT>)_lpVtbl[37])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_virtual"/>
+    public HRESULT get_virtual(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BOOL*, HRESULT>)_lpVtbl[38])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_intro"/>
+    public HRESULT get_intro(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BOOL*, HRESULT>)_lpVtbl[39])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_pure"/>
+    public HRESULT get_pure(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BOOL*, HRESULT>)_lpVtbl[40])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_callingConvention"/>
+    public HRESULT get_callingConvention(uint* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, uint*, HRESULT>)_lpVtbl[41])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_value"/>
+    public HRESULT get_value(VARIANT* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, VARIANT*, HRESULT>)_lpVtbl[42])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_baseType"/>
+    public HRESULT get_baseType(uint* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, uint*, HRESULT>)_lpVtbl[43])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_token"/>
+    public HRESULT get_token(uint* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, uint*, HRESULT>)_lpVtbl[44])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_timeStamp"/>
+    public HRESULT get_timeStamp(uint* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, uint*, HRESULT>)_lpVtbl[45])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_guid"/>
+    public HRESULT get_guid(Guid* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, Guid*, HRESULT>)_lpVtbl[46])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_symbolsFileName"/>
+    public HRESULT get_symbolsFileName(BSTR* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BSTR*, HRESULT>)_lpVtbl[47])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_reference"/>
+    public HRESULT get_reference(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BOOL*, HRESULT>)_lpVtbl[48])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_count"/>
+    public HRESULT get_count(uint* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, uint*, HRESULT>)_lpVtbl[49])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_bitPosition"/>
+    public HRESULT get_bitPosition(uint* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, uint*, HRESULT>)_lpVtbl[50])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_arrayIndexType"/>
+    public HRESULT get_arrayIndexType(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, IDiaSymbol**, HRESULT>)_lpVtbl[51])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_packed"/>
+    public HRESULT get_packed(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BOOL*, HRESULT>)_lpVtbl[52])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_constructor"/>
+    public HRESULT get_constructor(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BOOL*, HRESULT>)_lpVtbl[53])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_overloadedOperator"/>
+    public HRESULT get_overloadedOperator(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BOOL*, HRESULT>)_lpVtbl[54])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_nested"/>
+    public HRESULT get_nested(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BOOL*, HRESULT>)_lpVtbl[55])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasNestedTypes"/>
+    public HRESULT get_hasNestedTypes(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BOOL*, HRESULT>)_lpVtbl[56])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasAssignmentOperator"/>
+    public HRESULT get_hasAssignmentOperator(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BOOL*, HRESULT>)_lpVtbl[57])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasCastOperator"/>
+    public HRESULT get_hasCastOperator(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BOOL*, HRESULT>)_lpVtbl[58])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_scoped"/>
+    public HRESULT get_scoped(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BOOL*, HRESULT>)_lpVtbl[59])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_virtualBaseClass"/>
+    public HRESULT get_virtualBaseClass(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BOOL*, HRESULT>)_lpVtbl[60])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_indirectVirtualBaseClass"/>
+    public HRESULT get_indirectVirtualBaseClass(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BOOL*, HRESULT>)_lpVtbl[61])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_virtualBasePointerOffset"/>
+    public HRESULT get_virtualBasePointerOffset(int* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, int*, HRESULT>)_lpVtbl[62])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_virtualTableShape"/>
+    public HRESULT get_virtualTableShape(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, IDiaSymbol**, HRESULT>)_lpVtbl[63])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_lexicalParentId"/>
+    public HRESULT get_lexicalParentId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, uint*, HRESULT>)_lpVtbl[64])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_classParentId"/>
+    public HRESULT get_classParentId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, uint*, HRESULT>)_lpVtbl[65])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_typeId"/>
+    public HRESULT get_typeId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, uint*, HRESULT>)_lpVtbl[66])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_arrayIndexTypeId"/>
+    public HRESULT get_arrayIndexTypeId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, uint*, HRESULT>)_lpVtbl[67])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_virtualTableShapeId"/>
+    public HRESULT get_virtualTableShapeId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, uint*, HRESULT>)_lpVtbl[68])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_code"/>
+    public HRESULT get_code(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BOOL*, HRESULT>)_lpVtbl[69])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_function"/>
+    public HRESULT get_function(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BOOL*, HRESULT>)_lpVtbl[70])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_managed"/>
+    public HRESULT get_managed(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BOOL*, HRESULT>)_lpVtbl[71])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_msil"/>
+    public HRESULT get_msil(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BOOL*, HRESULT>)_lpVtbl[72])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_virtualBaseDispIndex"/>
+    public HRESULT get_virtualBaseDispIndex(uint* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, uint*, HRESULT>)_lpVtbl[73])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_undecoratedName"/>
+    public HRESULT get_undecoratedName(BSTR* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BSTR*, HRESULT>)_lpVtbl[74])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_age"/>
+    public HRESULT get_age(uint* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, uint*, HRESULT>)_lpVtbl[75])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_signature"/>
+    public HRESULT get_signature(uint* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, uint*, HRESULT>)_lpVtbl[76])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_compilerGenerated"/>
+    public HRESULT get_compilerGenerated(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BOOL*, HRESULT>)_lpVtbl[77])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_addressTaken"/>
+    public HRESULT get_addressTaken(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BOOL*, HRESULT>)_lpVtbl[78])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_rank"/>
+    public HRESULT get_rank(uint* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, uint*, HRESULT>)_lpVtbl[79])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_lowerBound"/>
+    public HRESULT get_lowerBound(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, IDiaSymbol**, HRESULT>)_lpVtbl[80])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_upperBound"/>
+    public HRESULT get_upperBound(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, IDiaSymbol**, HRESULT>)_lpVtbl[81])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_lowerBoundId"/>
+    public HRESULT get_lowerBoundId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, uint*, HRESULT>)_lpVtbl[82])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_upperBoundId"/>
+    public HRESULT get_upperBoundId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, uint*, HRESULT>)_lpVtbl[83])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_dataBytes"/>
+    public HRESULT get_dataBytes(uint cbData, uint* pcbData, byte* pbData)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, uint, uint*, byte*, HRESULT>)_lpVtbl[84])(pThis, cbData, pcbData, pbData);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findChildren"/>
+    public HRESULT findChildren(SymTagEnum symtag, PCWSTR name, uint compareFlags, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, SymTagEnum, PCWSTR, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[85])(pThis, symtag, name, compareFlags, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findChildrenEx"/>
+    public HRESULT findChildrenEx(SymTagEnum symtag, PCWSTR name, uint compareFlags, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, SymTagEnum, PCWSTR, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[86])(pThis, symtag, name, compareFlags, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findChildrenExByAddr"/>
+    public HRESULT findChildrenExByAddr(SymTagEnum symtag, PCWSTR name, uint compareFlags, uint isect, uint offset, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, SymTagEnum, PCWSTR, uint, uint, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[87])(pThis, symtag, name, compareFlags, isect, offset, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findChildrenExByVA"/>
+    public HRESULT findChildrenExByVA(SymTagEnum symtag, PCWSTR name, uint compareFlags, ulong va, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, SymTagEnum, PCWSTR, uint, ulong, IDiaEnumSymbols**, HRESULT>)_lpVtbl[88])(pThis, symtag, name, compareFlags, va, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findChildrenExByRVA"/>
+    public HRESULT findChildrenExByRVA(SymTagEnum symtag, PCWSTR name, uint compareFlags, uint rva, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, SymTagEnum, PCWSTR, uint, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[89])(pThis, symtag, name, compareFlags, rva, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_targetSection"/>
+    public HRESULT get_targetSection(uint* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, uint*, HRESULT>)_lpVtbl[90])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_targetOffset"/>
+    public HRESULT get_targetOffset(uint* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, uint*, HRESULT>)_lpVtbl[91])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_targetRelativeVirtualAddress"/>
+    public HRESULT get_targetRelativeVirtualAddress(uint* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, uint*, HRESULT>)_lpVtbl[92])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_targetVirtualAddress"/>
+    public HRESULT get_targetVirtualAddress(ulong* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, ulong*, HRESULT>)_lpVtbl[93])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_machineType"/>
+    public HRESULT get_machineType(uint* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, uint*, HRESULT>)_lpVtbl[94])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_oemId"/>
+    public HRESULT get_oemId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, uint*, HRESULT>)_lpVtbl[95])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_oemSymbolId"/>
+    public HRESULT get_oemSymbolId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, uint*, HRESULT>)_lpVtbl[96])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_types"/>
+    public HRESULT get_types(uint cTypes, uint* pcTypes, IDiaSymbol** pTypes)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, uint, uint*, IDiaSymbol**, HRESULT>)_lpVtbl[97])(pThis, cTypes, pcTypes, pTypes);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_typeIds"/>
+    public HRESULT get_typeIds(uint cTypeIds, uint* pcTypeIds, uint* pdwTypeIds)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, uint, uint*, uint*, HRESULT>)_lpVtbl[98])(pThis, cTypeIds, pcTypeIds, pdwTypeIds);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_objectPointerType"/>
+    public HRESULT get_objectPointerType(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, IDiaSymbol**, HRESULT>)_lpVtbl[99])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_udtKind"/>
+    public HRESULT get_udtKind(uint* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, uint*, HRESULT>)_lpVtbl[100])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_undecoratedNameEx"/>
+    public HRESULT get_undecoratedNameEx(uint undecorateOptions, BSTR* name)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, uint, BSTR*, HRESULT>)_lpVtbl[101])(pThis, undecorateOptions, name);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_noReturn"/>
+    public HRESULT get_noReturn(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BOOL*, HRESULT>)_lpVtbl[102])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_customCallingConvention"/>
+    public HRESULT get_customCallingConvention(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BOOL*, HRESULT>)_lpVtbl[103])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_noInline"/>
+    public HRESULT get_noInline(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BOOL*, HRESULT>)_lpVtbl[104])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_optimizedCodeDebugInfo"/>
+    public HRESULT get_optimizedCodeDebugInfo(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BOOL*, HRESULT>)_lpVtbl[105])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_notReached"/>
+    public HRESULT get_notReached(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BOOL*, HRESULT>)_lpVtbl[106])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_interruptReturn"/>
+    public HRESULT get_interruptReturn(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BOOL*, HRESULT>)_lpVtbl[107])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_farReturn"/>
+    public HRESULT get_farReturn(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BOOL*, HRESULT>)_lpVtbl[108])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isStatic"/>
+    public HRESULT get_isStatic(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BOOL*, HRESULT>)_lpVtbl[109])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasDebugInfo"/>
+    public HRESULT get_hasDebugInfo(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BOOL*, HRESULT>)_lpVtbl[110])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isLTCG"/>
+    public HRESULT get_isLTCG(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BOOL*, HRESULT>)_lpVtbl[111])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isDataAligned"/>
+    public HRESULT get_isDataAligned(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BOOL*, HRESULT>)_lpVtbl[112])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasSecurityChecks"/>
+    public HRESULT get_hasSecurityChecks(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BOOL*, HRESULT>)_lpVtbl[113])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_compilerName"/>
+    public HRESULT get_compilerName(BSTR* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BSTR*, HRESULT>)_lpVtbl[114])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasAlloca"/>
+    public HRESULT get_hasAlloca(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BOOL*, HRESULT>)_lpVtbl[115])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasSetJump"/>
+    public HRESULT get_hasSetJump(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BOOL*, HRESULT>)_lpVtbl[116])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasLongJump"/>
+    public HRESULT get_hasLongJump(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BOOL*, HRESULT>)_lpVtbl[117])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasInlAsm"/>
+    public HRESULT get_hasInlAsm(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BOOL*, HRESULT>)_lpVtbl[118])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasEH"/>
+    public HRESULT get_hasEH(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BOOL*, HRESULT>)_lpVtbl[119])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasSEH"/>
+    public HRESULT get_hasSEH(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BOOL*, HRESULT>)_lpVtbl[120])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasEHa"/>
+    public HRESULT get_hasEHa(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BOOL*, HRESULT>)_lpVtbl[121])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isNaked"/>
+    public HRESULT get_isNaked(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BOOL*, HRESULT>)_lpVtbl[122])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isAggregated"/>
+    public HRESULT get_isAggregated(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BOOL*, HRESULT>)_lpVtbl[123])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isSplitted"/>
+    public HRESULT get_isSplitted(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BOOL*, HRESULT>)_lpVtbl[124])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_container"/>
+    public HRESULT get_container(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, IDiaSymbol**, HRESULT>)_lpVtbl[125])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_inlSpec"/>
+    public HRESULT get_inlSpec(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BOOL*, HRESULT>)_lpVtbl[126])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_noStackOrdering"/>
+    public HRESULT get_noStackOrdering(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BOOL*, HRESULT>)_lpVtbl[127])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_virtualBaseTableType"/>
+    public HRESULT get_virtualBaseTableType(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, IDiaSymbol**, HRESULT>)_lpVtbl[128])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasManagedCode"/>
+    public HRESULT get_hasManagedCode(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BOOL*, HRESULT>)_lpVtbl[129])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isHotpatchable"/>
+    public HRESULT get_isHotpatchable(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BOOL*, HRESULT>)_lpVtbl[130])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isCVTCIL"/>
+    public HRESULT get_isCVTCIL(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BOOL*, HRESULT>)_lpVtbl[131])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isMSILNetmodule"/>
+    public HRESULT get_isMSILNetmodule(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BOOL*, HRESULT>)_lpVtbl[132])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isCTypes"/>
+    public HRESULT get_isCTypes(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BOOL*, HRESULT>)_lpVtbl[133])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isStripped"/>
+    public HRESULT get_isStripped(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BOOL*, HRESULT>)_lpVtbl[134])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_frontEndQFE"/>
+    public HRESULT get_frontEndQFE(uint* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, uint*, HRESULT>)_lpVtbl[135])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_backEndQFE"/>
+    public HRESULT get_backEndQFE(uint* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, uint*, HRESULT>)_lpVtbl[136])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_wasInlined"/>
+    public HRESULT get_wasInlined(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BOOL*, HRESULT>)_lpVtbl[137])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_strictGSCheck"/>
+    public HRESULT get_strictGSCheck(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BOOL*, HRESULT>)_lpVtbl[138])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isCxxReturnUdt"/>
+    public HRESULT get_isCxxReturnUdt(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BOOL*, HRESULT>)_lpVtbl[139])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isConstructorVirtualBase"/>
+    public HRESULT get_isConstructorVirtualBase(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BOOL*, HRESULT>)_lpVtbl[140])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_RValueReference"/>
+    public HRESULT get_RValueReference(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BOOL*, HRESULT>)_lpVtbl[141])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_unmodifiedType"/>
+    public HRESULT get_unmodifiedType(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, IDiaSymbol**, HRESULT>)_lpVtbl[142])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_framePointerPresent"/>
+    public HRESULT get_framePointerPresent(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BOOL*, HRESULT>)_lpVtbl[143])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isSafeBuffers"/>
+    public HRESULT get_isSafeBuffers(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BOOL*, HRESULT>)_lpVtbl[144])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_intrinsic"/>
+    public HRESULT get_intrinsic(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BOOL*, HRESULT>)_lpVtbl[145])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_sealed"/>
+    public HRESULT get_sealed(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BOOL*, HRESULT>)_lpVtbl[146])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hfaFloat"/>
+    public HRESULT get_hfaFloat(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BOOL*, HRESULT>)_lpVtbl[147])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hfaDouble"/>
+    public HRESULT get_hfaDouble(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BOOL*, HRESULT>)_lpVtbl[148])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_liveRangeStartAddressSection"/>
+    public HRESULT get_liveRangeStartAddressSection(uint* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, uint*, HRESULT>)_lpVtbl[149])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_liveRangeStartAddressOffset"/>
+    public HRESULT get_liveRangeStartAddressOffset(uint* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, uint*, HRESULT>)_lpVtbl[150])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_liveRangeStartRelativeVirtualAddress"/>
+    public HRESULT get_liveRangeStartRelativeVirtualAddress(uint* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, uint*, HRESULT>)_lpVtbl[151])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_countLiveRanges"/>
+    public HRESULT get_countLiveRanges(uint* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, uint*, HRESULT>)_lpVtbl[152])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_liveRangeLength"/>
+    public HRESULT get_liveRangeLength(ulong* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, ulong*, HRESULT>)_lpVtbl[153])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_offsetInUdt"/>
+    public HRESULT get_offsetInUdt(uint* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, uint*, HRESULT>)_lpVtbl[154])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_paramBasePointerRegisterId"/>
+    public HRESULT get_paramBasePointerRegisterId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, uint*, HRESULT>)_lpVtbl[155])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_localBasePointerRegisterId"/>
+    public HRESULT get_localBasePointerRegisterId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, uint*, HRESULT>)_lpVtbl[156])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isLocationControlFlowDependent"/>
+    public HRESULT get_isLocationControlFlowDependent(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BOOL*, HRESULT>)_lpVtbl[157])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_stride"/>
+    public HRESULT get_stride(uint* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, uint*, HRESULT>)_lpVtbl[158])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_numberOfRows"/>
+    public HRESULT get_numberOfRows(uint* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, uint*, HRESULT>)_lpVtbl[159])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_numberOfColumns"/>
+    public HRESULT get_numberOfColumns(uint* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, uint*, HRESULT>)_lpVtbl[160])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isMatrixRowMajor"/>
+    public HRESULT get_isMatrixRowMajor(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BOOL*, HRESULT>)_lpVtbl[161])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_numericProperties"/>
+    public HRESULT get_numericProperties(uint cnt, uint* pcnt, uint* pProperties)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, uint, uint*, uint*, HRESULT>)_lpVtbl[162])(pThis, cnt, pcnt, pProperties);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_modifierValues"/>
+    public HRESULT get_modifierValues(uint cnt, uint* pcnt, ushort* pModifiers)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, uint, uint*, ushort*, HRESULT>)_lpVtbl[163])(pThis, cnt, pcnt, pModifiers);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isReturnValue"/>
+    public HRESULT get_isReturnValue(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BOOL*, HRESULT>)_lpVtbl[164])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isOptimizedAway"/>
+    public HRESULT get_isOptimizedAway(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BOOL*, HRESULT>)_lpVtbl[165])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_builtInKind"/>
+    public HRESULT get_builtInKind(uint* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, uint*, HRESULT>)_lpVtbl[166])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_registerType"/>
+    public HRESULT get_registerType(uint* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, uint*, HRESULT>)_lpVtbl[167])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_baseDataSlot"/>
+    public HRESULT get_baseDataSlot(uint* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, uint*, HRESULT>)_lpVtbl[168])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_baseDataOffset"/>
+    public HRESULT get_baseDataOffset(uint* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, uint*, HRESULT>)_lpVtbl[169])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_textureSlot"/>
+    public HRESULT get_textureSlot(uint* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, uint*, HRESULT>)_lpVtbl[170])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_samplerSlot"/>
+    public HRESULT get_samplerSlot(uint* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, uint*, HRESULT>)_lpVtbl[171])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_uavSlot"/>
+    public HRESULT get_uavSlot(uint* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, uint*, HRESULT>)_lpVtbl[172])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_sizeInUdt"/>
+    public HRESULT get_sizeInUdt(uint* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, uint*, HRESULT>)_lpVtbl[173])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_memorySpaceKind"/>
+    public HRESULT get_memorySpaceKind(uint* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, uint*, HRESULT>)_lpVtbl[174])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_unmodifiedTypeId"/>
+    public HRESULT get_unmodifiedTypeId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, uint*, HRESULT>)_lpVtbl[175])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_subTypeId"/>
+    public HRESULT get_subTypeId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, uint*, HRESULT>)_lpVtbl[176])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_subType"/>
+    public HRESULT get_subType(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, IDiaSymbol**, HRESULT>)_lpVtbl[177])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_numberOfModifiers"/>
+    public HRESULT get_numberOfModifiers(uint* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, uint*, HRESULT>)_lpVtbl[178])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_numberOfRegisterIndices"/>
+    public HRESULT get_numberOfRegisterIndices(uint* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, uint*, HRESULT>)_lpVtbl[179])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isHLSLData"/>
+    public HRESULT get_isHLSLData(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BOOL*, HRESULT>)_lpVtbl[180])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isPointerToDataMember"/>
+    public HRESULT get_isPointerToDataMember(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BOOL*, HRESULT>)_lpVtbl[181])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isPointerToMemberFunction"/>
+    public HRESULT get_isPointerToMemberFunction(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BOOL*, HRESULT>)_lpVtbl[182])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isSingleInheritance"/>
+    public HRESULT get_isSingleInheritance(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BOOL*, HRESULT>)_lpVtbl[183])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isMultipleInheritance"/>
+    public HRESULT get_isMultipleInheritance(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BOOL*, HRESULT>)_lpVtbl[184])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isVirtualInheritance"/>
+    public HRESULT get_isVirtualInheritance(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BOOL*, HRESULT>)_lpVtbl[185])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_restrictedType"/>
+    public HRESULT get_restrictedType(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BOOL*, HRESULT>)_lpVtbl[186])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isPointerBasedOnSymbolValue"/>
+    public HRESULT get_isPointerBasedOnSymbolValue(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BOOL*, HRESULT>)_lpVtbl[187])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_baseSymbol"/>
+    public HRESULT get_baseSymbol(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, IDiaSymbol**, HRESULT>)_lpVtbl[188])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_baseSymbolId"/>
+    public HRESULT get_baseSymbolId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, uint*, HRESULT>)_lpVtbl[189])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_objectFileName"/>
+    public HRESULT get_objectFileName(BSTR* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BSTR*, HRESULT>)_lpVtbl[190])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isAcceleratorGroupSharedLocal"/>
+    public HRESULT get_isAcceleratorGroupSharedLocal(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BOOL*, HRESULT>)_lpVtbl[191])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isAcceleratorPointerTagLiveRange"/>
+    public HRESULT get_isAcceleratorPointerTagLiveRange(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BOOL*, HRESULT>)_lpVtbl[192])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isAcceleratorStubFunction"/>
+    public HRESULT get_isAcceleratorStubFunction(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BOOL*, HRESULT>)_lpVtbl[193])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_numberOfAcceleratorPointerTags"/>
+    public HRESULT get_numberOfAcceleratorPointerTags(uint* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, uint*, HRESULT>)_lpVtbl[194])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isSdl"/>
+    public HRESULT get_isSdl(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BOOL*, HRESULT>)_lpVtbl[195])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isWinRTPointer"/>
+    public HRESULT get_isWinRTPointer(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BOOL*, HRESULT>)_lpVtbl[196])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isRefUdt"/>
+    public HRESULT get_isRefUdt(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BOOL*, HRESULT>)_lpVtbl[197])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isValueUdt"/>
+    public HRESULT get_isValueUdt(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BOOL*, HRESULT>)_lpVtbl[198])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isInterfaceUdt"/>
+    public HRESULT get_isInterfaceUdt(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BOOL*, HRESULT>)_lpVtbl[199])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findInlineFramesByAddr"/>
+    public HRESULT findInlineFramesByAddr(uint isect, uint offset, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, uint, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[200])(pThis, isect, offset, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findInlineFramesByRVA"/>
+    public HRESULT findInlineFramesByRVA(uint rva, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[201])(pThis, rva, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findInlineFramesByVA"/>
+    public HRESULT findInlineFramesByVA(ulong va, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, ulong, IDiaEnumSymbols**, HRESULT>)_lpVtbl[202])(pThis, va, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findInlineeLines"/>
+    public HRESULT findInlineeLines(IDiaEnumLineNumbers** ppResult)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, IDiaEnumLineNumbers**, HRESULT>)_lpVtbl[203])(pThis, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findInlineeLinesByAddr"/>
+    public HRESULT findInlineeLinesByAddr(uint isect, uint offset, uint length, IDiaEnumLineNumbers** ppResult)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, uint, uint, uint, IDiaEnumLineNumbers**, HRESULT>)_lpVtbl[204])(pThis, isect, offset, length, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findInlineeLinesByRVA"/>
+    public HRESULT findInlineeLinesByRVA(uint rva, uint length, IDiaEnumLineNumbers** ppResult)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, uint, uint, IDiaEnumLineNumbers**, HRESULT>)_lpVtbl[205])(pThis, rva, length, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findInlineeLinesByVA"/>
+    public HRESULT findInlineeLinesByVA(ulong va, uint length, IDiaEnumLineNumbers** ppResult)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, ulong, uint, IDiaEnumLineNumbers**, HRESULT>)_lpVtbl[206])(pThis, va, length, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findSymbolsForAcceleratorPointerTag"/>
+    public HRESULT findSymbolsForAcceleratorPointerTag(uint tagValue, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[207])(pThis, tagValue, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findSymbolsByRVAForAcceleratorPointerTag"/>
+    public HRESULT findSymbolsByRVAForAcceleratorPointerTag(uint tagValue, uint rva, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, uint, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[208])(pThis, tagValue, rva, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_acceleratorPointerTags"/>
+    public HRESULT get_acceleratorPointerTags(uint cnt, uint* pcnt, uint* pPointerTags)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, uint, uint*, uint*, HRESULT>)_lpVtbl[209])(pThis, cnt, pcnt, pPointerTags);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.getSrcLineOnTypeDefn"/>
+    public HRESULT getSrcLineOnTypeDefn(IDiaLineNumber** ppResult)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, IDiaLineNumber**, HRESULT>)_lpVtbl[210])(pThis, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isPGO"/>
+    public HRESULT get_isPGO(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BOOL*, HRESULT>)_lpVtbl[211])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasValidPGOCounts"/>
+    public HRESULT get_hasValidPGOCounts(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BOOL*, HRESULT>)_lpVtbl[212])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isOptimizedForSpeed"/>
+    public HRESULT get_isOptimizedForSpeed(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BOOL*, HRESULT>)_lpVtbl[213])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_PGOEntryCount"/>
+    public HRESULT get_PGOEntryCount(uint* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, uint*, HRESULT>)_lpVtbl[214])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_PGOEdgeCount"/>
+    public HRESULT get_PGOEdgeCount(uint* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, uint*, HRESULT>)_lpVtbl[215])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_PGODynamicInstructionCount"/>
+    public HRESULT get_PGODynamicInstructionCount(ulong* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, ulong*, HRESULT>)_lpVtbl[216])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_staticSize"/>
+    public HRESULT get_staticSize(uint* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, uint*, HRESULT>)_lpVtbl[217])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_finalLiveStaticSize"/>
+    public HRESULT get_finalLiveStaticSize(uint* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, uint*, HRESULT>)_lpVtbl[218])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_phaseName"/>
+    public HRESULT get_phaseName(BSTR* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BSTR*, HRESULT>)_lpVtbl[219])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasControlFlowCheck"/>
+    public HRESULT get_hasControlFlowCheck(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BOOL*, HRESULT>)_lpVtbl[220])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_constantExport"/>
+    public HRESULT get_constantExport(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BOOL*, HRESULT>)_lpVtbl[221])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_dataExport"/>
+    public HRESULT get_dataExport(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BOOL*, HRESULT>)_lpVtbl[222])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_privateExport"/>
+    public HRESULT get_privateExport(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BOOL*, HRESULT>)_lpVtbl[223])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_noNameExport"/>
+    public HRESULT get_noNameExport(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BOOL*, HRESULT>)_lpVtbl[224])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_exportHasExplicitlyAssignedOrdinal"/>
+    public HRESULT get_exportHasExplicitlyAssignedOrdinal(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BOOL*, HRESULT>)_lpVtbl[225])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_exportIsForwarder"/>
+    public HRESULT get_exportIsForwarder(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BOOL*, HRESULT>)_lpVtbl[226])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_ordinal"/>
+    public HRESULT get_ordinal(uint* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, uint*, HRESULT>)_lpVtbl[227])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_frameSize"/>
+    public HRESULT get_frameSize(uint* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, uint*, HRESULT>)_lpVtbl[228])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_exceptionHandlerAddressSection"/>
+    public HRESULT get_exceptionHandlerAddressSection(uint* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, uint*, HRESULT>)_lpVtbl[229])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_exceptionHandlerAddressOffset"/>
+    public HRESULT get_exceptionHandlerAddressOffset(uint* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, uint*, HRESULT>)_lpVtbl[230])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_exceptionHandlerRelativeVirtualAddress"/>
+    public HRESULT get_exceptionHandlerRelativeVirtualAddress(uint* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, uint*, HRESULT>)_lpVtbl[231])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_exceptionHandlerVirtualAddress"/>
+    public HRESULT get_exceptionHandlerVirtualAddress(ulong* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, ulong*, HRESULT>)_lpVtbl[232])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findInputAssemblyFile"/>
+    public HRESULT findInputAssemblyFile(IDiaInputAssemblyFile** ppResult)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, IDiaInputAssemblyFile**, HRESULT>)_lpVtbl[233])(pThis, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_characteristics"/>
+    public HRESULT get_characteristics(uint* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, uint*, HRESULT>)_lpVtbl[234])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_coffGroup"/>
+    public HRESULT get_coffGroup(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, IDiaSymbol**, HRESULT>)_lpVtbl[235])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_bindID"/>
+    public HRESULT get_bindID(uint* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, uint*, HRESULT>)_lpVtbl[236])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_bindSpace"/>
+    public HRESULT get_bindSpace(uint* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, uint*, HRESULT>)_lpVtbl[237])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_bindSlot"/>
+    public HRESULT get_bindSlot(uint* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, uint*, HRESULT>)_lpVtbl[238])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol2.Interface.get_isObjCClass"/>
+    public HRESULT get_isObjCClass(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BOOL*, HRESULT>)_lpVtbl[239])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol2.Interface.get_isObjCCategory"/>
+    public HRESULT get_isObjCCategory(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BOOL*, HRESULT>)_lpVtbl[240])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol2.Interface.get_isObjCProtocol"/>
+    public HRESULT get_isObjCProtocol(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BOOL*, HRESULT>)_lpVtbl[241])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol3.Interface.get_inlinee"/>
+    public HRESULT get_inlinee(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, IDiaSymbol**, HRESULT>)_lpVtbl[242])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol3.Interface.get_inlineeId"/>
+    public HRESULT get_inlineeId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, uint*, HRESULT>)_lpVtbl[243])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_noexcept"/>
+    public HRESULT get_noexcept(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol4* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol4*, BOOL*, HRESULT>)_lpVtbl[244])(pThis, pRetVal);
+    }
+
+    /// <summary>
+    ///  Extends IDiaSymbol3 with the noexcept property.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/visualstudio/debugger/debug-interface-access/idiasymbol4">
+    ///    Official documentation.
+    ///   </see>
+    ///  </para>
+    /// </remarks>
+    [ComImport]
+    [Guid("BF6C88A7-E9D6-4346-99A1-D053DE5A7808")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    public unsafe interface Interface : IDiaSymbol3.Interface
+    {
+        /// <summary>
+        ///  Noexcept.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_noexcept(BOOL* pRetVal);
+    }
+}

--- a/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaSymbol5.cs
+++ b/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaSymbol5.cs
@@ -1,0 +1,1790 @@
+﻿// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Runtime.InteropServices;
+using Windows.Win32.System.Variant;
+
+// For some reason the XML comment refs for IUnknown can't be resolved on .NET Framework without
+// explicitly using the fully qualified name, which falls afoul of the simplify warning.
+using ComIUnknown = Windows.Win32.System.Com.IUnknown;
+
+namespace Microsoft.VisualStudio.Debugging.DebugInterfaceAccess;
+
+/// <inheritdoc cref="Interface"/>
+public unsafe struct IDiaSymbol5 : IComIID
+{
+    /// <inheritdoc cref="IComIID.Guid"/>
+#pragma warning disable IDE1006 // Naming Styles
+    public static readonly Guid IID_Guid = new(0xABE2DE00, 0xDC2D, 0x4793, 0xAF, 0x9A, 0xEF, 0x1D, 0x90, 0x83, 0x26, 0x44);
+#pragma warning restore IDE1006
+
+#if NETFRAMEWORK
+    readonly ref readonly Guid IComIID.Guid => ref IID_Guid;
+#else
+    static ref readonly Guid IComIID.Guid
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get
+        {
+            ReadOnlySpan<byte> data =
+            [
+                0x00, 0xDE, 0xE2, 0xAB,
+                0x2D, 0xDC,
+                0x93, 0x47,
+                0xAF, 0x9A, 0xEF, 0x1D, 0x90, 0x83, 0x26, 0x44
+            ];
+
+            return ref Unsafe.As<byte, Guid>(ref MemoryMarshal.GetReference(data));
+        }
+    }
+#endif
+
+    private readonly void** _lpVtbl;
+
+    /// <inheritdoc cref="ComIUnknown.QueryInterface(Guid*, void**)"/>
+    public HRESULT QueryInterface(Guid* riid, void** ppvObject)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, Guid*, void**, HRESULT>)_lpVtbl[0])(pThis, riid, ppvObject);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.AddRef"/>
+    public uint AddRef()
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, uint>)_lpVtbl[1])(pThis);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.Release"/>
+    public uint Release()
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, uint>)_lpVtbl[2])(pThis);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_symIndexId"/>
+    public HRESULT get_symIndexId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, uint*, HRESULT>)_lpVtbl[3])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_symTag"/>
+    public HRESULT get_symTag(uint* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, uint*, HRESULT>)_lpVtbl[4])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_name"/>
+    public HRESULT get_name(BSTR* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BSTR*, HRESULT>)_lpVtbl[5])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_lexicalParent"/>
+    public HRESULT get_lexicalParent(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, IDiaSymbol**, HRESULT>)_lpVtbl[6])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_classParent"/>
+    public HRESULT get_classParent(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, IDiaSymbol**, HRESULT>)_lpVtbl[7])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_type"/>
+    public HRESULT get_type(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, IDiaSymbol**, HRESULT>)_lpVtbl[8])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_dataKind"/>
+    public HRESULT get_dataKind(uint* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, uint*, HRESULT>)_lpVtbl[9])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_locationType"/>
+    public HRESULT get_locationType(uint* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, uint*, HRESULT>)_lpVtbl[10])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_addressSection"/>
+    public HRESULT get_addressSection(uint* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, uint*, HRESULT>)_lpVtbl[11])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_addressOffset"/>
+    public HRESULT get_addressOffset(uint* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, uint*, HRESULT>)_lpVtbl[12])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_relativeVirtualAddress"/>
+    public HRESULT get_relativeVirtualAddress(uint* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, uint*, HRESULT>)_lpVtbl[13])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_virtualAddress"/>
+    public HRESULT get_virtualAddress(ulong* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, ulong*, HRESULT>)_lpVtbl[14])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_registerId"/>
+    public HRESULT get_registerId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, uint*, HRESULT>)_lpVtbl[15])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_offset"/>
+    public HRESULT get_offset(int* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, int*, HRESULT>)_lpVtbl[16])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_length"/>
+    public HRESULT get_length(ulong* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, ulong*, HRESULT>)_lpVtbl[17])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_slot"/>
+    public HRESULT get_slot(uint* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, uint*, HRESULT>)_lpVtbl[18])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_volatileType"/>
+    public HRESULT get_volatileType(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BOOL*, HRESULT>)_lpVtbl[19])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_constType"/>
+    public HRESULT get_constType(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BOOL*, HRESULT>)_lpVtbl[20])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_unalignedType"/>
+    public HRESULT get_unalignedType(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BOOL*, HRESULT>)_lpVtbl[21])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_access"/>
+    public HRESULT get_access(uint* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, uint*, HRESULT>)_lpVtbl[22])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_libraryName"/>
+    public HRESULT get_libraryName(BSTR* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BSTR*, HRESULT>)_lpVtbl[23])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_platform"/>
+    public HRESULT get_platform(uint* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, uint*, HRESULT>)_lpVtbl[24])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_language"/>
+    public HRESULT get_language(uint* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, uint*, HRESULT>)_lpVtbl[25])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_editAndContinueEnabled"/>
+    public HRESULT get_editAndContinueEnabled(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BOOL*, HRESULT>)_lpVtbl[26])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_frontEndMajor"/>
+    public HRESULT get_frontEndMajor(uint* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, uint*, HRESULT>)_lpVtbl[27])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_frontEndMinor"/>
+    public HRESULT get_frontEndMinor(uint* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, uint*, HRESULT>)_lpVtbl[28])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_frontEndBuild"/>
+    public HRESULT get_frontEndBuild(uint* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, uint*, HRESULT>)_lpVtbl[29])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_backEndMajor"/>
+    public HRESULT get_backEndMajor(uint* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, uint*, HRESULT>)_lpVtbl[30])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_backEndMinor"/>
+    public HRESULT get_backEndMinor(uint* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, uint*, HRESULT>)_lpVtbl[31])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_backEndBuild"/>
+    public HRESULT get_backEndBuild(uint* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, uint*, HRESULT>)_lpVtbl[32])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_sourceFileName"/>
+    public HRESULT get_sourceFileName(BSTR* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BSTR*, HRESULT>)_lpVtbl[33])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_unused"/>
+    public HRESULT get_unused(BSTR* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BSTR*, HRESULT>)_lpVtbl[34])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_thunkOrdinal"/>
+    public HRESULT get_thunkOrdinal(uint* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, uint*, HRESULT>)_lpVtbl[35])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_thisAdjust"/>
+    public HRESULT get_thisAdjust(int* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, int*, HRESULT>)_lpVtbl[36])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_virtualBaseOffset"/>
+    public HRESULT get_virtualBaseOffset(uint* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, uint*, HRESULT>)_lpVtbl[37])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_virtual"/>
+    public HRESULT get_virtual(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BOOL*, HRESULT>)_lpVtbl[38])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_intro"/>
+    public HRESULT get_intro(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BOOL*, HRESULT>)_lpVtbl[39])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_pure"/>
+    public HRESULT get_pure(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BOOL*, HRESULT>)_lpVtbl[40])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_callingConvention"/>
+    public HRESULT get_callingConvention(uint* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, uint*, HRESULT>)_lpVtbl[41])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_value"/>
+    public HRESULT get_value(VARIANT* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, VARIANT*, HRESULT>)_lpVtbl[42])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_baseType"/>
+    public HRESULT get_baseType(uint* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, uint*, HRESULT>)_lpVtbl[43])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_token"/>
+    public HRESULT get_token(uint* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, uint*, HRESULT>)_lpVtbl[44])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_timeStamp"/>
+    public HRESULT get_timeStamp(uint* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, uint*, HRESULT>)_lpVtbl[45])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_guid"/>
+    public HRESULT get_guid(Guid* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, Guid*, HRESULT>)_lpVtbl[46])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_symbolsFileName"/>
+    public HRESULT get_symbolsFileName(BSTR* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BSTR*, HRESULT>)_lpVtbl[47])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_reference"/>
+    public HRESULT get_reference(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BOOL*, HRESULT>)_lpVtbl[48])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_count"/>
+    public HRESULT get_count(uint* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, uint*, HRESULT>)_lpVtbl[49])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_bitPosition"/>
+    public HRESULT get_bitPosition(uint* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, uint*, HRESULT>)_lpVtbl[50])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_arrayIndexType"/>
+    public HRESULT get_arrayIndexType(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, IDiaSymbol**, HRESULT>)_lpVtbl[51])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_packed"/>
+    public HRESULT get_packed(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BOOL*, HRESULT>)_lpVtbl[52])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_constructor"/>
+    public HRESULT get_constructor(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BOOL*, HRESULT>)_lpVtbl[53])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_overloadedOperator"/>
+    public HRESULT get_overloadedOperator(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BOOL*, HRESULT>)_lpVtbl[54])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_nested"/>
+    public HRESULT get_nested(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BOOL*, HRESULT>)_lpVtbl[55])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasNestedTypes"/>
+    public HRESULT get_hasNestedTypes(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BOOL*, HRESULT>)_lpVtbl[56])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasAssignmentOperator"/>
+    public HRESULT get_hasAssignmentOperator(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BOOL*, HRESULT>)_lpVtbl[57])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasCastOperator"/>
+    public HRESULT get_hasCastOperator(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BOOL*, HRESULT>)_lpVtbl[58])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_scoped"/>
+    public HRESULT get_scoped(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BOOL*, HRESULT>)_lpVtbl[59])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_virtualBaseClass"/>
+    public HRESULT get_virtualBaseClass(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BOOL*, HRESULT>)_lpVtbl[60])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_indirectVirtualBaseClass"/>
+    public HRESULT get_indirectVirtualBaseClass(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BOOL*, HRESULT>)_lpVtbl[61])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_virtualBasePointerOffset"/>
+    public HRESULT get_virtualBasePointerOffset(int* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, int*, HRESULT>)_lpVtbl[62])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_virtualTableShape"/>
+    public HRESULT get_virtualTableShape(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, IDiaSymbol**, HRESULT>)_lpVtbl[63])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_lexicalParentId"/>
+    public HRESULT get_lexicalParentId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, uint*, HRESULT>)_lpVtbl[64])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_classParentId"/>
+    public HRESULT get_classParentId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, uint*, HRESULT>)_lpVtbl[65])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_typeId"/>
+    public HRESULT get_typeId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, uint*, HRESULT>)_lpVtbl[66])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_arrayIndexTypeId"/>
+    public HRESULT get_arrayIndexTypeId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, uint*, HRESULT>)_lpVtbl[67])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_virtualTableShapeId"/>
+    public HRESULT get_virtualTableShapeId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, uint*, HRESULT>)_lpVtbl[68])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_code"/>
+    public HRESULT get_code(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BOOL*, HRESULT>)_lpVtbl[69])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_function"/>
+    public HRESULT get_function(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BOOL*, HRESULT>)_lpVtbl[70])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_managed"/>
+    public HRESULT get_managed(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BOOL*, HRESULT>)_lpVtbl[71])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_msil"/>
+    public HRESULT get_msil(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BOOL*, HRESULT>)_lpVtbl[72])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_virtualBaseDispIndex"/>
+    public HRESULT get_virtualBaseDispIndex(uint* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, uint*, HRESULT>)_lpVtbl[73])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_undecoratedName"/>
+    public HRESULT get_undecoratedName(BSTR* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BSTR*, HRESULT>)_lpVtbl[74])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_age"/>
+    public HRESULT get_age(uint* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, uint*, HRESULT>)_lpVtbl[75])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_signature"/>
+    public HRESULT get_signature(uint* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, uint*, HRESULT>)_lpVtbl[76])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_compilerGenerated"/>
+    public HRESULT get_compilerGenerated(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BOOL*, HRESULT>)_lpVtbl[77])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_addressTaken"/>
+    public HRESULT get_addressTaken(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BOOL*, HRESULT>)_lpVtbl[78])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_rank"/>
+    public HRESULT get_rank(uint* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, uint*, HRESULT>)_lpVtbl[79])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_lowerBound"/>
+    public HRESULT get_lowerBound(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, IDiaSymbol**, HRESULT>)_lpVtbl[80])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_upperBound"/>
+    public HRESULT get_upperBound(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, IDiaSymbol**, HRESULT>)_lpVtbl[81])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_lowerBoundId"/>
+    public HRESULT get_lowerBoundId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, uint*, HRESULT>)_lpVtbl[82])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_upperBoundId"/>
+    public HRESULT get_upperBoundId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, uint*, HRESULT>)_lpVtbl[83])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_dataBytes"/>
+    public HRESULT get_dataBytes(uint cbData, uint* pcbData, byte* pbData)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, uint, uint*, byte*, HRESULT>)_lpVtbl[84])(pThis, cbData, pcbData, pbData);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findChildren"/>
+    public HRESULT findChildren(SymTagEnum symtag, PCWSTR name, uint compareFlags, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, SymTagEnum, PCWSTR, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[85])(pThis, symtag, name, compareFlags, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findChildrenEx"/>
+    public HRESULT findChildrenEx(SymTagEnum symtag, PCWSTR name, uint compareFlags, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, SymTagEnum, PCWSTR, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[86])(pThis, symtag, name, compareFlags, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findChildrenExByAddr"/>
+    public HRESULT findChildrenExByAddr(SymTagEnum symtag, PCWSTR name, uint compareFlags, uint isect, uint offset, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, SymTagEnum, PCWSTR, uint, uint, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[87])(pThis, symtag, name, compareFlags, isect, offset, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findChildrenExByVA"/>
+    public HRESULT findChildrenExByVA(SymTagEnum symtag, PCWSTR name, uint compareFlags, ulong va, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, SymTagEnum, PCWSTR, uint, ulong, IDiaEnumSymbols**, HRESULT>)_lpVtbl[88])(pThis, symtag, name, compareFlags, va, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findChildrenExByRVA"/>
+    public HRESULT findChildrenExByRVA(SymTagEnum symtag, PCWSTR name, uint compareFlags, uint rva, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, SymTagEnum, PCWSTR, uint, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[89])(pThis, symtag, name, compareFlags, rva, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_targetSection"/>
+    public HRESULT get_targetSection(uint* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, uint*, HRESULT>)_lpVtbl[90])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_targetOffset"/>
+    public HRESULT get_targetOffset(uint* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, uint*, HRESULT>)_lpVtbl[91])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_targetRelativeVirtualAddress"/>
+    public HRESULT get_targetRelativeVirtualAddress(uint* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, uint*, HRESULT>)_lpVtbl[92])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_targetVirtualAddress"/>
+    public HRESULT get_targetVirtualAddress(ulong* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, ulong*, HRESULT>)_lpVtbl[93])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_machineType"/>
+    public HRESULT get_machineType(uint* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, uint*, HRESULT>)_lpVtbl[94])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_oemId"/>
+    public HRESULT get_oemId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, uint*, HRESULT>)_lpVtbl[95])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_oemSymbolId"/>
+    public HRESULT get_oemSymbolId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, uint*, HRESULT>)_lpVtbl[96])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_types"/>
+    public HRESULT get_types(uint cTypes, uint* pcTypes, IDiaSymbol** pTypes)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, uint, uint*, IDiaSymbol**, HRESULT>)_lpVtbl[97])(pThis, cTypes, pcTypes, pTypes);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_typeIds"/>
+    public HRESULT get_typeIds(uint cTypeIds, uint* pcTypeIds, uint* pdwTypeIds)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, uint, uint*, uint*, HRESULT>)_lpVtbl[98])(pThis, cTypeIds, pcTypeIds, pdwTypeIds);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_objectPointerType"/>
+    public HRESULT get_objectPointerType(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, IDiaSymbol**, HRESULT>)_lpVtbl[99])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_udtKind"/>
+    public HRESULT get_udtKind(uint* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, uint*, HRESULT>)_lpVtbl[100])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_undecoratedNameEx"/>
+    public HRESULT get_undecoratedNameEx(uint undecorateOptions, BSTR* name)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, uint, BSTR*, HRESULT>)_lpVtbl[101])(pThis, undecorateOptions, name);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_noReturn"/>
+    public HRESULT get_noReturn(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BOOL*, HRESULT>)_lpVtbl[102])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_customCallingConvention"/>
+    public HRESULT get_customCallingConvention(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BOOL*, HRESULT>)_lpVtbl[103])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_noInline"/>
+    public HRESULT get_noInline(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BOOL*, HRESULT>)_lpVtbl[104])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_optimizedCodeDebugInfo"/>
+    public HRESULT get_optimizedCodeDebugInfo(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BOOL*, HRESULT>)_lpVtbl[105])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_notReached"/>
+    public HRESULT get_notReached(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BOOL*, HRESULT>)_lpVtbl[106])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_interruptReturn"/>
+    public HRESULT get_interruptReturn(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BOOL*, HRESULT>)_lpVtbl[107])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_farReturn"/>
+    public HRESULT get_farReturn(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BOOL*, HRESULT>)_lpVtbl[108])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isStatic"/>
+    public HRESULT get_isStatic(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BOOL*, HRESULT>)_lpVtbl[109])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasDebugInfo"/>
+    public HRESULT get_hasDebugInfo(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BOOL*, HRESULT>)_lpVtbl[110])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isLTCG"/>
+    public HRESULT get_isLTCG(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BOOL*, HRESULT>)_lpVtbl[111])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isDataAligned"/>
+    public HRESULT get_isDataAligned(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BOOL*, HRESULT>)_lpVtbl[112])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasSecurityChecks"/>
+    public HRESULT get_hasSecurityChecks(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BOOL*, HRESULT>)_lpVtbl[113])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_compilerName"/>
+    public HRESULT get_compilerName(BSTR* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BSTR*, HRESULT>)_lpVtbl[114])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasAlloca"/>
+    public HRESULT get_hasAlloca(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BOOL*, HRESULT>)_lpVtbl[115])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasSetJump"/>
+    public HRESULT get_hasSetJump(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BOOL*, HRESULT>)_lpVtbl[116])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasLongJump"/>
+    public HRESULT get_hasLongJump(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BOOL*, HRESULT>)_lpVtbl[117])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasInlAsm"/>
+    public HRESULT get_hasInlAsm(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BOOL*, HRESULT>)_lpVtbl[118])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasEH"/>
+    public HRESULT get_hasEH(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BOOL*, HRESULT>)_lpVtbl[119])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasSEH"/>
+    public HRESULT get_hasSEH(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BOOL*, HRESULT>)_lpVtbl[120])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasEHa"/>
+    public HRESULT get_hasEHa(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BOOL*, HRESULT>)_lpVtbl[121])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isNaked"/>
+    public HRESULT get_isNaked(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BOOL*, HRESULT>)_lpVtbl[122])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isAggregated"/>
+    public HRESULT get_isAggregated(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BOOL*, HRESULT>)_lpVtbl[123])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isSplitted"/>
+    public HRESULT get_isSplitted(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BOOL*, HRESULT>)_lpVtbl[124])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_container"/>
+    public HRESULT get_container(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, IDiaSymbol**, HRESULT>)_lpVtbl[125])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_inlSpec"/>
+    public HRESULT get_inlSpec(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BOOL*, HRESULT>)_lpVtbl[126])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_noStackOrdering"/>
+    public HRESULT get_noStackOrdering(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BOOL*, HRESULT>)_lpVtbl[127])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_virtualBaseTableType"/>
+    public HRESULT get_virtualBaseTableType(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, IDiaSymbol**, HRESULT>)_lpVtbl[128])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasManagedCode"/>
+    public HRESULT get_hasManagedCode(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BOOL*, HRESULT>)_lpVtbl[129])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isHotpatchable"/>
+    public HRESULT get_isHotpatchable(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BOOL*, HRESULT>)_lpVtbl[130])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isCVTCIL"/>
+    public HRESULT get_isCVTCIL(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BOOL*, HRESULT>)_lpVtbl[131])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isMSILNetmodule"/>
+    public HRESULT get_isMSILNetmodule(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BOOL*, HRESULT>)_lpVtbl[132])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isCTypes"/>
+    public HRESULT get_isCTypes(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BOOL*, HRESULT>)_lpVtbl[133])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isStripped"/>
+    public HRESULT get_isStripped(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BOOL*, HRESULT>)_lpVtbl[134])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_frontEndQFE"/>
+    public HRESULT get_frontEndQFE(uint* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, uint*, HRESULT>)_lpVtbl[135])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_backEndQFE"/>
+    public HRESULT get_backEndQFE(uint* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, uint*, HRESULT>)_lpVtbl[136])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_wasInlined"/>
+    public HRESULT get_wasInlined(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BOOL*, HRESULT>)_lpVtbl[137])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_strictGSCheck"/>
+    public HRESULT get_strictGSCheck(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BOOL*, HRESULT>)_lpVtbl[138])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isCxxReturnUdt"/>
+    public HRESULT get_isCxxReturnUdt(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BOOL*, HRESULT>)_lpVtbl[139])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isConstructorVirtualBase"/>
+    public HRESULT get_isConstructorVirtualBase(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BOOL*, HRESULT>)_lpVtbl[140])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_RValueReference"/>
+    public HRESULT get_RValueReference(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BOOL*, HRESULT>)_lpVtbl[141])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_unmodifiedType"/>
+    public HRESULT get_unmodifiedType(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, IDiaSymbol**, HRESULT>)_lpVtbl[142])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_framePointerPresent"/>
+    public HRESULT get_framePointerPresent(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BOOL*, HRESULT>)_lpVtbl[143])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isSafeBuffers"/>
+    public HRESULT get_isSafeBuffers(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BOOL*, HRESULT>)_lpVtbl[144])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_intrinsic"/>
+    public HRESULT get_intrinsic(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BOOL*, HRESULT>)_lpVtbl[145])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_sealed"/>
+    public HRESULT get_sealed(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BOOL*, HRESULT>)_lpVtbl[146])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hfaFloat"/>
+    public HRESULT get_hfaFloat(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BOOL*, HRESULT>)_lpVtbl[147])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hfaDouble"/>
+    public HRESULT get_hfaDouble(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BOOL*, HRESULT>)_lpVtbl[148])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_liveRangeStartAddressSection"/>
+    public HRESULT get_liveRangeStartAddressSection(uint* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, uint*, HRESULT>)_lpVtbl[149])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_liveRangeStartAddressOffset"/>
+    public HRESULT get_liveRangeStartAddressOffset(uint* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, uint*, HRESULT>)_lpVtbl[150])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_liveRangeStartRelativeVirtualAddress"/>
+    public HRESULT get_liveRangeStartRelativeVirtualAddress(uint* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, uint*, HRESULT>)_lpVtbl[151])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_countLiveRanges"/>
+    public HRESULT get_countLiveRanges(uint* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, uint*, HRESULT>)_lpVtbl[152])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_liveRangeLength"/>
+    public HRESULT get_liveRangeLength(ulong* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, ulong*, HRESULT>)_lpVtbl[153])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_offsetInUdt"/>
+    public HRESULT get_offsetInUdt(uint* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, uint*, HRESULT>)_lpVtbl[154])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_paramBasePointerRegisterId"/>
+    public HRESULT get_paramBasePointerRegisterId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, uint*, HRESULT>)_lpVtbl[155])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_localBasePointerRegisterId"/>
+    public HRESULT get_localBasePointerRegisterId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, uint*, HRESULT>)_lpVtbl[156])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isLocationControlFlowDependent"/>
+    public HRESULT get_isLocationControlFlowDependent(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BOOL*, HRESULT>)_lpVtbl[157])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_stride"/>
+    public HRESULT get_stride(uint* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, uint*, HRESULT>)_lpVtbl[158])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_numberOfRows"/>
+    public HRESULT get_numberOfRows(uint* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, uint*, HRESULT>)_lpVtbl[159])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_numberOfColumns"/>
+    public HRESULT get_numberOfColumns(uint* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, uint*, HRESULT>)_lpVtbl[160])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isMatrixRowMajor"/>
+    public HRESULT get_isMatrixRowMajor(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BOOL*, HRESULT>)_lpVtbl[161])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_numericProperties"/>
+    public HRESULT get_numericProperties(uint cnt, uint* pcnt, uint* pProperties)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, uint, uint*, uint*, HRESULT>)_lpVtbl[162])(pThis, cnt, pcnt, pProperties);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_modifierValues"/>
+    public HRESULT get_modifierValues(uint cnt, uint* pcnt, ushort* pModifiers)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, uint, uint*, ushort*, HRESULT>)_lpVtbl[163])(pThis, cnt, pcnt, pModifiers);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isReturnValue"/>
+    public HRESULT get_isReturnValue(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BOOL*, HRESULT>)_lpVtbl[164])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isOptimizedAway"/>
+    public HRESULT get_isOptimizedAway(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BOOL*, HRESULT>)_lpVtbl[165])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_builtInKind"/>
+    public HRESULT get_builtInKind(uint* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, uint*, HRESULT>)_lpVtbl[166])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_registerType"/>
+    public HRESULT get_registerType(uint* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, uint*, HRESULT>)_lpVtbl[167])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_baseDataSlot"/>
+    public HRESULT get_baseDataSlot(uint* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, uint*, HRESULT>)_lpVtbl[168])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_baseDataOffset"/>
+    public HRESULT get_baseDataOffset(uint* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, uint*, HRESULT>)_lpVtbl[169])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_textureSlot"/>
+    public HRESULT get_textureSlot(uint* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, uint*, HRESULT>)_lpVtbl[170])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_samplerSlot"/>
+    public HRESULT get_samplerSlot(uint* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, uint*, HRESULT>)_lpVtbl[171])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_uavSlot"/>
+    public HRESULT get_uavSlot(uint* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, uint*, HRESULT>)_lpVtbl[172])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_sizeInUdt"/>
+    public HRESULT get_sizeInUdt(uint* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, uint*, HRESULT>)_lpVtbl[173])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_memorySpaceKind"/>
+    public HRESULT get_memorySpaceKind(uint* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, uint*, HRESULT>)_lpVtbl[174])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_unmodifiedTypeId"/>
+    public HRESULT get_unmodifiedTypeId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, uint*, HRESULT>)_lpVtbl[175])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_subTypeId"/>
+    public HRESULT get_subTypeId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, uint*, HRESULT>)_lpVtbl[176])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_subType"/>
+    public HRESULT get_subType(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, IDiaSymbol**, HRESULT>)_lpVtbl[177])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_numberOfModifiers"/>
+    public HRESULT get_numberOfModifiers(uint* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, uint*, HRESULT>)_lpVtbl[178])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_numberOfRegisterIndices"/>
+    public HRESULT get_numberOfRegisterIndices(uint* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, uint*, HRESULT>)_lpVtbl[179])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isHLSLData"/>
+    public HRESULT get_isHLSLData(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BOOL*, HRESULT>)_lpVtbl[180])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isPointerToDataMember"/>
+    public HRESULT get_isPointerToDataMember(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BOOL*, HRESULT>)_lpVtbl[181])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isPointerToMemberFunction"/>
+    public HRESULT get_isPointerToMemberFunction(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BOOL*, HRESULT>)_lpVtbl[182])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isSingleInheritance"/>
+    public HRESULT get_isSingleInheritance(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BOOL*, HRESULT>)_lpVtbl[183])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isMultipleInheritance"/>
+    public HRESULT get_isMultipleInheritance(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BOOL*, HRESULT>)_lpVtbl[184])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isVirtualInheritance"/>
+    public HRESULT get_isVirtualInheritance(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BOOL*, HRESULT>)_lpVtbl[185])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_restrictedType"/>
+    public HRESULT get_restrictedType(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BOOL*, HRESULT>)_lpVtbl[186])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isPointerBasedOnSymbolValue"/>
+    public HRESULT get_isPointerBasedOnSymbolValue(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BOOL*, HRESULT>)_lpVtbl[187])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_baseSymbol"/>
+    public HRESULT get_baseSymbol(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, IDiaSymbol**, HRESULT>)_lpVtbl[188])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_baseSymbolId"/>
+    public HRESULT get_baseSymbolId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, uint*, HRESULT>)_lpVtbl[189])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_objectFileName"/>
+    public HRESULT get_objectFileName(BSTR* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BSTR*, HRESULT>)_lpVtbl[190])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isAcceleratorGroupSharedLocal"/>
+    public HRESULT get_isAcceleratorGroupSharedLocal(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BOOL*, HRESULT>)_lpVtbl[191])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isAcceleratorPointerTagLiveRange"/>
+    public HRESULT get_isAcceleratorPointerTagLiveRange(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BOOL*, HRESULT>)_lpVtbl[192])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isAcceleratorStubFunction"/>
+    public HRESULT get_isAcceleratorStubFunction(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BOOL*, HRESULT>)_lpVtbl[193])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_numberOfAcceleratorPointerTags"/>
+    public HRESULT get_numberOfAcceleratorPointerTags(uint* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, uint*, HRESULT>)_lpVtbl[194])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isSdl"/>
+    public HRESULT get_isSdl(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BOOL*, HRESULT>)_lpVtbl[195])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isWinRTPointer"/>
+    public HRESULT get_isWinRTPointer(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BOOL*, HRESULT>)_lpVtbl[196])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isRefUdt"/>
+    public HRESULT get_isRefUdt(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BOOL*, HRESULT>)_lpVtbl[197])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isValueUdt"/>
+    public HRESULT get_isValueUdt(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BOOL*, HRESULT>)_lpVtbl[198])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isInterfaceUdt"/>
+    public HRESULT get_isInterfaceUdt(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BOOL*, HRESULT>)_lpVtbl[199])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findInlineFramesByAddr"/>
+    public HRESULT findInlineFramesByAddr(uint isect, uint offset, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, uint, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[200])(pThis, isect, offset, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findInlineFramesByRVA"/>
+    public HRESULT findInlineFramesByRVA(uint rva, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[201])(pThis, rva, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findInlineFramesByVA"/>
+    public HRESULT findInlineFramesByVA(ulong va, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, ulong, IDiaEnumSymbols**, HRESULT>)_lpVtbl[202])(pThis, va, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findInlineeLines"/>
+    public HRESULT findInlineeLines(IDiaEnumLineNumbers** ppResult)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, IDiaEnumLineNumbers**, HRESULT>)_lpVtbl[203])(pThis, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findInlineeLinesByAddr"/>
+    public HRESULT findInlineeLinesByAddr(uint isect, uint offset, uint length, IDiaEnumLineNumbers** ppResult)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, uint, uint, uint, IDiaEnumLineNumbers**, HRESULT>)_lpVtbl[204])(pThis, isect, offset, length, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findInlineeLinesByRVA"/>
+    public HRESULT findInlineeLinesByRVA(uint rva, uint length, IDiaEnumLineNumbers** ppResult)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, uint, uint, IDiaEnumLineNumbers**, HRESULT>)_lpVtbl[205])(pThis, rva, length, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findInlineeLinesByVA"/>
+    public HRESULT findInlineeLinesByVA(ulong va, uint length, IDiaEnumLineNumbers** ppResult)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, ulong, uint, IDiaEnumLineNumbers**, HRESULT>)_lpVtbl[206])(pThis, va, length, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findSymbolsForAcceleratorPointerTag"/>
+    public HRESULT findSymbolsForAcceleratorPointerTag(uint tagValue, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[207])(pThis, tagValue, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findSymbolsByRVAForAcceleratorPointerTag"/>
+    public HRESULT findSymbolsByRVAForAcceleratorPointerTag(uint tagValue, uint rva, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, uint, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[208])(pThis, tagValue, rva, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_acceleratorPointerTags"/>
+    public HRESULT get_acceleratorPointerTags(uint cnt, uint* pcnt, uint* pPointerTags)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, uint, uint*, uint*, HRESULT>)_lpVtbl[209])(pThis, cnt, pcnt, pPointerTags);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.getSrcLineOnTypeDefn"/>
+    public HRESULT getSrcLineOnTypeDefn(IDiaLineNumber** ppResult)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, IDiaLineNumber**, HRESULT>)_lpVtbl[210])(pThis, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isPGO"/>
+    public HRESULT get_isPGO(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BOOL*, HRESULT>)_lpVtbl[211])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasValidPGOCounts"/>
+    public HRESULT get_hasValidPGOCounts(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BOOL*, HRESULT>)_lpVtbl[212])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isOptimizedForSpeed"/>
+    public HRESULT get_isOptimizedForSpeed(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BOOL*, HRESULT>)_lpVtbl[213])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_PGOEntryCount"/>
+    public HRESULT get_PGOEntryCount(uint* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, uint*, HRESULT>)_lpVtbl[214])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_PGOEdgeCount"/>
+    public HRESULT get_PGOEdgeCount(uint* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, uint*, HRESULT>)_lpVtbl[215])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_PGODynamicInstructionCount"/>
+    public HRESULT get_PGODynamicInstructionCount(ulong* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, ulong*, HRESULT>)_lpVtbl[216])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_staticSize"/>
+    public HRESULT get_staticSize(uint* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, uint*, HRESULT>)_lpVtbl[217])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_finalLiveStaticSize"/>
+    public HRESULT get_finalLiveStaticSize(uint* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, uint*, HRESULT>)_lpVtbl[218])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_phaseName"/>
+    public HRESULT get_phaseName(BSTR* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BSTR*, HRESULT>)_lpVtbl[219])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasControlFlowCheck"/>
+    public HRESULT get_hasControlFlowCheck(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BOOL*, HRESULT>)_lpVtbl[220])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_constantExport"/>
+    public HRESULT get_constantExport(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BOOL*, HRESULT>)_lpVtbl[221])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_dataExport"/>
+    public HRESULT get_dataExport(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BOOL*, HRESULT>)_lpVtbl[222])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_privateExport"/>
+    public HRESULT get_privateExport(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BOOL*, HRESULT>)_lpVtbl[223])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_noNameExport"/>
+    public HRESULT get_noNameExport(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BOOL*, HRESULT>)_lpVtbl[224])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_exportHasExplicitlyAssignedOrdinal"/>
+    public HRESULT get_exportHasExplicitlyAssignedOrdinal(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BOOL*, HRESULT>)_lpVtbl[225])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_exportIsForwarder"/>
+    public HRESULT get_exportIsForwarder(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BOOL*, HRESULT>)_lpVtbl[226])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_ordinal"/>
+    public HRESULT get_ordinal(uint* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, uint*, HRESULT>)_lpVtbl[227])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_frameSize"/>
+    public HRESULT get_frameSize(uint* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, uint*, HRESULT>)_lpVtbl[228])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_exceptionHandlerAddressSection"/>
+    public HRESULT get_exceptionHandlerAddressSection(uint* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, uint*, HRESULT>)_lpVtbl[229])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_exceptionHandlerAddressOffset"/>
+    public HRESULT get_exceptionHandlerAddressOffset(uint* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, uint*, HRESULT>)_lpVtbl[230])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_exceptionHandlerRelativeVirtualAddress"/>
+    public HRESULT get_exceptionHandlerRelativeVirtualAddress(uint* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, uint*, HRESULT>)_lpVtbl[231])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_exceptionHandlerVirtualAddress"/>
+    public HRESULT get_exceptionHandlerVirtualAddress(ulong* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, ulong*, HRESULT>)_lpVtbl[232])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findInputAssemblyFile"/>
+    public HRESULT findInputAssemblyFile(IDiaInputAssemblyFile** ppResult)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, IDiaInputAssemblyFile**, HRESULT>)_lpVtbl[233])(pThis, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_characteristics"/>
+    public HRESULT get_characteristics(uint* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, uint*, HRESULT>)_lpVtbl[234])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_coffGroup"/>
+    public HRESULT get_coffGroup(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, IDiaSymbol**, HRESULT>)_lpVtbl[235])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_bindID"/>
+    public HRESULT get_bindID(uint* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, uint*, HRESULT>)_lpVtbl[236])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_bindSpace"/>
+    public HRESULT get_bindSpace(uint* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, uint*, HRESULT>)_lpVtbl[237])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_bindSlot"/>
+    public HRESULT get_bindSlot(uint* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, uint*, HRESULT>)_lpVtbl[238])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol2.Interface.get_isObjCClass"/>
+    public HRESULT get_isObjCClass(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BOOL*, HRESULT>)_lpVtbl[239])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol2.Interface.get_isObjCCategory"/>
+    public HRESULT get_isObjCCategory(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BOOL*, HRESULT>)_lpVtbl[240])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol2.Interface.get_isObjCProtocol"/>
+    public HRESULT get_isObjCProtocol(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BOOL*, HRESULT>)_lpVtbl[241])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol3.Interface.get_inlinee"/>
+    public HRESULT get_inlinee(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, IDiaSymbol**, HRESULT>)_lpVtbl[242])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol3.Interface.get_inlineeId"/>
+    public HRESULT get_inlineeId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, uint*, HRESULT>)_lpVtbl[243])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol4.Interface.get_noexcept"/>
+    public HRESULT get_noexcept(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BOOL*, HRESULT>)_lpVtbl[244])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_hasAbsoluteAddress"/>
+    public HRESULT get_hasAbsoluteAddress(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol5* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol5*, BOOL*, HRESULT>)_lpVtbl[245])(pThis, pRetVal);
+    }
+
+    /// <summary>
+    ///  Extends IDiaSymbol4 with the absolute address property.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/visualstudio/debugger/debug-interface-access/idiasymbol5">
+    ///    Official documentation.
+    ///   </see>
+    ///  </para>
+    /// </remarks>
+    [ComImport]
+    [Guid("ABE2DE00-DC2D-4793-AF9A-EF1D90832644")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    public unsafe interface Interface : IDiaSymbol4.Interface
+    {
+        /// <summary>
+        ///  Absolute address.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_hasAbsoluteAddress(BOOL* pRetVal);
+    }
+}

--- a/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaSymbol6.cs
+++ b/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaSymbol6.cs
@@ -1,0 +1,1797 @@
+﻿// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Runtime.InteropServices;
+using Windows.Win32.System.Variant;
+
+// For some reason the XML comment refs for IUnknown can't be resolved on .NET Framework without
+// explicitly using the fully qualified name, which falls afoul of the simplify warning.
+using ComIUnknown = Windows.Win32.System.Com.IUnknown;
+
+namespace Microsoft.VisualStudio.Debugging.DebugInterfaceAccess;
+
+/// <inheritdoc cref="Interface"/>
+public unsafe struct IDiaSymbol6 : IComIID
+{
+    /// <inheritdoc cref="IComIID.Guid"/>
+#pragma warning disable IDE1006 // Naming Styles
+    public static readonly Guid IID_Guid = new(0x8133DAD3, 0x75FE, 0x4234, 0xAC, 0x7E, 0xF8, 0xE7, 0xA1, 0xD3, 0xCB, 0xB3);
+#pragma warning restore IDE1006
+
+#if NETFRAMEWORK
+    readonly ref readonly Guid IComIID.Guid => ref IID_Guid;
+#else
+    static ref readonly Guid IComIID.Guid
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get
+        {
+            ReadOnlySpan<byte> data =
+            [
+                0xD3, 0xDA, 0x33, 0x81,
+                0xFE, 0x75,
+                0x34, 0x42,
+                0xAC, 0x7E, 0xF8, 0xE7, 0xA1, 0xD3, 0xCB, 0xB3
+            ];
+
+            return ref Unsafe.As<byte, Guid>(ref MemoryMarshal.GetReference(data));
+        }
+    }
+#endif
+
+    private readonly void** _lpVtbl;
+
+    /// <inheritdoc cref="ComIUnknown.QueryInterface(Guid*, void**)"/>
+    public HRESULT QueryInterface(Guid* riid, void** ppvObject)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, Guid*, void**, HRESULT>)_lpVtbl[0])(pThis, riid, ppvObject);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.AddRef"/>
+    public uint AddRef()
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, uint>)_lpVtbl[1])(pThis);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.Release"/>
+    public uint Release()
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, uint>)_lpVtbl[2])(pThis);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_symIndexId"/>
+    public HRESULT get_symIndexId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, uint*, HRESULT>)_lpVtbl[3])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_symTag"/>
+    public HRESULT get_symTag(uint* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, uint*, HRESULT>)_lpVtbl[4])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_name"/>
+    public HRESULT get_name(BSTR* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BSTR*, HRESULT>)_lpVtbl[5])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_lexicalParent"/>
+    public HRESULT get_lexicalParent(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, IDiaSymbol**, HRESULT>)_lpVtbl[6])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_classParent"/>
+    public HRESULT get_classParent(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, IDiaSymbol**, HRESULT>)_lpVtbl[7])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_type"/>
+    public HRESULT get_type(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, IDiaSymbol**, HRESULT>)_lpVtbl[8])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_dataKind"/>
+    public HRESULT get_dataKind(uint* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, uint*, HRESULT>)_lpVtbl[9])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_locationType"/>
+    public HRESULT get_locationType(uint* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, uint*, HRESULT>)_lpVtbl[10])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_addressSection"/>
+    public HRESULT get_addressSection(uint* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, uint*, HRESULT>)_lpVtbl[11])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_addressOffset"/>
+    public HRESULT get_addressOffset(uint* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, uint*, HRESULT>)_lpVtbl[12])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_relativeVirtualAddress"/>
+    public HRESULT get_relativeVirtualAddress(uint* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, uint*, HRESULT>)_lpVtbl[13])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_virtualAddress"/>
+    public HRESULT get_virtualAddress(ulong* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, ulong*, HRESULT>)_lpVtbl[14])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_registerId"/>
+    public HRESULT get_registerId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, uint*, HRESULT>)_lpVtbl[15])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_offset"/>
+    public HRESULT get_offset(int* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, int*, HRESULT>)_lpVtbl[16])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_length"/>
+    public HRESULT get_length(ulong* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, ulong*, HRESULT>)_lpVtbl[17])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_slot"/>
+    public HRESULT get_slot(uint* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, uint*, HRESULT>)_lpVtbl[18])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_volatileType"/>
+    public HRESULT get_volatileType(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BOOL*, HRESULT>)_lpVtbl[19])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_constType"/>
+    public HRESULT get_constType(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BOOL*, HRESULT>)_lpVtbl[20])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_unalignedType"/>
+    public HRESULT get_unalignedType(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BOOL*, HRESULT>)_lpVtbl[21])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_access"/>
+    public HRESULT get_access(uint* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, uint*, HRESULT>)_lpVtbl[22])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_libraryName"/>
+    public HRESULT get_libraryName(BSTR* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BSTR*, HRESULT>)_lpVtbl[23])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_platform"/>
+    public HRESULT get_platform(uint* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, uint*, HRESULT>)_lpVtbl[24])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_language"/>
+    public HRESULT get_language(uint* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, uint*, HRESULT>)_lpVtbl[25])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_editAndContinueEnabled"/>
+    public HRESULT get_editAndContinueEnabled(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BOOL*, HRESULT>)_lpVtbl[26])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_frontEndMajor"/>
+    public HRESULT get_frontEndMajor(uint* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, uint*, HRESULT>)_lpVtbl[27])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_frontEndMinor"/>
+    public HRESULT get_frontEndMinor(uint* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, uint*, HRESULT>)_lpVtbl[28])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_frontEndBuild"/>
+    public HRESULT get_frontEndBuild(uint* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, uint*, HRESULT>)_lpVtbl[29])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_backEndMajor"/>
+    public HRESULT get_backEndMajor(uint* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, uint*, HRESULT>)_lpVtbl[30])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_backEndMinor"/>
+    public HRESULT get_backEndMinor(uint* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, uint*, HRESULT>)_lpVtbl[31])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_backEndBuild"/>
+    public HRESULT get_backEndBuild(uint* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, uint*, HRESULT>)_lpVtbl[32])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_sourceFileName"/>
+    public HRESULT get_sourceFileName(BSTR* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BSTR*, HRESULT>)_lpVtbl[33])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_unused"/>
+    public HRESULT get_unused(BSTR* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BSTR*, HRESULT>)_lpVtbl[34])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_thunkOrdinal"/>
+    public HRESULT get_thunkOrdinal(uint* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, uint*, HRESULT>)_lpVtbl[35])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_thisAdjust"/>
+    public HRESULT get_thisAdjust(int* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, int*, HRESULT>)_lpVtbl[36])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_virtualBaseOffset"/>
+    public HRESULT get_virtualBaseOffset(uint* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, uint*, HRESULT>)_lpVtbl[37])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_virtual"/>
+    public HRESULT get_virtual(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BOOL*, HRESULT>)_lpVtbl[38])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_intro"/>
+    public HRESULT get_intro(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BOOL*, HRESULT>)_lpVtbl[39])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_pure"/>
+    public HRESULT get_pure(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BOOL*, HRESULT>)_lpVtbl[40])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_callingConvention"/>
+    public HRESULT get_callingConvention(uint* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, uint*, HRESULT>)_lpVtbl[41])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_value"/>
+    public HRESULT get_value(VARIANT* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, VARIANT*, HRESULT>)_lpVtbl[42])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_baseType"/>
+    public HRESULT get_baseType(uint* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, uint*, HRESULT>)_lpVtbl[43])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_token"/>
+    public HRESULT get_token(uint* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, uint*, HRESULT>)_lpVtbl[44])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_timeStamp"/>
+    public HRESULT get_timeStamp(uint* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, uint*, HRESULT>)_lpVtbl[45])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_guid"/>
+    public HRESULT get_guid(Guid* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, Guid*, HRESULT>)_lpVtbl[46])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_symbolsFileName"/>
+    public HRESULT get_symbolsFileName(BSTR* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BSTR*, HRESULT>)_lpVtbl[47])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_reference"/>
+    public HRESULT get_reference(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BOOL*, HRESULT>)_lpVtbl[48])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_count"/>
+    public HRESULT get_count(uint* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, uint*, HRESULT>)_lpVtbl[49])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_bitPosition"/>
+    public HRESULT get_bitPosition(uint* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, uint*, HRESULT>)_lpVtbl[50])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_arrayIndexType"/>
+    public HRESULT get_arrayIndexType(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, IDiaSymbol**, HRESULT>)_lpVtbl[51])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_packed"/>
+    public HRESULT get_packed(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BOOL*, HRESULT>)_lpVtbl[52])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_constructor"/>
+    public HRESULT get_constructor(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BOOL*, HRESULT>)_lpVtbl[53])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_overloadedOperator"/>
+    public HRESULT get_overloadedOperator(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BOOL*, HRESULT>)_lpVtbl[54])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_nested"/>
+    public HRESULT get_nested(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BOOL*, HRESULT>)_lpVtbl[55])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasNestedTypes"/>
+    public HRESULT get_hasNestedTypes(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BOOL*, HRESULT>)_lpVtbl[56])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasAssignmentOperator"/>
+    public HRESULT get_hasAssignmentOperator(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BOOL*, HRESULT>)_lpVtbl[57])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasCastOperator"/>
+    public HRESULT get_hasCastOperator(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BOOL*, HRESULT>)_lpVtbl[58])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_scoped"/>
+    public HRESULT get_scoped(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BOOL*, HRESULT>)_lpVtbl[59])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_virtualBaseClass"/>
+    public HRESULT get_virtualBaseClass(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BOOL*, HRESULT>)_lpVtbl[60])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_indirectVirtualBaseClass"/>
+    public HRESULT get_indirectVirtualBaseClass(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BOOL*, HRESULT>)_lpVtbl[61])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_virtualBasePointerOffset"/>
+    public HRESULT get_virtualBasePointerOffset(int* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, int*, HRESULT>)_lpVtbl[62])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_virtualTableShape"/>
+    public HRESULT get_virtualTableShape(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, IDiaSymbol**, HRESULT>)_lpVtbl[63])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_lexicalParentId"/>
+    public HRESULT get_lexicalParentId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, uint*, HRESULT>)_lpVtbl[64])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_classParentId"/>
+    public HRESULT get_classParentId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, uint*, HRESULT>)_lpVtbl[65])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_typeId"/>
+    public HRESULT get_typeId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, uint*, HRESULT>)_lpVtbl[66])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_arrayIndexTypeId"/>
+    public HRESULT get_arrayIndexTypeId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, uint*, HRESULT>)_lpVtbl[67])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_virtualTableShapeId"/>
+    public HRESULT get_virtualTableShapeId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, uint*, HRESULT>)_lpVtbl[68])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_code"/>
+    public HRESULT get_code(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BOOL*, HRESULT>)_lpVtbl[69])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_function"/>
+    public HRESULT get_function(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BOOL*, HRESULT>)_lpVtbl[70])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_managed"/>
+    public HRESULT get_managed(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BOOL*, HRESULT>)_lpVtbl[71])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_msil"/>
+    public HRESULT get_msil(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BOOL*, HRESULT>)_lpVtbl[72])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_virtualBaseDispIndex"/>
+    public HRESULT get_virtualBaseDispIndex(uint* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, uint*, HRESULT>)_lpVtbl[73])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_undecoratedName"/>
+    public HRESULT get_undecoratedName(BSTR* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BSTR*, HRESULT>)_lpVtbl[74])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_age"/>
+    public HRESULT get_age(uint* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, uint*, HRESULT>)_lpVtbl[75])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_signature"/>
+    public HRESULT get_signature(uint* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, uint*, HRESULT>)_lpVtbl[76])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_compilerGenerated"/>
+    public HRESULT get_compilerGenerated(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BOOL*, HRESULT>)_lpVtbl[77])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_addressTaken"/>
+    public HRESULT get_addressTaken(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BOOL*, HRESULT>)_lpVtbl[78])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_rank"/>
+    public HRESULT get_rank(uint* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, uint*, HRESULT>)_lpVtbl[79])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_lowerBound"/>
+    public HRESULT get_lowerBound(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, IDiaSymbol**, HRESULT>)_lpVtbl[80])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_upperBound"/>
+    public HRESULT get_upperBound(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, IDiaSymbol**, HRESULT>)_lpVtbl[81])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_lowerBoundId"/>
+    public HRESULT get_lowerBoundId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, uint*, HRESULT>)_lpVtbl[82])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_upperBoundId"/>
+    public HRESULT get_upperBoundId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, uint*, HRESULT>)_lpVtbl[83])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_dataBytes"/>
+    public HRESULT get_dataBytes(uint cbData, uint* pcbData, byte* pbData)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, uint, uint*, byte*, HRESULT>)_lpVtbl[84])(pThis, cbData, pcbData, pbData);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findChildren"/>
+    public HRESULT findChildren(SymTagEnum symtag, PCWSTR name, uint compareFlags, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, SymTagEnum, PCWSTR, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[85])(pThis, symtag, name, compareFlags, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findChildrenEx"/>
+    public HRESULT findChildrenEx(SymTagEnum symtag, PCWSTR name, uint compareFlags, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, SymTagEnum, PCWSTR, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[86])(pThis, symtag, name, compareFlags, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findChildrenExByAddr"/>
+    public HRESULT findChildrenExByAddr(SymTagEnum symtag, PCWSTR name, uint compareFlags, uint isect, uint offset, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, SymTagEnum, PCWSTR, uint, uint, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[87])(pThis, symtag, name, compareFlags, isect, offset, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findChildrenExByVA"/>
+    public HRESULT findChildrenExByVA(SymTagEnum symtag, PCWSTR name, uint compareFlags, ulong va, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, SymTagEnum, PCWSTR, uint, ulong, IDiaEnumSymbols**, HRESULT>)_lpVtbl[88])(pThis, symtag, name, compareFlags, va, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findChildrenExByRVA"/>
+    public HRESULT findChildrenExByRVA(SymTagEnum symtag, PCWSTR name, uint compareFlags, uint rva, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, SymTagEnum, PCWSTR, uint, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[89])(pThis, symtag, name, compareFlags, rva, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_targetSection"/>
+    public HRESULT get_targetSection(uint* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, uint*, HRESULT>)_lpVtbl[90])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_targetOffset"/>
+    public HRESULT get_targetOffset(uint* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, uint*, HRESULT>)_lpVtbl[91])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_targetRelativeVirtualAddress"/>
+    public HRESULT get_targetRelativeVirtualAddress(uint* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, uint*, HRESULT>)_lpVtbl[92])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_targetVirtualAddress"/>
+    public HRESULT get_targetVirtualAddress(ulong* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, ulong*, HRESULT>)_lpVtbl[93])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_machineType"/>
+    public HRESULT get_machineType(uint* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, uint*, HRESULT>)_lpVtbl[94])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_oemId"/>
+    public HRESULT get_oemId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, uint*, HRESULT>)_lpVtbl[95])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_oemSymbolId"/>
+    public HRESULT get_oemSymbolId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, uint*, HRESULT>)_lpVtbl[96])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_types"/>
+    public HRESULT get_types(uint cTypes, uint* pcTypes, IDiaSymbol** pTypes)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, uint, uint*, IDiaSymbol**, HRESULT>)_lpVtbl[97])(pThis, cTypes, pcTypes, pTypes);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_typeIds"/>
+    public HRESULT get_typeIds(uint cTypeIds, uint* pcTypeIds, uint* pdwTypeIds)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, uint, uint*, uint*, HRESULT>)_lpVtbl[98])(pThis, cTypeIds, pcTypeIds, pdwTypeIds);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_objectPointerType"/>
+    public HRESULT get_objectPointerType(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, IDiaSymbol**, HRESULT>)_lpVtbl[99])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_udtKind"/>
+    public HRESULT get_udtKind(uint* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, uint*, HRESULT>)_lpVtbl[100])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_undecoratedNameEx"/>
+    public HRESULT get_undecoratedNameEx(uint undecorateOptions, BSTR* name)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, uint, BSTR*, HRESULT>)_lpVtbl[101])(pThis, undecorateOptions, name);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_noReturn"/>
+    public HRESULT get_noReturn(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BOOL*, HRESULT>)_lpVtbl[102])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_customCallingConvention"/>
+    public HRESULT get_customCallingConvention(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BOOL*, HRESULT>)_lpVtbl[103])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_noInline"/>
+    public HRESULT get_noInline(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BOOL*, HRESULT>)_lpVtbl[104])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_optimizedCodeDebugInfo"/>
+    public HRESULT get_optimizedCodeDebugInfo(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BOOL*, HRESULT>)_lpVtbl[105])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_notReached"/>
+    public HRESULT get_notReached(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BOOL*, HRESULT>)_lpVtbl[106])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_interruptReturn"/>
+    public HRESULT get_interruptReturn(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BOOL*, HRESULT>)_lpVtbl[107])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_farReturn"/>
+    public HRESULT get_farReturn(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BOOL*, HRESULT>)_lpVtbl[108])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isStatic"/>
+    public HRESULT get_isStatic(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BOOL*, HRESULT>)_lpVtbl[109])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasDebugInfo"/>
+    public HRESULT get_hasDebugInfo(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BOOL*, HRESULT>)_lpVtbl[110])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isLTCG"/>
+    public HRESULT get_isLTCG(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BOOL*, HRESULT>)_lpVtbl[111])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isDataAligned"/>
+    public HRESULT get_isDataAligned(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BOOL*, HRESULT>)_lpVtbl[112])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasSecurityChecks"/>
+    public HRESULT get_hasSecurityChecks(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BOOL*, HRESULT>)_lpVtbl[113])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_compilerName"/>
+    public HRESULT get_compilerName(BSTR* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BSTR*, HRESULT>)_lpVtbl[114])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasAlloca"/>
+    public HRESULT get_hasAlloca(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BOOL*, HRESULT>)_lpVtbl[115])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasSetJump"/>
+    public HRESULT get_hasSetJump(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BOOL*, HRESULT>)_lpVtbl[116])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasLongJump"/>
+    public HRESULT get_hasLongJump(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BOOL*, HRESULT>)_lpVtbl[117])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasInlAsm"/>
+    public HRESULT get_hasInlAsm(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BOOL*, HRESULT>)_lpVtbl[118])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasEH"/>
+    public HRESULT get_hasEH(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BOOL*, HRESULT>)_lpVtbl[119])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasSEH"/>
+    public HRESULT get_hasSEH(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BOOL*, HRESULT>)_lpVtbl[120])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasEHa"/>
+    public HRESULT get_hasEHa(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BOOL*, HRESULT>)_lpVtbl[121])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isNaked"/>
+    public HRESULT get_isNaked(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BOOL*, HRESULT>)_lpVtbl[122])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isAggregated"/>
+    public HRESULT get_isAggregated(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BOOL*, HRESULT>)_lpVtbl[123])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isSplitted"/>
+    public HRESULT get_isSplitted(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BOOL*, HRESULT>)_lpVtbl[124])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_container"/>
+    public HRESULT get_container(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, IDiaSymbol**, HRESULT>)_lpVtbl[125])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_inlSpec"/>
+    public HRESULT get_inlSpec(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BOOL*, HRESULT>)_lpVtbl[126])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_noStackOrdering"/>
+    public HRESULT get_noStackOrdering(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BOOL*, HRESULT>)_lpVtbl[127])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_virtualBaseTableType"/>
+    public HRESULT get_virtualBaseTableType(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, IDiaSymbol**, HRESULT>)_lpVtbl[128])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasManagedCode"/>
+    public HRESULT get_hasManagedCode(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BOOL*, HRESULT>)_lpVtbl[129])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isHotpatchable"/>
+    public HRESULT get_isHotpatchable(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BOOL*, HRESULT>)_lpVtbl[130])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isCVTCIL"/>
+    public HRESULT get_isCVTCIL(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BOOL*, HRESULT>)_lpVtbl[131])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isMSILNetmodule"/>
+    public HRESULT get_isMSILNetmodule(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BOOL*, HRESULT>)_lpVtbl[132])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isCTypes"/>
+    public HRESULT get_isCTypes(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BOOL*, HRESULT>)_lpVtbl[133])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isStripped"/>
+    public HRESULT get_isStripped(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BOOL*, HRESULT>)_lpVtbl[134])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_frontEndQFE"/>
+    public HRESULT get_frontEndQFE(uint* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, uint*, HRESULT>)_lpVtbl[135])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_backEndQFE"/>
+    public HRESULT get_backEndQFE(uint* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, uint*, HRESULT>)_lpVtbl[136])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_wasInlined"/>
+    public HRESULT get_wasInlined(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BOOL*, HRESULT>)_lpVtbl[137])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_strictGSCheck"/>
+    public HRESULT get_strictGSCheck(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BOOL*, HRESULT>)_lpVtbl[138])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isCxxReturnUdt"/>
+    public HRESULT get_isCxxReturnUdt(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BOOL*, HRESULT>)_lpVtbl[139])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isConstructorVirtualBase"/>
+    public HRESULT get_isConstructorVirtualBase(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BOOL*, HRESULT>)_lpVtbl[140])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_RValueReference"/>
+    public HRESULT get_RValueReference(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BOOL*, HRESULT>)_lpVtbl[141])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_unmodifiedType"/>
+    public HRESULT get_unmodifiedType(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, IDiaSymbol**, HRESULT>)_lpVtbl[142])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_framePointerPresent"/>
+    public HRESULT get_framePointerPresent(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BOOL*, HRESULT>)_lpVtbl[143])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isSafeBuffers"/>
+    public HRESULT get_isSafeBuffers(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BOOL*, HRESULT>)_lpVtbl[144])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_intrinsic"/>
+    public HRESULT get_intrinsic(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BOOL*, HRESULT>)_lpVtbl[145])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_sealed"/>
+    public HRESULT get_sealed(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BOOL*, HRESULT>)_lpVtbl[146])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hfaFloat"/>
+    public HRESULT get_hfaFloat(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BOOL*, HRESULT>)_lpVtbl[147])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hfaDouble"/>
+    public HRESULT get_hfaDouble(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BOOL*, HRESULT>)_lpVtbl[148])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_liveRangeStartAddressSection"/>
+    public HRESULT get_liveRangeStartAddressSection(uint* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, uint*, HRESULT>)_lpVtbl[149])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_liveRangeStartAddressOffset"/>
+    public HRESULT get_liveRangeStartAddressOffset(uint* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, uint*, HRESULT>)_lpVtbl[150])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_liveRangeStartRelativeVirtualAddress"/>
+    public HRESULT get_liveRangeStartRelativeVirtualAddress(uint* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, uint*, HRESULT>)_lpVtbl[151])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_countLiveRanges"/>
+    public HRESULT get_countLiveRanges(uint* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, uint*, HRESULT>)_lpVtbl[152])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_liveRangeLength"/>
+    public HRESULT get_liveRangeLength(ulong* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, ulong*, HRESULT>)_lpVtbl[153])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_offsetInUdt"/>
+    public HRESULT get_offsetInUdt(uint* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, uint*, HRESULT>)_lpVtbl[154])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_paramBasePointerRegisterId"/>
+    public HRESULT get_paramBasePointerRegisterId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, uint*, HRESULT>)_lpVtbl[155])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_localBasePointerRegisterId"/>
+    public HRESULT get_localBasePointerRegisterId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, uint*, HRESULT>)_lpVtbl[156])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isLocationControlFlowDependent"/>
+    public HRESULT get_isLocationControlFlowDependent(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BOOL*, HRESULT>)_lpVtbl[157])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_stride"/>
+    public HRESULT get_stride(uint* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, uint*, HRESULT>)_lpVtbl[158])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_numberOfRows"/>
+    public HRESULT get_numberOfRows(uint* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, uint*, HRESULT>)_lpVtbl[159])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_numberOfColumns"/>
+    public HRESULT get_numberOfColumns(uint* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, uint*, HRESULT>)_lpVtbl[160])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isMatrixRowMajor"/>
+    public HRESULT get_isMatrixRowMajor(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BOOL*, HRESULT>)_lpVtbl[161])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_numericProperties"/>
+    public HRESULT get_numericProperties(uint cnt, uint* pcnt, uint* pProperties)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, uint, uint*, uint*, HRESULT>)_lpVtbl[162])(pThis, cnt, pcnt, pProperties);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_modifierValues"/>
+    public HRESULT get_modifierValues(uint cnt, uint* pcnt, ushort* pModifiers)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, uint, uint*, ushort*, HRESULT>)_lpVtbl[163])(pThis, cnt, pcnt, pModifiers);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isReturnValue"/>
+    public HRESULT get_isReturnValue(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BOOL*, HRESULT>)_lpVtbl[164])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isOptimizedAway"/>
+    public HRESULT get_isOptimizedAway(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BOOL*, HRESULT>)_lpVtbl[165])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_builtInKind"/>
+    public HRESULT get_builtInKind(uint* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, uint*, HRESULT>)_lpVtbl[166])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_registerType"/>
+    public HRESULT get_registerType(uint* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, uint*, HRESULT>)_lpVtbl[167])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_baseDataSlot"/>
+    public HRESULT get_baseDataSlot(uint* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, uint*, HRESULT>)_lpVtbl[168])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_baseDataOffset"/>
+    public HRESULT get_baseDataOffset(uint* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, uint*, HRESULT>)_lpVtbl[169])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_textureSlot"/>
+    public HRESULT get_textureSlot(uint* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, uint*, HRESULT>)_lpVtbl[170])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_samplerSlot"/>
+    public HRESULT get_samplerSlot(uint* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, uint*, HRESULT>)_lpVtbl[171])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_uavSlot"/>
+    public HRESULT get_uavSlot(uint* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, uint*, HRESULT>)_lpVtbl[172])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_sizeInUdt"/>
+    public HRESULT get_sizeInUdt(uint* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, uint*, HRESULT>)_lpVtbl[173])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_memorySpaceKind"/>
+    public HRESULT get_memorySpaceKind(uint* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, uint*, HRESULT>)_lpVtbl[174])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_unmodifiedTypeId"/>
+    public HRESULT get_unmodifiedTypeId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, uint*, HRESULT>)_lpVtbl[175])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_subTypeId"/>
+    public HRESULT get_subTypeId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, uint*, HRESULT>)_lpVtbl[176])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_subType"/>
+    public HRESULT get_subType(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, IDiaSymbol**, HRESULT>)_lpVtbl[177])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_numberOfModifiers"/>
+    public HRESULT get_numberOfModifiers(uint* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, uint*, HRESULT>)_lpVtbl[178])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_numberOfRegisterIndices"/>
+    public HRESULT get_numberOfRegisterIndices(uint* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, uint*, HRESULT>)_lpVtbl[179])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isHLSLData"/>
+    public HRESULT get_isHLSLData(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BOOL*, HRESULT>)_lpVtbl[180])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isPointerToDataMember"/>
+    public HRESULT get_isPointerToDataMember(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BOOL*, HRESULT>)_lpVtbl[181])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isPointerToMemberFunction"/>
+    public HRESULT get_isPointerToMemberFunction(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BOOL*, HRESULT>)_lpVtbl[182])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isSingleInheritance"/>
+    public HRESULT get_isSingleInheritance(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BOOL*, HRESULT>)_lpVtbl[183])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isMultipleInheritance"/>
+    public HRESULT get_isMultipleInheritance(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BOOL*, HRESULT>)_lpVtbl[184])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isVirtualInheritance"/>
+    public HRESULT get_isVirtualInheritance(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BOOL*, HRESULT>)_lpVtbl[185])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_restrictedType"/>
+    public HRESULT get_restrictedType(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BOOL*, HRESULT>)_lpVtbl[186])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isPointerBasedOnSymbolValue"/>
+    public HRESULT get_isPointerBasedOnSymbolValue(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BOOL*, HRESULT>)_lpVtbl[187])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_baseSymbol"/>
+    public HRESULT get_baseSymbol(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, IDiaSymbol**, HRESULT>)_lpVtbl[188])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_baseSymbolId"/>
+    public HRESULT get_baseSymbolId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, uint*, HRESULT>)_lpVtbl[189])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_objectFileName"/>
+    public HRESULT get_objectFileName(BSTR* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BSTR*, HRESULT>)_lpVtbl[190])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isAcceleratorGroupSharedLocal"/>
+    public HRESULT get_isAcceleratorGroupSharedLocal(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BOOL*, HRESULT>)_lpVtbl[191])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isAcceleratorPointerTagLiveRange"/>
+    public HRESULT get_isAcceleratorPointerTagLiveRange(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BOOL*, HRESULT>)_lpVtbl[192])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isAcceleratorStubFunction"/>
+    public HRESULT get_isAcceleratorStubFunction(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BOOL*, HRESULT>)_lpVtbl[193])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_numberOfAcceleratorPointerTags"/>
+    public HRESULT get_numberOfAcceleratorPointerTags(uint* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, uint*, HRESULT>)_lpVtbl[194])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isSdl"/>
+    public HRESULT get_isSdl(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BOOL*, HRESULT>)_lpVtbl[195])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isWinRTPointer"/>
+    public HRESULT get_isWinRTPointer(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BOOL*, HRESULT>)_lpVtbl[196])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isRefUdt"/>
+    public HRESULT get_isRefUdt(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BOOL*, HRESULT>)_lpVtbl[197])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isValueUdt"/>
+    public HRESULT get_isValueUdt(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BOOL*, HRESULT>)_lpVtbl[198])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isInterfaceUdt"/>
+    public HRESULT get_isInterfaceUdt(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BOOL*, HRESULT>)_lpVtbl[199])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findInlineFramesByAddr"/>
+    public HRESULT findInlineFramesByAddr(uint isect, uint offset, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, uint, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[200])(pThis, isect, offset, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findInlineFramesByRVA"/>
+    public HRESULT findInlineFramesByRVA(uint rva, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[201])(pThis, rva, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findInlineFramesByVA"/>
+    public HRESULT findInlineFramesByVA(ulong va, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, ulong, IDiaEnumSymbols**, HRESULT>)_lpVtbl[202])(pThis, va, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findInlineeLines"/>
+    public HRESULT findInlineeLines(IDiaEnumLineNumbers** ppResult)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, IDiaEnumLineNumbers**, HRESULT>)_lpVtbl[203])(pThis, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findInlineeLinesByAddr"/>
+    public HRESULT findInlineeLinesByAddr(uint isect, uint offset, uint length, IDiaEnumLineNumbers** ppResult)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, uint, uint, uint, IDiaEnumLineNumbers**, HRESULT>)_lpVtbl[204])(pThis, isect, offset, length, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findInlineeLinesByRVA"/>
+    public HRESULT findInlineeLinesByRVA(uint rva, uint length, IDiaEnumLineNumbers** ppResult)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, uint, uint, IDiaEnumLineNumbers**, HRESULT>)_lpVtbl[205])(pThis, rva, length, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findInlineeLinesByVA"/>
+    public HRESULT findInlineeLinesByVA(ulong va, uint length, IDiaEnumLineNumbers** ppResult)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, ulong, uint, IDiaEnumLineNumbers**, HRESULT>)_lpVtbl[206])(pThis, va, length, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findSymbolsForAcceleratorPointerTag"/>
+    public HRESULT findSymbolsForAcceleratorPointerTag(uint tagValue, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[207])(pThis, tagValue, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findSymbolsByRVAForAcceleratorPointerTag"/>
+    public HRESULT findSymbolsByRVAForAcceleratorPointerTag(uint tagValue, uint rva, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, uint, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[208])(pThis, tagValue, rva, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_acceleratorPointerTags"/>
+    public HRESULT get_acceleratorPointerTags(uint cnt, uint* pcnt, uint* pPointerTags)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, uint, uint*, uint*, HRESULT>)_lpVtbl[209])(pThis, cnt, pcnt, pPointerTags);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.getSrcLineOnTypeDefn"/>
+    public HRESULT getSrcLineOnTypeDefn(IDiaLineNumber** ppResult)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, IDiaLineNumber**, HRESULT>)_lpVtbl[210])(pThis, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isPGO"/>
+    public HRESULT get_isPGO(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BOOL*, HRESULT>)_lpVtbl[211])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasValidPGOCounts"/>
+    public HRESULT get_hasValidPGOCounts(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BOOL*, HRESULT>)_lpVtbl[212])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isOptimizedForSpeed"/>
+    public HRESULT get_isOptimizedForSpeed(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BOOL*, HRESULT>)_lpVtbl[213])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_PGOEntryCount"/>
+    public HRESULT get_PGOEntryCount(uint* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, uint*, HRESULT>)_lpVtbl[214])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_PGOEdgeCount"/>
+    public HRESULT get_PGOEdgeCount(uint* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, uint*, HRESULT>)_lpVtbl[215])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_PGODynamicInstructionCount"/>
+    public HRESULT get_PGODynamicInstructionCount(ulong* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, ulong*, HRESULT>)_lpVtbl[216])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_staticSize"/>
+    public HRESULT get_staticSize(uint* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, uint*, HRESULT>)_lpVtbl[217])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_finalLiveStaticSize"/>
+    public HRESULT get_finalLiveStaticSize(uint* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, uint*, HRESULT>)_lpVtbl[218])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_phaseName"/>
+    public HRESULT get_phaseName(BSTR* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BSTR*, HRESULT>)_lpVtbl[219])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasControlFlowCheck"/>
+    public HRESULT get_hasControlFlowCheck(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BOOL*, HRESULT>)_lpVtbl[220])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_constantExport"/>
+    public HRESULT get_constantExport(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BOOL*, HRESULT>)_lpVtbl[221])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_dataExport"/>
+    public HRESULT get_dataExport(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BOOL*, HRESULT>)_lpVtbl[222])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_privateExport"/>
+    public HRESULT get_privateExport(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BOOL*, HRESULT>)_lpVtbl[223])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_noNameExport"/>
+    public HRESULT get_noNameExport(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BOOL*, HRESULT>)_lpVtbl[224])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_exportHasExplicitlyAssignedOrdinal"/>
+    public HRESULT get_exportHasExplicitlyAssignedOrdinal(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BOOL*, HRESULT>)_lpVtbl[225])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_exportIsForwarder"/>
+    public HRESULT get_exportIsForwarder(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BOOL*, HRESULT>)_lpVtbl[226])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_ordinal"/>
+    public HRESULT get_ordinal(uint* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, uint*, HRESULT>)_lpVtbl[227])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_frameSize"/>
+    public HRESULT get_frameSize(uint* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, uint*, HRESULT>)_lpVtbl[228])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_exceptionHandlerAddressSection"/>
+    public HRESULT get_exceptionHandlerAddressSection(uint* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, uint*, HRESULT>)_lpVtbl[229])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_exceptionHandlerAddressOffset"/>
+    public HRESULT get_exceptionHandlerAddressOffset(uint* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, uint*, HRESULT>)_lpVtbl[230])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_exceptionHandlerRelativeVirtualAddress"/>
+    public HRESULT get_exceptionHandlerRelativeVirtualAddress(uint* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, uint*, HRESULT>)_lpVtbl[231])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_exceptionHandlerVirtualAddress"/>
+    public HRESULT get_exceptionHandlerVirtualAddress(ulong* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, ulong*, HRESULT>)_lpVtbl[232])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findInputAssemblyFile"/>
+    public HRESULT findInputAssemblyFile(IDiaInputAssemblyFile** ppResult)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, IDiaInputAssemblyFile**, HRESULT>)_lpVtbl[233])(pThis, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_characteristics"/>
+    public HRESULT get_characteristics(uint* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, uint*, HRESULT>)_lpVtbl[234])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_coffGroup"/>
+    public HRESULT get_coffGroup(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, IDiaSymbol**, HRESULT>)_lpVtbl[235])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_bindID"/>
+    public HRESULT get_bindID(uint* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, uint*, HRESULT>)_lpVtbl[236])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_bindSpace"/>
+    public HRESULT get_bindSpace(uint* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, uint*, HRESULT>)_lpVtbl[237])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_bindSlot"/>
+    public HRESULT get_bindSlot(uint* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, uint*, HRESULT>)_lpVtbl[238])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol2.Interface.get_isObjCClass"/>
+    public HRESULT get_isObjCClass(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BOOL*, HRESULT>)_lpVtbl[239])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol2.Interface.get_isObjCCategory"/>
+    public HRESULT get_isObjCCategory(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BOOL*, HRESULT>)_lpVtbl[240])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol2.Interface.get_isObjCProtocol"/>
+    public HRESULT get_isObjCProtocol(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BOOL*, HRESULT>)_lpVtbl[241])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol3.Interface.get_inlinee"/>
+    public HRESULT get_inlinee(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, IDiaSymbol**, HRESULT>)_lpVtbl[242])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol3.Interface.get_inlineeId"/>
+    public HRESULT get_inlineeId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, uint*, HRESULT>)_lpVtbl[243])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol4.Interface.get_noexcept"/>
+    public HRESULT get_noexcept(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BOOL*, HRESULT>)_lpVtbl[244])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol5.Interface.get_hasAbsoluteAddress"/>
+    public HRESULT get_hasAbsoluteAddress(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BOOL*, HRESULT>)_lpVtbl[245])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_isStaticMemberFunc"/>
+    public HRESULT get_isStaticMemberFunc(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol6* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol6*, BOOL*, HRESULT>)_lpVtbl[246])(pThis, pRetVal);
+    }
+
+    /// <summary>
+    ///  Extends IDiaSymbol5 with the static member function property.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/visualstudio/debugger/debug-interface-access/idiasymbol6">
+    ///    Official documentation.
+    ///   </see>
+    ///  </para>
+    /// </remarks>
+    [ComImport]
+    [Guid("8133DAD3-75FE-4234-AC7E-F8E7A1D3CBB3")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    public unsafe interface Interface : IDiaSymbol5.Interface
+    {
+        /// <summary>
+        ///  Static member function.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_isStaticMemberFunc(BOOL* pRetVal);
+    }
+}

--- a/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaSymbol7.cs
+++ b/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaSymbol7.cs
@@ -1,0 +1,1804 @@
+﻿// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Runtime.InteropServices;
+using Windows.Win32.System.Variant;
+
+// For some reason the XML comment refs for IUnknown can't be resolved on .NET Framework without
+// explicitly using the fully qualified name, which falls afoul of the simplify warning.
+using ComIUnknown = Windows.Win32.System.Com.IUnknown;
+
+namespace Microsoft.VisualStudio.Debugging.DebugInterfaceAccess;
+
+/// <inheritdoc cref="Interface"/>
+public unsafe struct IDiaSymbol7 : IComIID
+{
+    /// <inheritdoc cref="IComIID.Guid"/>
+#pragma warning disable IDE1006 // Naming Styles
+    public static readonly Guid IID_Guid = new(0x64CE6CD5, 0x7315, 0x4328, 0x86, 0xD6, 0x10, 0xE3, 0x03, 0xE0, 0x10, 0xB4);
+#pragma warning restore IDE1006
+
+#if NETFRAMEWORK
+    readonly ref readonly Guid IComIID.Guid => ref IID_Guid;
+#else
+    static ref readonly Guid IComIID.Guid
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get
+        {
+            ReadOnlySpan<byte> data =
+            [
+                0xD5, 0x6C, 0xCE, 0x64,
+                0x15, 0x73,
+                0x28, 0x43,
+                0x86, 0xD6, 0x10, 0xE3, 0x03, 0xE0, 0x10, 0xB4
+            ];
+
+            return ref Unsafe.As<byte, Guid>(ref MemoryMarshal.GetReference(data));
+        }
+    }
+#endif
+
+    private readonly void** _lpVtbl;
+
+    /// <inheritdoc cref="ComIUnknown.QueryInterface(Guid*, void**)"/>
+    public HRESULT QueryInterface(Guid* riid, void** ppvObject)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, Guid*, void**, HRESULT>)_lpVtbl[0])(pThis, riid, ppvObject);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.AddRef"/>
+    public uint AddRef()
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, uint>)_lpVtbl[1])(pThis);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.Release"/>
+    public uint Release()
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, uint>)_lpVtbl[2])(pThis);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_symIndexId"/>
+    public HRESULT get_symIndexId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, uint*, HRESULT>)_lpVtbl[3])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_symTag"/>
+    public HRESULT get_symTag(uint* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, uint*, HRESULT>)_lpVtbl[4])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_name"/>
+    public HRESULT get_name(BSTR* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BSTR*, HRESULT>)_lpVtbl[5])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_lexicalParent"/>
+    public HRESULT get_lexicalParent(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, IDiaSymbol**, HRESULT>)_lpVtbl[6])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_classParent"/>
+    public HRESULT get_classParent(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, IDiaSymbol**, HRESULT>)_lpVtbl[7])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_type"/>
+    public HRESULT get_type(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, IDiaSymbol**, HRESULT>)_lpVtbl[8])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_dataKind"/>
+    public HRESULT get_dataKind(uint* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, uint*, HRESULT>)_lpVtbl[9])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_locationType"/>
+    public HRESULT get_locationType(uint* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, uint*, HRESULT>)_lpVtbl[10])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_addressSection"/>
+    public HRESULT get_addressSection(uint* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, uint*, HRESULT>)_lpVtbl[11])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_addressOffset"/>
+    public HRESULT get_addressOffset(uint* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, uint*, HRESULT>)_lpVtbl[12])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_relativeVirtualAddress"/>
+    public HRESULT get_relativeVirtualAddress(uint* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, uint*, HRESULT>)_lpVtbl[13])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_virtualAddress"/>
+    public HRESULT get_virtualAddress(ulong* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, ulong*, HRESULT>)_lpVtbl[14])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_registerId"/>
+    public HRESULT get_registerId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, uint*, HRESULT>)_lpVtbl[15])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_offset"/>
+    public HRESULT get_offset(int* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, int*, HRESULT>)_lpVtbl[16])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_length"/>
+    public HRESULT get_length(ulong* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, ulong*, HRESULT>)_lpVtbl[17])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_slot"/>
+    public HRESULT get_slot(uint* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, uint*, HRESULT>)_lpVtbl[18])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_volatileType"/>
+    public HRESULT get_volatileType(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BOOL*, HRESULT>)_lpVtbl[19])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_constType"/>
+    public HRESULT get_constType(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BOOL*, HRESULT>)_lpVtbl[20])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_unalignedType"/>
+    public HRESULT get_unalignedType(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BOOL*, HRESULT>)_lpVtbl[21])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_access"/>
+    public HRESULT get_access(uint* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, uint*, HRESULT>)_lpVtbl[22])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_libraryName"/>
+    public HRESULT get_libraryName(BSTR* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BSTR*, HRESULT>)_lpVtbl[23])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_platform"/>
+    public HRESULT get_platform(uint* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, uint*, HRESULT>)_lpVtbl[24])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_language"/>
+    public HRESULT get_language(uint* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, uint*, HRESULT>)_lpVtbl[25])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_editAndContinueEnabled"/>
+    public HRESULT get_editAndContinueEnabled(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BOOL*, HRESULT>)_lpVtbl[26])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_frontEndMajor"/>
+    public HRESULT get_frontEndMajor(uint* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, uint*, HRESULT>)_lpVtbl[27])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_frontEndMinor"/>
+    public HRESULT get_frontEndMinor(uint* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, uint*, HRESULT>)_lpVtbl[28])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_frontEndBuild"/>
+    public HRESULT get_frontEndBuild(uint* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, uint*, HRESULT>)_lpVtbl[29])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_backEndMajor"/>
+    public HRESULT get_backEndMajor(uint* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, uint*, HRESULT>)_lpVtbl[30])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_backEndMinor"/>
+    public HRESULT get_backEndMinor(uint* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, uint*, HRESULT>)_lpVtbl[31])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_backEndBuild"/>
+    public HRESULT get_backEndBuild(uint* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, uint*, HRESULT>)_lpVtbl[32])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_sourceFileName"/>
+    public HRESULT get_sourceFileName(BSTR* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BSTR*, HRESULT>)_lpVtbl[33])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_unused"/>
+    public HRESULT get_unused(BSTR* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BSTR*, HRESULT>)_lpVtbl[34])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_thunkOrdinal"/>
+    public HRESULT get_thunkOrdinal(uint* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, uint*, HRESULT>)_lpVtbl[35])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_thisAdjust"/>
+    public HRESULT get_thisAdjust(int* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, int*, HRESULT>)_lpVtbl[36])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_virtualBaseOffset"/>
+    public HRESULT get_virtualBaseOffset(uint* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, uint*, HRESULT>)_lpVtbl[37])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_virtual"/>
+    public HRESULT get_virtual(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BOOL*, HRESULT>)_lpVtbl[38])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_intro"/>
+    public HRESULT get_intro(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BOOL*, HRESULT>)_lpVtbl[39])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_pure"/>
+    public HRESULT get_pure(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BOOL*, HRESULT>)_lpVtbl[40])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_callingConvention"/>
+    public HRESULT get_callingConvention(uint* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, uint*, HRESULT>)_lpVtbl[41])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_value"/>
+    public HRESULT get_value(VARIANT* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, VARIANT*, HRESULT>)_lpVtbl[42])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_baseType"/>
+    public HRESULT get_baseType(uint* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, uint*, HRESULT>)_lpVtbl[43])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_token"/>
+    public HRESULT get_token(uint* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, uint*, HRESULT>)_lpVtbl[44])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_timeStamp"/>
+    public HRESULT get_timeStamp(uint* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, uint*, HRESULT>)_lpVtbl[45])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_guid"/>
+    public HRESULT get_guid(Guid* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, Guid*, HRESULT>)_lpVtbl[46])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_symbolsFileName"/>
+    public HRESULT get_symbolsFileName(BSTR* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BSTR*, HRESULT>)_lpVtbl[47])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_reference"/>
+    public HRESULT get_reference(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BOOL*, HRESULT>)_lpVtbl[48])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_count"/>
+    public HRESULT get_count(uint* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, uint*, HRESULT>)_lpVtbl[49])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_bitPosition"/>
+    public HRESULT get_bitPosition(uint* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, uint*, HRESULT>)_lpVtbl[50])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_arrayIndexType"/>
+    public HRESULT get_arrayIndexType(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, IDiaSymbol**, HRESULT>)_lpVtbl[51])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_packed"/>
+    public HRESULT get_packed(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BOOL*, HRESULT>)_lpVtbl[52])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_constructor"/>
+    public HRESULT get_constructor(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BOOL*, HRESULT>)_lpVtbl[53])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_overloadedOperator"/>
+    public HRESULT get_overloadedOperator(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BOOL*, HRESULT>)_lpVtbl[54])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_nested"/>
+    public HRESULT get_nested(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BOOL*, HRESULT>)_lpVtbl[55])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasNestedTypes"/>
+    public HRESULT get_hasNestedTypes(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BOOL*, HRESULT>)_lpVtbl[56])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasAssignmentOperator"/>
+    public HRESULT get_hasAssignmentOperator(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BOOL*, HRESULT>)_lpVtbl[57])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasCastOperator"/>
+    public HRESULT get_hasCastOperator(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BOOL*, HRESULT>)_lpVtbl[58])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_scoped"/>
+    public HRESULT get_scoped(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BOOL*, HRESULT>)_lpVtbl[59])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_virtualBaseClass"/>
+    public HRESULT get_virtualBaseClass(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BOOL*, HRESULT>)_lpVtbl[60])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_indirectVirtualBaseClass"/>
+    public HRESULT get_indirectVirtualBaseClass(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BOOL*, HRESULT>)_lpVtbl[61])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_virtualBasePointerOffset"/>
+    public HRESULT get_virtualBasePointerOffset(int* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, int*, HRESULT>)_lpVtbl[62])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_virtualTableShape"/>
+    public HRESULT get_virtualTableShape(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, IDiaSymbol**, HRESULT>)_lpVtbl[63])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_lexicalParentId"/>
+    public HRESULT get_lexicalParentId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, uint*, HRESULT>)_lpVtbl[64])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_classParentId"/>
+    public HRESULT get_classParentId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, uint*, HRESULT>)_lpVtbl[65])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_typeId"/>
+    public HRESULT get_typeId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, uint*, HRESULT>)_lpVtbl[66])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_arrayIndexTypeId"/>
+    public HRESULT get_arrayIndexTypeId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, uint*, HRESULT>)_lpVtbl[67])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_virtualTableShapeId"/>
+    public HRESULT get_virtualTableShapeId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, uint*, HRESULT>)_lpVtbl[68])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_code"/>
+    public HRESULT get_code(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BOOL*, HRESULT>)_lpVtbl[69])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_function"/>
+    public HRESULT get_function(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BOOL*, HRESULT>)_lpVtbl[70])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_managed"/>
+    public HRESULT get_managed(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BOOL*, HRESULT>)_lpVtbl[71])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_msil"/>
+    public HRESULT get_msil(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BOOL*, HRESULT>)_lpVtbl[72])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_virtualBaseDispIndex"/>
+    public HRESULT get_virtualBaseDispIndex(uint* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, uint*, HRESULT>)_lpVtbl[73])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_undecoratedName"/>
+    public HRESULT get_undecoratedName(BSTR* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BSTR*, HRESULT>)_lpVtbl[74])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_age"/>
+    public HRESULT get_age(uint* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, uint*, HRESULT>)_lpVtbl[75])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_signature"/>
+    public HRESULT get_signature(uint* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, uint*, HRESULT>)_lpVtbl[76])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_compilerGenerated"/>
+    public HRESULT get_compilerGenerated(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BOOL*, HRESULT>)_lpVtbl[77])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_addressTaken"/>
+    public HRESULT get_addressTaken(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BOOL*, HRESULT>)_lpVtbl[78])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_rank"/>
+    public HRESULT get_rank(uint* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, uint*, HRESULT>)_lpVtbl[79])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_lowerBound"/>
+    public HRESULT get_lowerBound(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, IDiaSymbol**, HRESULT>)_lpVtbl[80])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_upperBound"/>
+    public HRESULT get_upperBound(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, IDiaSymbol**, HRESULT>)_lpVtbl[81])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_lowerBoundId"/>
+    public HRESULT get_lowerBoundId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, uint*, HRESULT>)_lpVtbl[82])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_upperBoundId"/>
+    public HRESULT get_upperBoundId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, uint*, HRESULT>)_lpVtbl[83])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_dataBytes"/>
+    public HRESULT get_dataBytes(uint cbData, uint* pcbData, byte* pbData)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, uint, uint*, byte*, HRESULT>)_lpVtbl[84])(pThis, cbData, pcbData, pbData);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findChildren"/>
+    public HRESULT findChildren(SymTagEnum symtag, PCWSTR name, uint compareFlags, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, SymTagEnum, PCWSTR, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[85])(pThis, symtag, name, compareFlags, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findChildrenEx"/>
+    public HRESULT findChildrenEx(SymTagEnum symtag, PCWSTR name, uint compareFlags, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, SymTagEnum, PCWSTR, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[86])(pThis, symtag, name, compareFlags, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findChildrenExByAddr"/>
+    public HRESULT findChildrenExByAddr(SymTagEnum symtag, PCWSTR name, uint compareFlags, uint isect, uint offset, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, SymTagEnum, PCWSTR, uint, uint, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[87])(pThis, symtag, name, compareFlags, isect, offset, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findChildrenExByVA"/>
+    public HRESULT findChildrenExByVA(SymTagEnum symtag, PCWSTR name, uint compareFlags, ulong va, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, SymTagEnum, PCWSTR, uint, ulong, IDiaEnumSymbols**, HRESULT>)_lpVtbl[88])(pThis, symtag, name, compareFlags, va, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findChildrenExByRVA"/>
+    public HRESULT findChildrenExByRVA(SymTagEnum symtag, PCWSTR name, uint compareFlags, uint rva, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, SymTagEnum, PCWSTR, uint, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[89])(pThis, symtag, name, compareFlags, rva, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_targetSection"/>
+    public HRESULT get_targetSection(uint* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, uint*, HRESULT>)_lpVtbl[90])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_targetOffset"/>
+    public HRESULT get_targetOffset(uint* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, uint*, HRESULT>)_lpVtbl[91])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_targetRelativeVirtualAddress"/>
+    public HRESULT get_targetRelativeVirtualAddress(uint* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, uint*, HRESULT>)_lpVtbl[92])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_targetVirtualAddress"/>
+    public HRESULT get_targetVirtualAddress(ulong* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, ulong*, HRESULT>)_lpVtbl[93])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_machineType"/>
+    public HRESULT get_machineType(uint* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, uint*, HRESULT>)_lpVtbl[94])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_oemId"/>
+    public HRESULT get_oemId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, uint*, HRESULT>)_lpVtbl[95])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_oemSymbolId"/>
+    public HRESULT get_oemSymbolId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, uint*, HRESULT>)_lpVtbl[96])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_types"/>
+    public HRESULT get_types(uint cTypes, uint* pcTypes, IDiaSymbol** pTypes)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, uint, uint*, IDiaSymbol**, HRESULT>)_lpVtbl[97])(pThis, cTypes, pcTypes, pTypes);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_typeIds"/>
+    public HRESULT get_typeIds(uint cTypeIds, uint* pcTypeIds, uint* pdwTypeIds)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, uint, uint*, uint*, HRESULT>)_lpVtbl[98])(pThis, cTypeIds, pcTypeIds, pdwTypeIds);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_objectPointerType"/>
+    public HRESULT get_objectPointerType(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, IDiaSymbol**, HRESULT>)_lpVtbl[99])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_udtKind"/>
+    public HRESULT get_udtKind(uint* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, uint*, HRESULT>)_lpVtbl[100])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_undecoratedNameEx"/>
+    public HRESULT get_undecoratedNameEx(uint undecorateOptions, BSTR* name)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, uint, BSTR*, HRESULT>)_lpVtbl[101])(pThis, undecorateOptions, name);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_noReturn"/>
+    public HRESULT get_noReturn(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BOOL*, HRESULT>)_lpVtbl[102])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_customCallingConvention"/>
+    public HRESULT get_customCallingConvention(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BOOL*, HRESULT>)_lpVtbl[103])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_noInline"/>
+    public HRESULT get_noInline(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BOOL*, HRESULT>)_lpVtbl[104])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_optimizedCodeDebugInfo"/>
+    public HRESULT get_optimizedCodeDebugInfo(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BOOL*, HRESULT>)_lpVtbl[105])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_notReached"/>
+    public HRESULT get_notReached(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BOOL*, HRESULT>)_lpVtbl[106])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_interruptReturn"/>
+    public HRESULT get_interruptReturn(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BOOL*, HRESULT>)_lpVtbl[107])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_farReturn"/>
+    public HRESULT get_farReturn(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BOOL*, HRESULT>)_lpVtbl[108])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isStatic"/>
+    public HRESULT get_isStatic(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BOOL*, HRESULT>)_lpVtbl[109])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasDebugInfo"/>
+    public HRESULT get_hasDebugInfo(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BOOL*, HRESULT>)_lpVtbl[110])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isLTCG"/>
+    public HRESULT get_isLTCG(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BOOL*, HRESULT>)_lpVtbl[111])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isDataAligned"/>
+    public HRESULT get_isDataAligned(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BOOL*, HRESULT>)_lpVtbl[112])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasSecurityChecks"/>
+    public HRESULT get_hasSecurityChecks(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BOOL*, HRESULT>)_lpVtbl[113])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_compilerName"/>
+    public HRESULT get_compilerName(BSTR* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BSTR*, HRESULT>)_lpVtbl[114])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasAlloca"/>
+    public HRESULT get_hasAlloca(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BOOL*, HRESULT>)_lpVtbl[115])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasSetJump"/>
+    public HRESULT get_hasSetJump(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BOOL*, HRESULT>)_lpVtbl[116])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasLongJump"/>
+    public HRESULT get_hasLongJump(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BOOL*, HRESULT>)_lpVtbl[117])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasInlAsm"/>
+    public HRESULT get_hasInlAsm(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BOOL*, HRESULT>)_lpVtbl[118])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasEH"/>
+    public HRESULT get_hasEH(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BOOL*, HRESULT>)_lpVtbl[119])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasSEH"/>
+    public HRESULT get_hasSEH(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BOOL*, HRESULT>)_lpVtbl[120])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasEHa"/>
+    public HRESULT get_hasEHa(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BOOL*, HRESULT>)_lpVtbl[121])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isNaked"/>
+    public HRESULT get_isNaked(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BOOL*, HRESULT>)_lpVtbl[122])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isAggregated"/>
+    public HRESULT get_isAggregated(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BOOL*, HRESULT>)_lpVtbl[123])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isSplitted"/>
+    public HRESULT get_isSplitted(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BOOL*, HRESULT>)_lpVtbl[124])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_container"/>
+    public HRESULT get_container(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, IDiaSymbol**, HRESULT>)_lpVtbl[125])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_inlSpec"/>
+    public HRESULT get_inlSpec(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BOOL*, HRESULT>)_lpVtbl[126])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_noStackOrdering"/>
+    public HRESULT get_noStackOrdering(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BOOL*, HRESULT>)_lpVtbl[127])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_virtualBaseTableType"/>
+    public HRESULT get_virtualBaseTableType(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, IDiaSymbol**, HRESULT>)_lpVtbl[128])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasManagedCode"/>
+    public HRESULT get_hasManagedCode(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BOOL*, HRESULT>)_lpVtbl[129])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isHotpatchable"/>
+    public HRESULT get_isHotpatchable(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BOOL*, HRESULT>)_lpVtbl[130])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isCVTCIL"/>
+    public HRESULT get_isCVTCIL(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BOOL*, HRESULT>)_lpVtbl[131])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isMSILNetmodule"/>
+    public HRESULT get_isMSILNetmodule(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BOOL*, HRESULT>)_lpVtbl[132])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isCTypes"/>
+    public HRESULT get_isCTypes(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BOOL*, HRESULT>)_lpVtbl[133])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isStripped"/>
+    public HRESULT get_isStripped(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BOOL*, HRESULT>)_lpVtbl[134])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_frontEndQFE"/>
+    public HRESULT get_frontEndQFE(uint* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, uint*, HRESULT>)_lpVtbl[135])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_backEndQFE"/>
+    public HRESULT get_backEndQFE(uint* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, uint*, HRESULT>)_lpVtbl[136])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_wasInlined"/>
+    public HRESULT get_wasInlined(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BOOL*, HRESULT>)_lpVtbl[137])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_strictGSCheck"/>
+    public HRESULT get_strictGSCheck(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BOOL*, HRESULT>)_lpVtbl[138])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isCxxReturnUdt"/>
+    public HRESULT get_isCxxReturnUdt(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BOOL*, HRESULT>)_lpVtbl[139])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isConstructorVirtualBase"/>
+    public HRESULT get_isConstructorVirtualBase(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BOOL*, HRESULT>)_lpVtbl[140])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_RValueReference"/>
+    public HRESULT get_RValueReference(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BOOL*, HRESULT>)_lpVtbl[141])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_unmodifiedType"/>
+    public HRESULT get_unmodifiedType(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, IDiaSymbol**, HRESULT>)_lpVtbl[142])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_framePointerPresent"/>
+    public HRESULT get_framePointerPresent(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BOOL*, HRESULT>)_lpVtbl[143])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isSafeBuffers"/>
+    public HRESULT get_isSafeBuffers(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BOOL*, HRESULT>)_lpVtbl[144])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_intrinsic"/>
+    public HRESULT get_intrinsic(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BOOL*, HRESULT>)_lpVtbl[145])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_sealed"/>
+    public HRESULT get_sealed(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BOOL*, HRESULT>)_lpVtbl[146])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hfaFloat"/>
+    public HRESULT get_hfaFloat(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BOOL*, HRESULT>)_lpVtbl[147])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hfaDouble"/>
+    public HRESULT get_hfaDouble(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BOOL*, HRESULT>)_lpVtbl[148])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_liveRangeStartAddressSection"/>
+    public HRESULT get_liveRangeStartAddressSection(uint* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, uint*, HRESULT>)_lpVtbl[149])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_liveRangeStartAddressOffset"/>
+    public HRESULT get_liveRangeStartAddressOffset(uint* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, uint*, HRESULT>)_lpVtbl[150])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_liveRangeStartRelativeVirtualAddress"/>
+    public HRESULT get_liveRangeStartRelativeVirtualAddress(uint* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, uint*, HRESULT>)_lpVtbl[151])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_countLiveRanges"/>
+    public HRESULT get_countLiveRanges(uint* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, uint*, HRESULT>)_lpVtbl[152])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_liveRangeLength"/>
+    public HRESULT get_liveRangeLength(ulong* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, ulong*, HRESULT>)_lpVtbl[153])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_offsetInUdt"/>
+    public HRESULT get_offsetInUdt(uint* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, uint*, HRESULT>)_lpVtbl[154])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_paramBasePointerRegisterId"/>
+    public HRESULT get_paramBasePointerRegisterId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, uint*, HRESULT>)_lpVtbl[155])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_localBasePointerRegisterId"/>
+    public HRESULT get_localBasePointerRegisterId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, uint*, HRESULT>)_lpVtbl[156])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isLocationControlFlowDependent"/>
+    public HRESULT get_isLocationControlFlowDependent(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BOOL*, HRESULT>)_lpVtbl[157])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_stride"/>
+    public HRESULT get_stride(uint* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, uint*, HRESULT>)_lpVtbl[158])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_numberOfRows"/>
+    public HRESULT get_numberOfRows(uint* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, uint*, HRESULT>)_lpVtbl[159])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_numberOfColumns"/>
+    public HRESULT get_numberOfColumns(uint* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, uint*, HRESULT>)_lpVtbl[160])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isMatrixRowMajor"/>
+    public HRESULT get_isMatrixRowMajor(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BOOL*, HRESULT>)_lpVtbl[161])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_numericProperties"/>
+    public HRESULT get_numericProperties(uint cnt, uint* pcnt, uint* pProperties)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, uint, uint*, uint*, HRESULT>)_lpVtbl[162])(pThis, cnt, pcnt, pProperties);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_modifierValues"/>
+    public HRESULT get_modifierValues(uint cnt, uint* pcnt, ushort* pModifiers)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, uint, uint*, ushort*, HRESULT>)_lpVtbl[163])(pThis, cnt, pcnt, pModifiers);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isReturnValue"/>
+    public HRESULT get_isReturnValue(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BOOL*, HRESULT>)_lpVtbl[164])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isOptimizedAway"/>
+    public HRESULT get_isOptimizedAway(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BOOL*, HRESULT>)_lpVtbl[165])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_builtInKind"/>
+    public HRESULT get_builtInKind(uint* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, uint*, HRESULT>)_lpVtbl[166])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_registerType"/>
+    public HRESULT get_registerType(uint* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, uint*, HRESULT>)_lpVtbl[167])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_baseDataSlot"/>
+    public HRESULT get_baseDataSlot(uint* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, uint*, HRESULT>)_lpVtbl[168])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_baseDataOffset"/>
+    public HRESULT get_baseDataOffset(uint* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, uint*, HRESULT>)_lpVtbl[169])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_textureSlot"/>
+    public HRESULT get_textureSlot(uint* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, uint*, HRESULT>)_lpVtbl[170])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_samplerSlot"/>
+    public HRESULT get_samplerSlot(uint* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, uint*, HRESULT>)_lpVtbl[171])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_uavSlot"/>
+    public HRESULT get_uavSlot(uint* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, uint*, HRESULT>)_lpVtbl[172])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_sizeInUdt"/>
+    public HRESULT get_sizeInUdt(uint* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, uint*, HRESULT>)_lpVtbl[173])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_memorySpaceKind"/>
+    public HRESULT get_memorySpaceKind(uint* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, uint*, HRESULT>)_lpVtbl[174])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_unmodifiedTypeId"/>
+    public HRESULT get_unmodifiedTypeId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, uint*, HRESULT>)_lpVtbl[175])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_subTypeId"/>
+    public HRESULT get_subTypeId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, uint*, HRESULT>)_lpVtbl[176])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_subType"/>
+    public HRESULT get_subType(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, IDiaSymbol**, HRESULT>)_lpVtbl[177])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_numberOfModifiers"/>
+    public HRESULT get_numberOfModifiers(uint* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, uint*, HRESULT>)_lpVtbl[178])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_numberOfRegisterIndices"/>
+    public HRESULT get_numberOfRegisterIndices(uint* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, uint*, HRESULT>)_lpVtbl[179])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isHLSLData"/>
+    public HRESULT get_isHLSLData(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BOOL*, HRESULT>)_lpVtbl[180])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isPointerToDataMember"/>
+    public HRESULT get_isPointerToDataMember(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BOOL*, HRESULT>)_lpVtbl[181])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isPointerToMemberFunction"/>
+    public HRESULT get_isPointerToMemberFunction(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BOOL*, HRESULT>)_lpVtbl[182])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isSingleInheritance"/>
+    public HRESULT get_isSingleInheritance(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BOOL*, HRESULT>)_lpVtbl[183])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isMultipleInheritance"/>
+    public HRESULT get_isMultipleInheritance(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BOOL*, HRESULT>)_lpVtbl[184])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isVirtualInheritance"/>
+    public HRESULT get_isVirtualInheritance(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BOOL*, HRESULT>)_lpVtbl[185])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_restrictedType"/>
+    public HRESULT get_restrictedType(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BOOL*, HRESULT>)_lpVtbl[186])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isPointerBasedOnSymbolValue"/>
+    public HRESULT get_isPointerBasedOnSymbolValue(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BOOL*, HRESULT>)_lpVtbl[187])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_baseSymbol"/>
+    public HRESULT get_baseSymbol(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, IDiaSymbol**, HRESULT>)_lpVtbl[188])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_baseSymbolId"/>
+    public HRESULT get_baseSymbolId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, uint*, HRESULT>)_lpVtbl[189])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_objectFileName"/>
+    public HRESULT get_objectFileName(BSTR* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BSTR*, HRESULT>)_lpVtbl[190])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isAcceleratorGroupSharedLocal"/>
+    public HRESULT get_isAcceleratorGroupSharedLocal(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BOOL*, HRESULT>)_lpVtbl[191])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isAcceleratorPointerTagLiveRange"/>
+    public HRESULT get_isAcceleratorPointerTagLiveRange(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BOOL*, HRESULT>)_lpVtbl[192])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isAcceleratorStubFunction"/>
+    public HRESULT get_isAcceleratorStubFunction(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BOOL*, HRESULT>)_lpVtbl[193])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_numberOfAcceleratorPointerTags"/>
+    public HRESULT get_numberOfAcceleratorPointerTags(uint* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, uint*, HRESULT>)_lpVtbl[194])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isSdl"/>
+    public HRESULT get_isSdl(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BOOL*, HRESULT>)_lpVtbl[195])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isWinRTPointer"/>
+    public HRESULT get_isWinRTPointer(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BOOL*, HRESULT>)_lpVtbl[196])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isRefUdt"/>
+    public HRESULT get_isRefUdt(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BOOL*, HRESULT>)_lpVtbl[197])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isValueUdt"/>
+    public HRESULT get_isValueUdt(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BOOL*, HRESULT>)_lpVtbl[198])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isInterfaceUdt"/>
+    public HRESULT get_isInterfaceUdt(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BOOL*, HRESULT>)_lpVtbl[199])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findInlineFramesByAddr"/>
+    public HRESULT findInlineFramesByAddr(uint isect, uint offset, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, uint, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[200])(pThis, isect, offset, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findInlineFramesByRVA"/>
+    public HRESULT findInlineFramesByRVA(uint rva, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[201])(pThis, rva, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findInlineFramesByVA"/>
+    public HRESULT findInlineFramesByVA(ulong va, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, ulong, IDiaEnumSymbols**, HRESULT>)_lpVtbl[202])(pThis, va, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findInlineeLines"/>
+    public HRESULT findInlineeLines(IDiaEnumLineNumbers** ppResult)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, IDiaEnumLineNumbers**, HRESULT>)_lpVtbl[203])(pThis, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findInlineeLinesByAddr"/>
+    public HRESULT findInlineeLinesByAddr(uint isect, uint offset, uint length, IDiaEnumLineNumbers** ppResult)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, uint, uint, uint, IDiaEnumLineNumbers**, HRESULT>)_lpVtbl[204])(pThis, isect, offset, length, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findInlineeLinesByRVA"/>
+    public HRESULT findInlineeLinesByRVA(uint rva, uint length, IDiaEnumLineNumbers** ppResult)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, uint, uint, IDiaEnumLineNumbers**, HRESULT>)_lpVtbl[205])(pThis, rva, length, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findInlineeLinesByVA"/>
+    public HRESULT findInlineeLinesByVA(ulong va, uint length, IDiaEnumLineNumbers** ppResult)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, ulong, uint, IDiaEnumLineNumbers**, HRESULT>)_lpVtbl[206])(pThis, va, length, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findSymbolsForAcceleratorPointerTag"/>
+    public HRESULT findSymbolsForAcceleratorPointerTag(uint tagValue, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[207])(pThis, tagValue, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findSymbolsByRVAForAcceleratorPointerTag"/>
+    public HRESULT findSymbolsByRVAForAcceleratorPointerTag(uint tagValue, uint rva, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, uint, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[208])(pThis, tagValue, rva, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_acceleratorPointerTags"/>
+    public HRESULT get_acceleratorPointerTags(uint cnt, uint* pcnt, uint* pPointerTags)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, uint, uint*, uint*, HRESULT>)_lpVtbl[209])(pThis, cnt, pcnt, pPointerTags);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.getSrcLineOnTypeDefn"/>
+    public HRESULT getSrcLineOnTypeDefn(IDiaLineNumber** ppResult)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, IDiaLineNumber**, HRESULT>)_lpVtbl[210])(pThis, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isPGO"/>
+    public HRESULT get_isPGO(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BOOL*, HRESULT>)_lpVtbl[211])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasValidPGOCounts"/>
+    public HRESULT get_hasValidPGOCounts(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BOOL*, HRESULT>)_lpVtbl[212])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isOptimizedForSpeed"/>
+    public HRESULT get_isOptimizedForSpeed(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BOOL*, HRESULT>)_lpVtbl[213])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_PGOEntryCount"/>
+    public HRESULT get_PGOEntryCount(uint* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, uint*, HRESULT>)_lpVtbl[214])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_PGOEdgeCount"/>
+    public HRESULT get_PGOEdgeCount(uint* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, uint*, HRESULT>)_lpVtbl[215])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_PGODynamicInstructionCount"/>
+    public HRESULT get_PGODynamicInstructionCount(ulong* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, ulong*, HRESULT>)_lpVtbl[216])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_staticSize"/>
+    public HRESULT get_staticSize(uint* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, uint*, HRESULT>)_lpVtbl[217])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_finalLiveStaticSize"/>
+    public HRESULT get_finalLiveStaticSize(uint* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, uint*, HRESULT>)_lpVtbl[218])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_phaseName"/>
+    public HRESULT get_phaseName(BSTR* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BSTR*, HRESULT>)_lpVtbl[219])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasControlFlowCheck"/>
+    public HRESULT get_hasControlFlowCheck(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BOOL*, HRESULT>)_lpVtbl[220])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_constantExport"/>
+    public HRESULT get_constantExport(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BOOL*, HRESULT>)_lpVtbl[221])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_dataExport"/>
+    public HRESULT get_dataExport(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BOOL*, HRESULT>)_lpVtbl[222])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_privateExport"/>
+    public HRESULT get_privateExport(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BOOL*, HRESULT>)_lpVtbl[223])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_noNameExport"/>
+    public HRESULT get_noNameExport(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BOOL*, HRESULT>)_lpVtbl[224])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_exportHasExplicitlyAssignedOrdinal"/>
+    public HRESULT get_exportHasExplicitlyAssignedOrdinal(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BOOL*, HRESULT>)_lpVtbl[225])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_exportIsForwarder"/>
+    public HRESULT get_exportIsForwarder(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BOOL*, HRESULT>)_lpVtbl[226])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_ordinal"/>
+    public HRESULT get_ordinal(uint* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, uint*, HRESULT>)_lpVtbl[227])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_frameSize"/>
+    public HRESULT get_frameSize(uint* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, uint*, HRESULT>)_lpVtbl[228])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_exceptionHandlerAddressSection"/>
+    public HRESULT get_exceptionHandlerAddressSection(uint* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, uint*, HRESULT>)_lpVtbl[229])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_exceptionHandlerAddressOffset"/>
+    public HRESULT get_exceptionHandlerAddressOffset(uint* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, uint*, HRESULT>)_lpVtbl[230])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_exceptionHandlerRelativeVirtualAddress"/>
+    public HRESULT get_exceptionHandlerRelativeVirtualAddress(uint* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, uint*, HRESULT>)_lpVtbl[231])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_exceptionHandlerVirtualAddress"/>
+    public HRESULT get_exceptionHandlerVirtualAddress(ulong* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, ulong*, HRESULT>)_lpVtbl[232])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findInputAssemblyFile"/>
+    public HRESULT findInputAssemblyFile(IDiaInputAssemblyFile** ppResult)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, IDiaInputAssemblyFile**, HRESULT>)_lpVtbl[233])(pThis, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_characteristics"/>
+    public HRESULT get_characteristics(uint* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, uint*, HRESULT>)_lpVtbl[234])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_coffGroup"/>
+    public HRESULT get_coffGroup(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, IDiaSymbol**, HRESULT>)_lpVtbl[235])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_bindID"/>
+    public HRESULT get_bindID(uint* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, uint*, HRESULT>)_lpVtbl[236])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_bindSpace"/>
+    public HRESULT get_bindSpace(uint* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, uint*, HRESULT>)_lpVtbl[237])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_bindSlot"/>
+    public HRESULT get_bindSlot(uint* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, uint*, HRESULT>)_lpVtbl[238])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol2.Interface.get_isObjCClass"/>
+    public HRESULT get_isObjCClass(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BOOL*, HRESULT>)_lpVtbl[239])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol2.Interface.get_isObjCCategory"/>
+    public HRESULT get_isObjCCategory(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BOOL*, HRESULT>)_lpVtbl[240])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol2.Interface.get_isObjCProtocol"/>
+    public HRESULT get_isObjCProtocol(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BOOL*, HRESULT>)_lpVtbl[241])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol3.Interface.get_inlinee"/>
+    public HRESULT get_inlinee(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, IDiaSymbol**, HRESULT>)_lpVtbl[242])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol3.Interface.get_inlineeId"/>
+    public HRESULT get_inlineeId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, uint*, HRESULT>)_lpVtbl[243])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol4.Interface.get_noexcept"/>
+    public HRESULT get_noexcept(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BOOL*, HRESULT>)_lpVtbl[244])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol5.Interface.get_hasAbsoluteAddress"/>
+    public HRESULT get_hasAbsoluteAddress(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BOOL*, HRESULT>)_lpVtbl[245])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol6.Interface.get_isStaticMemberFunc"/>
+    public HRESULT get_isStaticMemberFunc(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BOOL*, HRESULT>)_lpVtbl[246])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_isSignRet"/>
+    public HRESULT get_isSignRet(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol7* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol7*, BOOL*, HRESULT>)_lpVtbl[247])(pThis, pRetVal);
+    }
+
+    /// <summary>
+    ///  Extends IDiaSymbol6 with the return address signing property.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/visualstudio/debugger/debug-interface-access/idiasymbol7">
+    ///    Official documentation.
+    ///   </see>
+    ///  </para>
+    /// </remarks>
+    [ComImport]
+    [Guid("64CE6CD5-7315-4328-86D6-10E303E010B4")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    public unsafe interface Interface : IDiaSymbol6.Interface
+    {
+        /// <summary>
+        ///  Function signs return address.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_isSignRet(BOOL* pRetVal);
+    }
+}

--- a/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaSymbol8.cs
+++ b/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaSymbol8.cs
@@ -1,0 +1,1886 @@
+﻿// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Runtime.InteropServices;
+using Windows.Win32.System.Variant;
+
+// For some reason the XML comment refs for IUnknown can't be resolved on .NET Framework without
+// explicitly using the fully qualified name, which falls afoul of the simplify warning.
+using ComIUnknown = Windows.Win32.System.Com.IUnknown;
+
+namespace Microsoft.VisualStudio.Debugging.DebugInterfaceAccess;
+
+/// <inheritdoc cref="Interface"/>
+public unsafe struct IDiaSymbol8 : IComIID
+{
+    /// <inheritdoc cref="IComIID.Guid"/>
+#pragma warning disable IDE1006 // Naming Styles
+    public static readonly Guid IID_Guid = new(0x7F2E041F, 0x1294, 0x41BD, 0xB8, 0x3A, 0xE7, 0x15, 0x97, 0x2D, 0x2C, 0xE3);
+#pragma warning restore IDE1006
+
+#if NETFRAMEWORK
+    readonly ref readonly Guid IComIID.Guid => ref IID_Guid;
+#else
+    static ref readonly Guid IComIID.Guid
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get
+        {
+            ReadOnlySpan<byte> data =
+            [
+                0x1F, 0x04, 0x2E, 0x7F,
+                0x94, 0x12,
+                0xBD, 0x41,
+                0xB8, 0x3A, 0xE7, 0x15, 0x97, 0x2D, 0x2C, 0xE3
+            ];
+
+            return ref Unsafe.As<byte, Guid>(ref MemoryMarshal.GetReference(data));
+        }
+    }
+#endif
+
+    private readonly void** _lpVtbl;
+
+    /// <inheritdoc cref="ComIUnknown.QueryInterface(Guid*, void**)"/>
+    public HRESULT QueryInterface(Guid* riid, void** ppvObject)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, Guid*, void**, HRESULT>)_lpVtbl[0])(pThis, riid, ppvObject);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.AddRef"/>
+    public uint AddRef()
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, uint>)_lpVtbl[1])(pThis);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.Release"/>
+    public uint Release()
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, uint>)_lpVtbl[2])(pThis);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_symIndexId"/>
+    public HRESULT get_symIndexId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, uint*, HRESULT>)_lpVtbl[3])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_symTag"/>
+    public HRESULT get_symTag(uint* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, uint*, HRESULT>)_lpVtbl[4])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_name"/>
+    public HRESULT get_name(BSTR* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BSTR*, HRESULT>)_lpVtbl[5])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_lexicalParent"/>
+    public HRESULT get_lexicalParent(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, IDiaSymbol**, HRESULT>)_lpVtbl[6])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_classParent"/>
+    public HRESULT get_classParent(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, IDiaSymbol**, HRESULT>)_lpVtbl[7])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_type"/>
+    public HRESULT get_type(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, IDiaSymbol**, HRESULT>)_lpVtbl[8])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_dataKind"/>
+    public HRESULT get_dataKind(uint* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, uint*, HRESULT>)_lpVtbl[9])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_locationType"/>
+    public HRESULT get_locationType(uint* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, uint*, HRESULT>)_lpVtbl[10])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_addressSection"/>
+    public HRESULT get_addressSection(uint* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, uint*, HRESULT>)_lpVtbl[11])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_addressOffset"/>
+    public HRESULT get_addressOffset(uint* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, uint*, HRESULT>)_lpVtbl[12])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_relativeVirtualAddress"/>
+    public HRESULT get_relativeVirtualAddress(uint* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, uint*, HRESULT>)_lpVtbl[13])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_virtualAddress"/>
+    public HRESULT get_virtualAddress(ulong* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, ulong*, HRESULT>)_lpVtbl[14])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_registerId"/>
+    public HRESULT get_registerId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, uint*, HRESULT>)_lpVtbl[15])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_offset"/>
+    public HRESULT get_offset(int* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, int*, HRESULT>)_lpVtbl[16])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_length"/>
+    public HRESULT get_length(ulong* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, ulong*, HRESULT>)_lpVtbl[17])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_slot"/>
+    public HRESULT get_slot(uint* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, uint*, HRESULT>)_lpVtbl[18])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_volatileType"/>
+    public HRESULT get_volatileType(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BOOL*, HRESULT>)_lpVtbl[19])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_constType"/>
+    public HRESULT get_constType(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BOOL*, HRESULT>)_lpVtbl[20])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_unalignedType"/>
+    public HRESULT get_unalignedType(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BOOL*, HRESULT>)_lpVtbl[21])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_access"/>
+    public HRESULT get_access(uint* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, uint*, HRESULT>)_lpVtbl[22])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_libraryName"/>
+    public HRESULT get_libraryName(BSTR* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BSTR*, HRESULT>)_lpVtbl[23])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_platform"/>
+    public HRESULT get_platform(uint* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, uint*, HRESULT>)_lpVtbl[24])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_language"/>
+    public HRESULT get_language(uint* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, uint*, HRESULT>)_lpVtbl[25])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_editAndContinueEnabled"/>
+    public HRESULT get_editAndContinueEnabled(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BOOL*, HRESULT>)_lpVtbl[26])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_frontEndMajor"/>
+    public HRESULT get_frontEndMajor(uint* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, uint*, HRESULT>)_lpVtbl[27])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_frontEndMinor"/>
+    public HRESULT get_frontEndMinor(uint* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, uint*, HRESULT>)_lpVtbl[28])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_frontEndBuild"/>
+    public HRESULT get_frontEndBuild(uint* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, uint*, HRESULT>)_lpVtbl[29])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_backEndMajor"/>
+    public HRESULT get_backEndMajor(uint* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, uint*, HRESULT>)_lpVtbl[30])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_backEndMinor"/>
+    public HRESULT get_backEndMinor(uint* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, uint*, HRESULT>)_lpVtbl[31])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_backEndBuild"/>
+    public HRESULT get_backEndBuild(uint* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, uint*, HRESULT>)_lpVtbl[32])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_sourceFileName"/>
+    public HRESULT get_sourceFileName(BSTR* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BSTR*, HRESULT>)_lpVtbl[33])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_unused"/>
+    public HRESULT get_unused(BSTR* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BSTR*, HRESULT>)_lpVtbl[34])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_thunkOrdinal"/>
+    public HRESULT get_thunkOrdinal(uint* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, uint*, HRESULT>)_lpVtbl[35])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_thisAdjust"/>
+    public HRESULT get_thisAdjust(int* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, int*, HRESULT>)_lpVtbl[36])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_virtualBaseOffset"/>
+    public HRESULT get_virtualBaseOffset(uint* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, uint*, HRESULT>)_lpVtbl[37])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_virtual"/>
+    public HRESULT get_virtual(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BOOL*, HRESULT>)_lpVtbl[38])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_intro"/>
+    public HRESULT get_intro(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BOOL*, HRESULT>)_lpVtbl[39])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_pure"/>
+    public HRESULT get_pure(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BOOL*, HRESULT>)_lpVtbl[40])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_callingConvention"/>
+    public HRESULT get_callingConvention(uint* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, uint*, HRESULT>)_lpVtbl[41])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_value"/>
+    public HRESULT get_value(VARIANT* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, VARIANT*, HRESULT>)_lpVtbl[42])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_baseType"/>
+    public HRESULT get_baseType(uint* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, uint*, HRESULT>)_lpVtbl[43])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_token"/>
+    public HRESULT get_token(uint* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, uint*, HRESULT>)_lpVtbl[44])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_timeStamp"/>
+    public HRESULT get_timeStamp(uint* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, uint*, HRESULT>)_lpVtbl[45])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_guid"/>
+    public HRESULT get_guid(Guid* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, Guid*, HRESULT>)_lpVtbl[46])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_symbolsFileName"/>
+    public HRESULT get_symbolsFileName(BSTR* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BSTR*, HRESULT>)_lpVtbl[47])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_reference"/>
+    public HRESULT get_reference(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BOOL*, HRESULT>)_lpVtbl[48])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_count"/>
+    public HRESULT get_count(uint* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, uint*, HRESULT>)_lpVtbl[49])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_bitPosition"/>
+    public HRESULT get_bitPosition(uint* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, uint*, HRESULT>)_lpVtbl[50])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_arrayIndexType"/>
+    public HRESULT get_arrayIndexType(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, IDiaSymbol**, HRESULT>)_lpVtbl[51])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_packed"/>
+    public HRESULT get_packed(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BOOL*, HRESULT>)_lpVtbl[52])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_constructor"/>
+    public HRESULT get_constructor(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BOOL*, HRESULT>)_lpVtbl[53])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_overloadedOperator"/>
+    public HRESULT get_overloadedOperator(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BOOL*, HRESULT>)_lpVtbl[54])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_nested"/>
+    public HRESULT get_nested(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BOOL*, HRESULT>)_lpVtbl[55])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasNestedTypes"/>
+    public HRESULT get_hasNestedTypes(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BOOL*, HRESULT>)_lpVtbl[56])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasAssignmentOperator"/>
+    public HRESULT get_hasAssignmentOperator(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BOOL*, HRESULT>)_lpVtbl[57])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasCastOperator"/>
+    public HRESULT get_hasCastOperator(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BOOL*, HRESULT>)_lpVtbl[58])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_scoped"/>
+    public HRESULT get_scoped(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BOOL*, HRESULT>)_lpVtbl[59])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_virtualBaseClass"/>
+    public HRESULT get_virtualBaseClass(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BOOL*, HRESULT>)_lpVtbl[60])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_indirectVirtualBaseClass"/>
+    public HRESULT get_indirectVirtualBaseClass(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BOOL*, HRESULT>)_lpVtbl[61])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_virtualBasePointerOffset"/>
+    public HRESULT get_virtualBasePointerOffset(int* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, int*, HRESULT>)_lpVtbl[62])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_virtualTableShape"/>
+    public HRESULT get_virtualTableShape(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, IDiaSymbol**, HRESULT>)_lpVtbl[63])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_lexicalParentId"/>
+    public HRESULT get_lexicalParentId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, uint*, HRESULT>)_lpVtbl[64])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_classParentId"/>
+    public HRESULT get_classParentId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, uint*, HRESULT>)_lpVtbl[65])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_typeId"/>
+    public HRESULT get_typeId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, uint*, HRESULT>)_lpVtbl[66])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_arrayIndexTypeId"/>
+    public HRESULT get_arrayIndexTypeId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, uint*, HRESULT>)_lpVtbl[67])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_virtualTableShapeId"/>
+    public HRESULT get_virtualTableShapeId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, uint*, HRESULT>)_lpVtbl[68])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_code"/>
+    public HRESULT get_code(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BOOL*, HRESULT>)_lpVtbl[69])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_function"/>
+    public HRESULT get_function(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BOOL*, HRESULT>)_lpVtbl[70])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_managed"/>
+    public HRESULT get_managed(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BOOL*, HRESULT>)_lpVtbl[71])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_msil"/>
+    public HRESULT get_msil(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BOOL*, HRESULT>)_lpVtbl[72])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_virtualBaseDispIndex"/>
+    public HRESULT get_virtualBaseDispIndex(uint* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, uint*, HRESULT>)_lpVtbl[73])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_undecoratedName"/>
+    public HRESULT get_undecoratedName(BSTR* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BSTR*, HRESULT>)_lpVtbl[74])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_age"/>
+    public HRESULT get_age(uint* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, uint*, HRESULT>)_lpVtbl[75])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_signature"/>
+    public HRESULT get_signature(uint* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, uint*, HRESULT>)_lpVtbl[76])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_compilerGenerated"/>
+    public HRESULT get_compilerGenerated(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BOOL*, HRESULT>)_lpVtbl[77])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_addressTaken"/>
+    public HRESULT get_addressTaken(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BOOL*, HRESULT>)_lpVtbl[78])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_rank"/>
+    public HRESULT get_rank(uint* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, uint*, HRESULT>)_lpVtbl[79])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_lowerBound"/>
+    public HRESULT get_lowerBound(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, IDiaSymbol**, HRESULT>)_lpVtbl[80])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_upperBound"/>
+    public HRESULT get_upperBound(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, IDiaSymbol**, HRESULT>)_lpVtbl[81])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_lowerBoundId"/>
+    public HRESULT get_lowerBoundId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, uint*, HRESULT>)_lpVtbl[82])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_upperBoundId"/>
+    public HRESULT get_upperBoundId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, uint*, HRESULT>)_lpVtbl[83])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_dataBytes"/>
+    public HRESULT get_dataBytes(uint cbData, uint* pcbData, byte* pbData)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, uint, uint*, byte*, HRESULT>)_lpVtbl[84])(pThis, cbData, pcbData, pbData);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findChildren"/>
+    public HRESULT findChildren(SymTagEnum symtag, PCWSTR name, uint compareFlags, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, SymTagEnum, PCWSTR, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[85])(pThis, symtag, name, compareFlags, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findChildrenEx"/>
+    public HRESULT findChildrenEx(SymTagEnum symtag, PCWSTR name, uint compareFlags, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, SymTagEnum, PCWSTR, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[86])(pThis, symtag, name, compareFlags, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findChildrenExByAddr"/>
+    public HRESULT findChildrenExByAddr(SymTagEnum symtag, PCWSTR name, uint compareFlags, uint isect, uint offset, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, SymTagEnum, PCWSTR, uint, uint, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[87])(pThis, symtag, name, compareFlags, isect, offset, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findChildrenExByVA"/>
+    public HRESULT findChildrenExByVA(SymTagEnum symtag, PCWSTR name, uint compareFlags, ulong va, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, SymTagEnum, PCWSTR, uint, ulong, IDiaEnumSymbols**, HRESULT>)_lpVtbl[88])(pThis, symtag, name, compareFlags, va, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findChildrenExByRVA"/>
+    public HRESULT findChildrenExByRVA(SymTagEnum symtag, PCWSTR name, uint compareFlags, uint rva, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, SymTagEnum, PCWSTR, uint, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[89])(pThis, symtag, name, compareFlags, rva, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_targetSection"/>
+    public HRESULT get_targetSection(uint* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, uint*, HRESULT>)_lpVtbl[90])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_targetOffset"/>
+    public HRESULT get_targetOffset(uint* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, uint*, HRESULT>)_lpVtbl[91])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_targetRelativeVirtualAddress"/>
+    public HRESULT get_targetRelativeVirtualAddress(uint* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, uint*, HRESULT>)_lpVtbl[92])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_targetVirtualAddress"/>
+    public HRESULT get_targetVirtualAddress(ulong* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, ulong*, HRESULT>)_lpVtbl[93])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_machineType"/>
+    public HRESULT get_machineType(uint* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, uint*, HRESULT>)_lpVtbl[94])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_oemId"/>
+    public HRESULT get_oemId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, uint*, HRESULT>)_lpVtbl[95])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_oemSymbolId"/>
+    public HRESULT get_oemSymbolId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, uint*, HRESULT>)_lpVtbl[96])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_types"/>
+    public HRESULT get_types(uint cTypes, uint* pcTypes, IDiaSymbol** pTypes)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, uint, uint*, IDiaSymbol**, HRESULT>)_lpVtbl[97])(pThis, cTypes, pcTypes, pTypes);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_typeIds"/>
+    public HRESULT get_typeIds(uint cTypeIds, uint* pcTypeIds, uint* pdwTypeIds)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, uint, uint*, uint*, HRESULT>)_lpVtbl[98])(pThis, cTypeIds, pcTypeIds, pdwTypeIds);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_objectPointerType"/>
+    public HRESULT get_objectPointerType(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, IDiaSymbol**, HRESULT>)_lpVtbl[99])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_udtKind"/>
+    public HRESULT get_udtKind(uint* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, uint*, HRESULT>)_lpVtbl[100])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_undecoratedNameEx"/>
+    public HRESULT get_undecoratedNameEx(uint undecorateOptions, BSTR* name)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, uint, BSTR*, HRESULT>)_lpVtbl[101])(pThis, undecorateOptions, name);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_noReturn"/>
+    public HRESULT get_noReturn(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BOOL*, HRESULT>)_lpVtbl[102])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_customCallingConvention"/>
+    public HRESULT get_customCallingConvention(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BOOL*, HRESULT>)_lpVtbl[103])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_noInline"/>
+    public HRESULT get_noInline(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BOOL*, HRESULT>)_lpVtbl[104])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_optimizedCodeDebugInfo"/>
+    public HRESULT get_optimizedCodeDebugInfo(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BOOL*, HRESULT>)_lpVtbl[105])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_notReached"/>
+    public HRESULT get_notReached(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BOOL*, HRESULT>)_lpVtbl[106])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_interruptReturn"/>
+    public HRESULT get_interruptReturn(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BOOL*, HRESULT>)_lpVtbl[107])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_farReturn"/>
+    public HRESULT get_farReturn(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BOOL*, HRESULT>)_lpVtbl[108])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isStatic"/>
+    public HRESULT get_isStatic(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BOOL*, HRESULT>)_lpVtbl[109])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasDebugInfo"/>
+    public HRESULT get_hasDebugInfo(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BOOL*, HRESULT>)_lpVtbl[110])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isLTCG"/>
+    public HRESULT get_isLTCG(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BOOL*, HRESULT>)_lpVtbl[111])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isDataAligned"/>
+    public HRESULT get_isDataAligned(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BOOL*, HRESULT>)_lpVtbl[112])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasSecurityChecks"/>
+    public HRESULT get_hasSecurityChecks(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BOOL*, HRESULT>)_lpVtbl[113])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_compilerName"/>
+    public HRESULT get_compilerName(BSTR* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BSTR*, HRESULT>)_lpVtbl[114])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasAlloca"/>
+    public HRESULT get_hasAlloca(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BOOL*, HRESULT>)_lpVtbl[115])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasSetJump"/>
+    public HRESULT get_hasSetJump(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BOOL*, HRESULT>)_lpVtbl[116])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasLongJump"/>
+    public HRESULT get_hasLongJump(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BOOL*, HRESULT>)_lpVtbl[117])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasInlAsm"/>
+    public HRESULT get_hasInlAsm(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BOOL*, HRESULT>)_lpVtbl[118])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasEH"/>
+    public HRESULT get_hasEH(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BOOL*, HRESULT>)_lpVtbl[119])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasSEH"/>
+    public HRESULT get_hasSEH(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BOOL*, HRESULT>)_lpVtbl[120])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasEHa"/>
+    public HRESULT get_hasEHa(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BOOL*, HRESULT>)_lpVtbl[121])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isNaked"/>
+    public HRESULT get_isNaked(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BOOL*, HRESULT>)_lpVtbl[122])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isAggregated"/>
+    public HRESULT get_isAggregated(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BOOL*, HRESULT>)_lpVtbl[123])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isSplitted"/>
+    public HRESULT get_isSplitted(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BOOL*, HRESULT>)_lpVtbl[124])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_container"/>
+    public HRESULT get_container(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, IDiaSymbol**, HRESULT>)_lpVtbl[125])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_inlSpec"/>
+    public HRESULT get_inlSpec(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BOOL*, HRESULT>)_lpVtbl[126])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_noStackOrdering"/>
+    public HRESULT get_noStackOrdering(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BOOL*, HRESULT>)_lpVtbl[127])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_virtualBaseTableType"/>
+    public HRESULT get_virtualBaseTableType(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, IDiaSymbol**, HRESULT>)_lpVtbl[128])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasManagedCode"/>
+    public HRESULT get_hasManagedCode(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BOOL*, HRESULT>)_lpVtbl[129])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isHotpatchable"/>
+    public HRESULT get_isHotpatchable(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BOOL*, HRESULT>)_lpVtbl[130])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isCVTCIL"/>
+    public HRESULT get_isCVTCIL(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BOOL*, HRESULT>)_lpVtbl[131])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isMSILNetmodule"/>
+    public HRESULT get_isMSILNetmodule(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BOOL*, HRESULT>)_lpVtbl[132])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isCTypes"/>
+    public HRESULT get_isCTypes(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BOOL*, HRESULT>)_lpVtbl[133])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isStripped"/>
+    public HRESULT get_isStripped(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BOOL*, HRESULT>)_lpVtbl[134])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_frontEndQFE"/>
+    public HRESULT get_frontEndQFE(uint* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, uint*, HRESULT>)_lpVtbl[135])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_backEndQFE"/>
+    public HRESULT get_backEndQFE(uint* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, uint*, HRESULT>)_lpVtbl[136])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_wasInlined"/>
+    public HRESULT get_wasInlined(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BOOL*, HRESULT>)_lpVtbl[137])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_strictGSCheck"/>
+    public HRESULT get_strictGSCheck(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BOOL*, HRESULT>)_lpVtbl[138])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isCxxReturnUdt"/>
+    public HRESULT get_isCxxReturnUdt(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BOOL*, HRESULT>)_lpVtbl[139])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isConstructorVirtualBase"/>
+    public HRESULT get_isConstructorVirtualBase(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BOOL*, HRESULT>)_lpVtbl[140])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_RValueReference"/>
+    public HRESULT get_RValueReference(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BOOL*, HRESULT>)_lpVtbl[141])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_unmodifiedType"/>
+    public HRESULT get_unmodifiedType(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, IDiaSymbol**, HRESULT>)_lpVtbl[142])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_framePointerPresent"/>
+    public HRESULT get_framePointerPresent(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BOOL*, HRESULT>)_lpVtbl[143])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isSafeBuffers"/>
+    public HRESULT get_isSafeBuffers(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BOOL*, HRESULT>)_lpVtbl[144])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_intrinsic"/>
+    public HRESULT get_intrinsic(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BOOL*, HRESULT>)_lpVtbl[145])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_sealed"/>
+    public HRESULT get_sealed(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BOOL*, HRESULT>)_lpVtbl[146])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hfaFloat"/>
+    public HRESULT get_hfaFloat(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BOOL*, HRESULT>)_lpVtbl[147])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hfaDouble"/>
+    public HRESULT get_hfaDouble(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BOOL*, HRESULT>)_lpVtbl[148])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_liveRangeStartAddressSection"/>
+    public HRESULT get_liveRangeStartAddressSection(uint* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, uint*, HRESULT>)_lpVtbl[149])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_liveRangeStartAddressOffset"/>
+    public HRESULT get_liveRangeStartAddressOffset(uint* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, uint*, HRESULT>)_lpVtbl[150])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_liveRangeStartRelativeVirtualAddress"/>
+    public HRESULT get_liveRangeStartRelativeVirtualAddress(uint* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, uint*, HRESULT>)_lpVtbl[151])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_countLiveRanges"/>
+    public HRESULT get_countLiveRanges(uint* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, uint*, HRESULT>)_lpVtbl[152])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_liveRangeLength"/>
+    public HRESULT get_liveRangeLength(ulong* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, ulong*, HRESULT>)_lpVtbl[153])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_offsetInUdt"/>
+    public HRESULT get_offsetInUdt(uint* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, uint*, HRESULT>)_lpVtbl[154])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_paramBasePointerRegisterId"/>
+    public HRESULT get_paramBasePointerRegisterId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, uint*, HRESULT>)_lpVtbl[155])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_localBasePointerRegisterId"/>
+    public HRESULT get_localBasePointerRegisterId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, uint*, HRESULT>)_lpVtbl[156])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isLocationControlFlowDependent"/>
+    public HRESULT get_isLocationControlFlowDependent(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BOOL*, HRESULT>)_lpVtbl[157])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_stride"/>
+    public HRESULT get_stride(uint* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, uint*, HRESULT>)_lpVtbl[158])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_numberOfRows"/>
+    public HRESULT get_numberOfRows(uint* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, uint*, HRESULT>)_lpVtbl[159])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_numberOfColumns"/>
+    public HRESULT get_numberOfColumns(uint* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, uint*, HRESULT>)_lpVtbl[160])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isMatrixRowMajor"/>
+    public HRESULT get_isMatrixRowMajor(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BOOL*, HRESULT>)_lpVtbl[161])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_numericProperties"/>
+    public HRESULT get_numericProperties(uint cnt, uint* pcnt, uint* pProperties)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, uint, uint*, uint*, HRESULT>)_lpVtbl[162])(pThis, cnt, pcnt, pProperties);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_modifierValues"/>
+    public HRESULT get_modifierValues(uint cnt, uint* pcnt, ushort* pModifiers)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, uint, uint*, ushort*, HRESULT>)_lpVtbl[163])(pThis, cnt, pcnt, pModifiers);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isReturnValue"/>
+    public HRESULT get_isReturnValue(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BOOL*, HRESULT>)_lpVtbl[164])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isOptimizedAway"/>
+    public HRESULT get_isOptimizedAway(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BOOL*, HRESULT>)_lpVtbl[165])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_builtInKind"/>
+    public HRESULT get_builtInKind(uint* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, uint*, HRESULT>)_lpVtbl[166])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_registerType"/>
+    public HRESULT get_registerType(uint* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, uint*, HRESULT>)_lpVtbl[167])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_baseDataSlot"/>
+    public HRESULT get_baseDataSlot(uint* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, uint*, HRESULT>)_lpVtbl[168])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_baseDataOffset"/>
+    public HRESULT get_baseDataOffset(uint* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, uint*, HRESULT>)_lpVtbl[169])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_textureSlot"/>
+    public HRESULT get_textureSlot(uint* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, uint*, HRESULT>)_lpVtbl[170])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_samplerSlot"/>
+    public HRESULT get_samplerSlot(uint* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, uint*, HRESULT>)_lpVtbl[171])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_uavSlot"/>
+    public HRESULT get_uavSlot(uint* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, uint*, HRESULT>)_lpVtbl[172])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_sizeInUdt"/>
+    public HRESULT get_sizeInUdt(uint* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, uint*, HRESULT>)_lpVtbl[173])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_memorySpaceKind"/>
+    public HRESULT get_memorySpaceKind(uint* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, uint*, HRESULT>)_lpVtbl[174])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_unmodifiedTypeId"/>
+    public HRESULT get_unmodifiedTypeId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, uint*, HRESULT>)_lpVtbl[175])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_subTypeId"/>
+    public HRESULT get_subTypeId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, uint*, HRESULT>)_lpVtbl[176])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_subType"/>
+    public HRESULT get_subType(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, IDiaSymbol**, HRESULT>)_lpVtbl[177])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_numberOfModifiers"/>
+    public HRESULT get_numberOfModifiers(uint* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, uint*, HRESULT>)_lpVtbl[178])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_numberOfRegisterIndices"/>
+    public HRESULT get_numberOfRegisterIndices(uint* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, uint*, HRESULT>)_lpVtbl[179])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isHLSLData"/>
+    public HRESULT get_isHLSLData(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BOOL*, HRESULT>)_lpVtbl[180])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isPointerToDataMember"/>
+    public HRESULT get_isPointerToDataMember(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BOOL*, HRESULT>)_lpVtbl[181])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isPointerToMemberFunction"/>
+    public HRESULT get_isPointerToMemberFunction(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BOOL*, HRESULT>)_lpVtbl[182])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isSingleInheritance"/>
+    public HRESULT get_isSingleInheritance(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BOOL*, HRESULT>)_lpVtbl[183])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isMultipleInheritance"/>
+    public HRESULT get_isMultipleInheritance(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BOOL*, HRESULT>)_lpVtbl[184])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isVirtualInheritance"/>
+    public HRESULT get_isVirtualInheritance(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BOOL*, HRESULT>)_lpVtbl[185])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_restrictedType"/>
+    public HRESULT get_restrictedType(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BOOL*, HRESULT>)_lpVtbl[186])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isPointerBasedOnSymbolValue"/>
+    public HRESULT get_isPointerBasedOnSymbolValue(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BOOL*, HRESULT>)_lpVtbl[187])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_baseSymbol"/>
+    public HRESULT get_baseSymbol(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, IDiaSymbol**, HRESULT>)_lpVtbl[188])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_baseSymbolId"/>
+    public HRESULT get_baseSymbolId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, uint*, HRESULT>)_lpVtbl[189])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_objectFileName"/>
+    public HRESULT get_objectFileName(BSTR* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BSTR*, HRESULT>)_lpVtbl[190])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isAcceleratorGroupSharedLocal"/>
+    public HRESULT get_isAcceleratorGroupSharedLocal(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BOOL*, HRESULT>)_lpVtbl[191])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isAcceleratorPointerTagLiveRange"/>
+    public HRESULT get_isAcceleratorPointerTagLiveRange(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BOOL*, HRESULT>)_lpVtbl[192])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isAcceleratorStubFunction"/>
+    public HRESULT get_isAcceleratorStubFunction(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BOOL*, HRESULT>)_lpVtbl[193])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_numberOfAcceleratorPointerTags"/>
+    public HRESULT get_numberOfAcceleratorPointerTags(uint* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, uint*, HRESULT>)_lpVtbl[194])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isSdl"/>
+    public HRESULT get_isSdl(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BOOL*, HRESULT>)_lpVtbl[195])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isWinRTPointer"/>
+    public HRESULT get_isWinRTPointer(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BOOL*, HRESULT>)_lpVtbl[196])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isRefUdt"/>
+    public HRESULT get_isRefUdt(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BOOL*, HRESULT>)_lpVtbl[197])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isValueUdt"/>
+    public HRESULT get_isValueUdt(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BOOL*, HRESULT>)_lpVtbl[198])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isInterfaceUdt"/>
+    public HRESULT get_isInterfaceUdt(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BOOL*, HRESULT>)_lpVtbl[199])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findInlineFramesByAddr"/>
+    public HRESULT findInlineFramesByAddr(uint isect, uint offset, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, uint, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[200])(pThis, isect, offset, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findInlineFramesByRVA"/>
+    public HRESULT findInlineFramesByRVA(uint rva, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[201])(pThis, rva, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findInlineFramesByVA"/>
+    public HRESULT findInlineFramesByVA(ulong va, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, ulong, IDiaEnumSymbols**, HRESULT>)_lpVtbl[202])(pThis, va, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findInlineeLines"/>
+    public HRESULT findInlineeLines(IDiaEnumLineNumbers** ppResult)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, IDiaEnumLineNumbers**, HRESULT>)_lpVtbl[203])(pThis, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findInlineeLinesByAddr"/>
+    public HRESULT findInlineeLinesByAddr(uint isect, uint offset, uint length, IDiaEnumLineNumbers** ppResult)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, uint, uint, uint, IDiaEnumLineNumbers**, HRESULT>)_lpVtbl[204])(pThis, isect, offset, length, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findInlineeLinesByRVA"/>
+    public HRESULT findInlineeLinesByRVA(uint rva, uint length, IDiaEnumLineNumbers** ppResult)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, uint, uint, IDiaEnumLineNumbers**, HRESULT>)_lpVtbl[205])(pThis, rva, length, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findInlineeLinesByVA"/>
+    public HRESULT findInlineeLinesByVA(ulong va, uint length, IDiaEnumLineNumbers** ppResult)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, ulong, uint, IDiaEnumLineNumbers**, HRESULT>)_lpVtbl[206])(pThis, va, length, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findSymbolsForAcceleratorPointerTag"/>
+    public HRESULT findSymbolsForAcceleratorPointerTag(uint tagValue, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[207])(pThis, tagValue, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findSymbolsByRVAForAcceleratorPointerTag"/>
+    public HRESULT findSymbolsByRVAForAcceleratorPointerTag(uint tagValue, uint rva, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, uint, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[208])(pThis, tagValue, rva, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_acceleratorPointerTags"/>
+    public HRESULT get_acceleratorPointerTags(uint cnt, uint* pcnt, uint* pPointerTags)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, uint, uint*, uint*, HRESULT>)_lpVtbl[209])(pThis, cnt, pcnt, pPointerTags);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.getSrcLineOnTypeDefn"/>
+    public HRESULT getSrcLineOnTypeDefn(IDiaLineNumber** ppResult)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, IDiaLineNumber**, HRESULT>)_lpVtbl[210])(pThis, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isPGO"/>
+    public HRESULT get_isPGO(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BOOL*, HRESULT>)_lpVtbl[211])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasValidPGOCounts"/>
+    public HRESULT get_hasValidPGOCounts(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BOOL*, HRESULT>)_lpVtbl[212])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isOptimizedForSpeed"/>
+    public HRESULT get_isOptimizedForSpeed(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BOOL*, HRESULT>)_lpVtbl[213])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_PGOEntryCount"/>
+    public HRESULT get_PGOEntryCount(uint* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, uint*, HRESULT>)_lpVtbl[214])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_PGOEdgeCount"/>
+    public HRESULT get_PGOEdgeCount(uint* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, uint*, HRESULT>)_lpVtbl[215])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_PGODynamicInstructionCount"/>
+    public HRESULT get_PGODynamicInstructionCount(ulong* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, ulong*, HRESULT>)_lpVtbl[216])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_staticSize"/>
+    public HRESULT get_staticSize(uint* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, uint*, HRESULT>)_lpVtbl[217])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_finalLiveStaticSize"/>
+    public HRESULT get_finalLiveStaticSize(uint* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, uint*, HRESULT>)_lpVtbl[218])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_phaseName"/>
+    public HRESULT get_phaseName(BSTR* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BSTR*, HRESULT>)_lpVtbl[219])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasControlFlowCheck"/>
+    public HRESULT get_hasControlFlowCheck(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BOOL*, HRESULT>)_lpVtbl[220])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_constantExport"/>
+    public HRESULT get_constantExport(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BOOL*, HRESULT>)_lpVtbl[221])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_dataExport"/>
+    public HRESULT get_dataExport(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BOOL*, HRESULT>)_lpVtbl[222])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_privateExport"/>
+    public HRESULT get_privateExport(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BOOL*, HRESULT>)_lpVtbl[223])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_noNameExport"/>
+    public HRESULT get_noNameExport(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BOOL*, HRESULT>)_lpVtbl[224])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_exportHasExplicitlyAssignedOrdinal"/>
+    public HRESULT get_exportHasExplicitlyAssignedOrdinal(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BOOL*, HRESULT>)_lpVtbl[225])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_exportIsForwarder"/>
+    public HRESULT get_exportIsForwarder(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BOOL*, HRESULT>)_lpVtbl[226])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_ordinal"/>
+    public HRESULT get_ordinal(uint* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, uint*, HRESULT>)_lpVtbl[227])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_frameSize"/>
+    public HRESULT get_frameSize(uint* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, uint*, HRESULT>)_lpVtbl[228])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_exceptionHandlerAddressSection"/>
+    public HRESULT get_exceptionHandlerAddressSection(uint* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, uint*, HRESULT>)_lpVtbl[229])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_exceptionHandlerAddressOffset"/>
+    public HRESULT get_exceptionHandlerAddressOffset(uint* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, uint*, HRESULT>)_lpVtbl[230])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_exceptionHandlerRelativeVirtualAddress"/>
+    public HRESULT get_exceptionHandlerRelativeVirtualAddress(uint* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, uint*, HRESULT>)_lpVtbl[231])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_exceptionHandlerVirtualAddress"/>
+    public HRESULT get_exceptionHandlerVirtualAddress(ulong* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, ulong*, HRESULT>)_lpVtbl[232])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findInputAssemblyFile"/>
+    public HRESULT findInputAssemblyFile(IDiaInputAssemblyFile** ppResult)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, IDiaInputAssemblyFile**, HRESULT>)_lpVtbl[233])(pThis, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_characteristics"/>
+    public HRESULT get_characteristics(uint* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, uint*, HRESULT>)_lpVtbl[234])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_coffGroup"/>
+    public HRESULT get_coffGroup(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, IDiaSymbol**, HRESULT>)_lpVtbl[235])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_bindID"/>
+    public HRESULT get_bindID(uint* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, uint*, HRESULT>)_lpVtbl[236])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_bindSpace"/>
+    public HRESULT get_bindSpace(uint* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, uint*, HRESULT>)_lpVtbl[237])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_bindSlot"/>
+    public HRESULT get_bindSlot(uint* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, uint*, HRESULT>)_lpVtbl[238])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol2.Interface.get_isObjCClass"/>
+    public HRESULT get_isObjCClass(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BOOL*, HRESULT>)_lpVtbl[239])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol2.Interface.get_isObjCCategory"/>
+    public HRESULT get_isObjCCategory(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BOOL*, HRESULT>)_lpVtbl[240])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol2.Interface.get_isObjCProtocol"/>
+    public HRESULT get_isObjCProtocol(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BOOL*, HRESULT>)_lpVtbl[241])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol3.Interface.get_inlinee"/>
+    public HRESULT get_inlinee(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, IDiaSymbol**, HRESULT>)_lpVtbl[242])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol3.Interface.get_inlineeId"/>
+    public HRESULT get_inlineeId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, uint*, HRESULT>)_lpVtbl[243])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol4.Interface.get_noexcept"/>
+    public HRESULT get_noexcept(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BOOL*, HRESULT>)_lpVtbl[244])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol5.Interface.get_hasAbsoluteAddress"/>
+    public HRESULT get_hasAbsoluteAddress(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BOOL*, HRESULT>)_lpVtbl[245])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol6.Interface.get_isStaticMemberFunc"/>
+    public HRESULT get_isStaticMemberFunc(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BOOL*, HRESULT>)_lpVtbl[246])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol7.Interface.get_isSignRet"/>
+    public HRESULT get_isSignRet(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, BOOL*, HRESULT>)_lpVtbl[247])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_coroutineKind"/>
+    public HRESULT get_coroutineKind(uint* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, uint*, HRESULT>)_lpVtbl[248])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_associatedSymbolKind"/>
+    public HRESULT get_associatedSymbolKind(uint* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, uint*, HRESULT>)_lpVtbl[249])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_associatedSymbolSection"/>
+    public HRESULT get_associatedSymbolSection(uint* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, uint*, HRESULT>)_lpVtbl[250])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_associatedSymbolOffset"/>
+    public HRESULT get_associatedSymbolOffset(uint* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, uint*, HRESULT>)_lpVtbl[251])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_associatedSymbolRva"/>
+    public HRESULT get_associatedSymbolRva(uint* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, uint*, HRESULT>)_lpVtbl[252])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_associatedSymbolAddr"/>
+    public HRESULT get_associatedSymbolAddr(ulong* pRetVal)
+    {
+        fixed (IDiaSymbol8* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol8*, ulong*, HRESULT>)_lpVtbl[253])(pThis, pRetVal);
+    }
+
+    /// <summary>
+    ///  Extends IDiaSymbol7 with coroutine and associated symbol properties.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/visualstudio/debugger/debug-interface-access/idiasymbol8">
+    ///    Official documentation.
+    ///   </see>
+    ///  </para>
+    /// </remarks>
+    [ComImport]
+    [Guid("7F2E041F-1294-41BD-B83A-E715972D2CE3")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    public unsafe interface Interface : IDiaSymbol7.Interface
+    {
+        /// <summary>
+        ///  Coroutine function kind.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_coroutineKind(uint* pRetVal);
+
+        /// <summary>
+        ///  Associated symbol kind.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_associatedSymbolKind(uint* pRetVal);
+
+        /// <summary>
+        ///  Associated symbol section.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_associatedSymbolSection(uint* pRetVal);
+
+        /// <summary>
+        ///  Associated symbol offset.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_associatedSymbolOffset(uint* pRetVal);
+
+        /// <summary>
+        ///  Associated symbol RVA.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_associatedSymbolRva(uint* pRetVal);
+
+        /// <summary>
+        ///  Associated symbol VA.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_associatedSymbolAddr(ulong* pRetVal);
+    }
+}

--- a/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaSymbol9.cs
+++ b/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaSymbol9.cs
@@ -1,0 +1,1883 @@
+﻿// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Runtime.InteropServices;
+using Windows.Win32.System.Variant;
+
+// For some reason the XML comment refs for IUnknown can't be resolved on .NET Framework without
+// explicitly using the fully qualified name, which falls afoul of the simplify warning.
+using ComIUnknown = Windows.Win32.System.Com.IUnknown;
+
+namespace Microsoft.VisualStudio.Debugging.DebugInterfaceAccess;
+
+/// <inheritdoc cref="Interface"/>
+public unsafe struct IDiaSymbol9 : IComIID
+{
+    /// <inheritdoc cref="IComIID.Guid"/>
+#pragma warning disable IDE1006 // Naming Styles
+    public static readonly Guid IID_Guid = new(0xA89E5969, 0x92A1, 0x4F8A, 0xB7, 0x04, 0x00, 0x12, 0x1C, 0x37, 0xAB, 0xBB);
+#pragma warning restore IDE1006
+
+#if NETFRAMEWORK
+    readonly ref readonly Guid IComIID.Guid => ref IID_Guid;
+#else
+    static ref readonly Guid IComIID.Guid
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get
+        {
+            ReadOnlySpan<byte> data =
+            [
+                0x69, 0x59, 0x9E, 0xA8,
+                0xA1, 0x92,
+                0x8A, 0x4F,
+                0xB7, 0x04, 0x00, 0x12, 0x1C, 0x37, 0xAB, 0xBB
+            ];
+
+            return ref Unsafe.As<byte, Guid>(ref MemoryMarshal.GetReference(data));
+        }
+    }
+#endif
+
+    private readonly void** _lpVtbl;
+
+    /// <inheritdoc cref="ComIUnknown.QueryInterface(Guid*, void**)"/>
+    public HRESULT QueryInterface(Guid* riid, void** ppvObject)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, Guid*, void**, HRESULT>)_lpVtbl[0])(pThis, riid, ppvObject);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.AddRef"/>
+    public uint AddRef()
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint>)_lpVtbl[1])(pThis);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.Release"/>
+    public uint Release()
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint>)_lpVtbl[2])(pThis);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_symIndexId"/>
+    public HRESULT get_symIndexId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint*, HRESULT>)_lpVtbl[3])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_symTag"/>
+    public HRESULT get_symTag(uint* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint*, HRESULT>)_lpVtbl[4])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_name"/>
+    public HRESULT get_name(BSTR* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BSTR*, HRESULT>)_lpVtbl[5])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_lexicalParent"/>
+    public HRESULT get_lexicalParent(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, IDiaSymbol**, HRESULT>)_lpVtbl[6])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_classParent"/>
+    public HRESULT get_classParent(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, IDiaSymbol**, HRESULT>)_lpVtbl[7])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_type"/>
+    public HRESULT get_type(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, IDiaSymbol**, HRESULT>)_lpVtbl[8])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_dataKind"/>
+    public HRESULT get_dataKind(uint* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint*, HRESULT>)_lpVtbl[9])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_locationType"/>
+    public HRESULT get_locationType(uint* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint*, HRESULT>)_lpVtbl[10])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_addressSection"/>
+    public HRESULT get_addressSection(uint* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint*, HRESULT>)_lpVtbl[11])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_addressOffset"/>
+    public HRESULT get_addressOffset(uint* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint*, HRESULT>)_lpVtbl[12])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_relativeVirtualAddress"/>
+    public HRESULT get_relativeVirtualAddress(uint* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint*, HRESULT>)_lpVtbl[13])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_virtualAddress"/>
+    public HRESULT get_virtualAddress(ulong* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, ulong*, HRESULT>)_lpVtbl[14])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_registerId"/>
+    public HRESULT get_registerId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint*, HRESULT>)_lpVtbl[15])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_offset"/>
+    public HRESULT get_offset(int* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, int*, HRESULT>)_lpVtbl[16])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_length"/>
+    public HRESULT get_length(ulong* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, ulong*, HRESULT>)_lpVtbl[17])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_slot"/>
+    public HRESULT get_slot(uint* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint*, HRESULT>)_lpVtbl[18])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_volatileType"/>
+    public HRESULT get_volatileType(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BOOL*, HRESULT>)_lpVtbl[19])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_constType"/>
+    public HRESULT get_constType(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BOOL*, HRESULT>)_lpVtbl[20])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_unalignedType"/>
+    public HRESULT get_unalignedType(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BOOL*, HRESULT>)_lpVtbl[21])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_access"/>
+    public HRESULT get_access(uint* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint*, HRESULT>)_lpVtbl[22])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_libraryName"/>
+    public HRESULT get_libraryName(BSTR* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BSTR*, HRESULT>)_lpVtbl[23])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_platform"/>
+    public HRESULT get_platform(uint* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint*, HRESULT>)_lpVtbl[24])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_language"/>
+    public HRESULT get_language(uint* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint*, HRESULT>)_lpVtbl[25])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_editAndContinueEnabled"/>
+    public HRESULT get_editAndContinueEnabled(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BOOL*, HRESULT>)_lpVtbl[26])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_frontEndMajor"/>
+    public HRESULT get_frontEndMajor(uint* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint*, HRESULT>)_lpVtbl[27])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_frontEndMinor"/>
+    public HRESULT get_frontEndMinor(uint* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint*, HRESULT>)_lpVtbl[28])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_frontEndBuild"/>
+    public HRESULT get_frontEndBuild(uint* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint*, HRESULT>)_lpVtbl[29])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_backEndMajor"/>
+    public HRESULT get_backEndMajor(uint* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint*, HRESULT>)_lpVtbl[30])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_backEndMinor"/>
+    public HRESULT get_backEndMinor(uint* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint*, HRESULT>)_lpVtbl[31])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_backEndBuild"/>
+    public HRESULT get_backEndBuild(uint* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint*, HRESULT>)_lpVtbl[32])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_sourceFileName"/>
+    public HRESULT get_sourceFileName(BSTR* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BSTR*, HRESULT>)_lpVtbl[33])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_unused"/>
+    public HRESULT get_unused(BSTR* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BSTR*, HRESULT>)_lpVtbl[34])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_thunkOrdinal"/>
+    public HRESULT get_thunkOrdinal(uint* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint*, HRESULT>)_lpVtbl[35])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_thisAdjust"/>
+    public HRESULT get_thisAdjust(int* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, int*, HRESULT>)_lpVtbl[36])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_virtualBaseOffset"/>
+    public HRESULT get_virtualBaseOffset(uint* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint*, HRESULT>)_lpVtbl[37])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_virtual"/>
+    public HRESULT get_virtual(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BOOL*, HRESULT>)_lpVtbl[38])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_intro"/>
+    public HRESULT get_intro(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BOOL*, HRESULT>)_lpVtbl[39])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_pure"/>
+    public HRESULT get_pure(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BOOL*, HRESULT>)_lpVtbl[40])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_callingConvention"/>
+    public HRESULT get_callingConvention(uint* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint*, HRESULT>)_lpVtbl[41])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_value"/>
+    public HRESULT get_value(VARIANT* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, VARIANT*, HRESULT>)_lpVtbl[42])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_baseType"/>
+    public HRESULT get_baseType(uint* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint*, HRESULT>)_lpVtbl[43])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_token"/>
+    public HRESULT get_token(uint* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint*, HRESULT>)_lpVtbl[44])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_timeStamp"/>
+    public HRESULT get_timeStamp(uint* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint*, HRESULT>)_lpVtbl[45])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_guid"/>
+    public HRESULT get_guid(Guid* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, Guid*, HRESULT>)_lpVtbl[46])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_symbolsFileName"/>
+    public HRESULT get_symbolsFileName(BSTR* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BSTR*, HRESULT>)_lpVtbl[47])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_reference"/>
+    public HRESULT get_reference(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BOOL*, HRESULT>)_lpVtbl[48])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_count"/>
+    public HRESULT get_count(uint* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint*, HRESULT>)_lpVtbl[49])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_bitPosition"/>
+    public HRESULT get_bitPosition(uint* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint*, HRESULT>)_lpVtbl[50])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_arrayIndexType"/>
+    public HRESULT get_arrayIndexType(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, IDiaSymbol**, HRESULT>)_lpVtbl[51])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_packed"/>
+    public HRESULT get_packed(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BOOL*, HRESULT>)_lpVtbl[52])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_constructor"/>
+    public HRESULT get_constructor(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BOOL*, HRESULT>)_lpVtbl[53])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_overloadedOperator"/>
+    public HRESULT get_overloadedOperator(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BOOL*, HRESULT>)_lpVtbl[54])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_nested"/>
+    public HRESULT get_nested(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BOOL*, HRESULT>)_lpVtbl[55])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasNestedTypes"/>
+    public HRESULT get_hasNestedTypes(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BOOL*, HRESULT>)_lpVtbl[56])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasAssignmentOperator"/>
+    public HRESULT get_hasAssignmentOperator(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BOOL*, HRESULT>)_lpVtbl[57])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasCastOperator"/>
+    public HRESULT get_hasCastOperator(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BOOL*, HRESULT>)_lpVtbl[58])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_scoped"/>
+    public HRESULT get_scoped(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BOOL*, HRESULT>)_lpVtbl[59])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_virtualBaseClass"/>
+    public HRESULT get_virtualBaseClass(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BOOL*, HRESULT>)_lpVtbl[60])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_indirectVirtualBaseClass"/>
+    public HRESULT get_indirectVirtualBaseClass(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BOOL*, HRESULT>)_lpVtbl[61])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_virtualBasePointerOffset"/>
+    public HRESULT get_virtualBasePointerOffset(int* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, int*, HRESULT>)_lpVtbl[62])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_virtualTableShape"/>
+    public HRESULT get_virtualTableShape(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, IDiaSymbol**, HRESULT>)_lpVtbl[63])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_lexicalParentId"/>
+    public HRESULT get_lexicalParentId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint*, HRESULT>)_lpVtbl[64])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_classParentId"/>
+    public HRESULT get_classParentId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint*, HRESULT>)_lpVtbl[65])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_typeId"/>
+    public HRESULT get_typeId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint*, HRESULT>)_lpVtbl[66])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_arrayIndexTypeId"/>
+    public HRESULT get_arrayIndexTypeId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint*, HRESULT>)_lpVtbl[67])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_virtualTableShapeId"/>
+    public HRESULT get_virtualTableShapeId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint*, HRESULT>)_lpVtbl[68])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_code"/>
+    public HRESULT get_code(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BOOL*, HRESULT>)_lpVtbl[69])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_function"/>
+    public HRESULT get_function(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BOOL*, HRESULT>)_lpVtbl[70])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_managed"/>
+    public HRESULT get_managed(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BOOL*, HRESULT>)_lpVtbl[71])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_msil"/>
+    public HRESULT get_msil(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BOOL*, HRESULT>)_lpVtbl[72])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_virtualBaseDispIndex"/>
+    public HRESULT get_virtualBaseDispIndex(uint* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint*, HRESULT>)_lpVtbl[73])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_undecoratedName"/>
+    public HRESULT get_undecoratedName(BSTR* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BSTR*, HRESULT>)_lpVtbl[74])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_age"/>
+    public HRESULT get_age(uint* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint*, HRESULT>)_lpVtbl[75])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_signature"/>
+    public HRESULT get_signature(uint* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint*, HRESULT>)_lpVtbl[76])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_compilerGenerated"/>
+    public HRESULT get_compilerGenerated(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BOOL*, HRESULT>)_lpVtbl[77])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_addressTaken"/>
+    public HRESULT get_addressTaken(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BOOL*, HRESULT>)_lpVtbl[78])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_rank"/>
+    public HRESULT get_rank(uint* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint*, HRESULT>)_lpVtbl[79])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_lowerBound"/>
+    public HRESULT get_lowerBound(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, IDiaSymbol**, HRESULT>)_lpVtbl[80])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_upperBound"/>
+    public HRESULT get_upperBound(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, IDiaSymbol**, HRESULT>)_lpVtbl[81])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_lowerBoundId"/>
+    public HRESULT get_lowerBoundId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint*, HRESULT>)_lpVtbl[82])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_upperBoundId"/>
+    public HRESULT get_upperBoundId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint*, HRESULT>)_lpVtbl[83])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_dataBytes"/>
+    public HRESULT get_dataBytes(uint cbData, uint* pcbData, byte* pbData)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint, uint*, byte*, HRESULT>)_lpVtbl[84])(pThis, cbData, pcbData, pbData);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findChildren"/>
+    public HRESULT findChildren(SymTagEnum symtag, PCWSTR name, uint compareFlags, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, SymTagEnum, PCWSTR, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[85])(pThis, symtag, name, compareFlags, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findChildrenEx"/>
+    public HRESULT findChildrenEx(SymTagEnum symtag, PCWSTR name, uint compareFlags, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, SymTagEnum, PCWSTR, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[86])(pThis, symtag, name, compareFlags, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findChildrenExByAddr"/>
+    public HRESULT findChildrenExByAddr(SymTagEnum symtag, PCWSTR name, uint compareFlags, uint isect, uint offset, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, SymTagEnum, PCWSTR, uint, uint, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[87])(pThis, symtag, name, compareFlags, isect, offset, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findChildrenExByVA"/>
+    public HRESULT findChildrenExByVA(SymTagEnum symtag, PCWSTR name, uint compareFlags, ulong va, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, SymTagEnum, PCWSTR, uint, ulong, IDiaEnumSymbols**, HRESULT>)_lpVtbl[88])(pThis, symtag, name, compareFlags, va, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findChildrenExByRVA"/>
+    public HRESULT findChildrenExByRVA(SymTagEnum symtag, PCWSTR name, uint compareFlags, uint rva, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, SymTagEnum, PCWSTR, uint, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[89])(pThis, symtag, name, compareFlags, rva, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_targetSection"/>
+    public HRESULT get_targetSection(uint* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint*, HRESULT>)_lpVtbl[90])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_targetOffset"/>
+    public HRESULT get_targetOffset(uint* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint*, HRESULT>)_lpVtbl[91])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_targetRelativeVirtualAddress"/>
+    public HRESULT get_targetRelativeVirtualAddress(uint* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint*, HRESULT>)_lpVtbl[92])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_targetVirtualAddress"/>
+    public HRESULT get_targetVirtualAddress(ulong* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, ulong*, HRESULT>)_lpVtbl[93])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_machineType"/>
+    public HRESULT get_machineType(uint* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint*, HRESULT>)_lpVtbl[94])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_oemId"/>
+    public HRESULT get_oemId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint*, HRESULT>)_lpVtbl[95])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_oemSymbolId"/>
+    public HRESULT get_oemSymbolId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint*, HRESULT>)_lpVtbl[96])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_types"/>
+    public HRESULT get_types(uint cTypes, uint* pcTypes, IDiaSymbol** pTypes)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint, uint*, IDiaSymbol**, HRESULT>)_lpVtbl[97])(pThis, cTypes, pcTypes, pTypes);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_typeIds"/>
+    public HRESULT get_typeIds(uint cTypeIds, uint* pcTypeIds, uint* pdwTypeIds)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint, uint*, uint*, HRESULT>)_lpVtbl[98])(pThis, cTypeIds, pcTypeIds, pdwTypeIds);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_objectPointerType"/>
+    public HRESULT get_objectPointerType(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, IDiaSymbol**, HRESULT>)_lpVtbl[99])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_udtKind"/>
+    public HRESULT get_udtKind(uint* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint*, HRESULT>)_lpVtbl[100])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_undecoratedNameEx"/>
+    public HRESULT get_undecoratedNameEx(uint undecorateOptions, BSTR* name)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint, BSTR*, HRESULT>)_lpVtbl[101])(pThis, undecorateOptions, name);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_noReturn"/>
+    public HRESULT get_noReturn(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BOOL*, HRESULT>)_lpVtbl[102])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_customCallingConvention"/>
+    public HRESULT get_customCallingConvention(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BOOL*, HRESULT>)_lpVtbl[103])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_noInline"/>
+    public HRESULT get_noInline(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BOOL*, HRESULT>)_lpVtbl[104])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_optimizedCodeDebugInfo"/>
+    public HRESULT get_optimizedCodeDebugInfo(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BOOL*, HRESULT>)_lpVtbl[105])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_notReached"/>
+    public HRESULT get_notReached(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BOOL*, HRESULT>)_lpVtbl[106])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_interruptReturn"/>
+    public HRESULT get_interruptReturn(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BOOL*, HRESULT>)_lpVtbl[107])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_farReturn"/>
+    public HRESULT get_farReturn(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BOOL*, HRESULT>)_lpVtbl[108])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isStatic"/>
+    public HRESULT get_isStatic(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BOOL*, HRESULT>)_lpVtbl[109])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasDebugInfo"/>
+    public HRESULT get_hasDebugInfo(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BOOL*, HRESULT>)_lpVtbl[110])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isLTCG"/>
+    public HRESULT get_isLTCG(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BOOL*, HRESULT>)_lpVtbl[111])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isDataAligned"/>
+    public HRESULT get_isDataAligned(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BOOL*, HRESULT>)_lpVtbl[112])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasSecurityChecks"/>
+    public HRESULT get_hasSecurityChecks(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BOOL*, HRESULT>)_lpVtbl[113])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_compilerName"/>
+    public HRESULT get_compilerName(BSTR* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BSTR*, HRESULT>)_lpVtbl[114])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasAlloca"/>
+    public HRESULT get_hasAlloca(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BOOL*, HRESULT>)_lpVtbl[115])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasSetJump"/>
+    public HRESULT get_hasSetJump(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BOOL*, HRESULT>)_lpVtbl[116])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasLongJump"/>
+    public HRESULT get_hasLongJump(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BOOL*, HRESULT>)_lpVtbl[117])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasInlAsm"/>
+    public HRESULT get_hasInlAsm(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BOOL*, HRESULT>)_lpVtbl[118])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasEH"/>
+    public HRESULT get_hasEH(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BOOL*, HRESULT>)_lpVtbl[119])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasSEH"/>
+    public HRESULT get_hasSEH(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BOOL*, HRESULT>)_lpVtbl[120])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasEHa"/>
+    public HRESULT get_hasEHa(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BOOL*, HRESULT>)_lpVtbl[121])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isNaked"/>
+    public HRESULT get_isNaked(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BOOL*, HRESULT>)_lpVtbl[122])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isAggregated"/>
+    public HRESULT get_isAggregated(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BOOL*, HRESULT>)_lpVtbl[123])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isSplitted"/>
+    public HRESULT get_isSplitted(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BOOL*, HRESULT>)_lpVtbl[124])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_container"/>
+    public HRESULT get_container(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, IDiaSymbol**, HRESULT>)_lpVtbl[125])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_inlSpec"/>
+    public HRESULT get_inlSpec(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BOOL*, HRESULT>)_lpVtbl[126])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_noStackOrdering"/>
+    public HRESULT get_noStackOrdering(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BOOL*, HRESULT>)_lpVtbl[127])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_virtualBaseTableType"/>
+    public HRESULT get_virtualBaseTableType(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, IDiaSymbol**, HRESULT>)_lpVtbl[128])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasManagedCode"/>
+    public HRESULT get_hasManagedCode(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BOOL*, HRESULT>)_lpVtbl[129])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isHotpatchable"/>
+    public HRESULT get_isHotpatchable(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BOOL*, HRESULT>)_lpVtbl[130])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isCVTCIL"/>
+    public HRESULT get_isCVTCIL(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BOOL*, HRESULT>)_lpVtbl[131])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isMSILNetmodule"/>
+    public HRESULT get_isMSILNetmodule(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BOOL*, HRESULT>)_lpVtbl[132])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isCTypes"/>
+    public HRESULT get_isCTypes(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BOOL*, HRESULT>)_lpVtbl[133])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isStripped"/>
+    public HRESULT get_isStripped(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BOOL*, HRESULT>)_lpVtbl[134])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_frontEndQFE"/>
+    public HRESULT get_frontEndQFE(uint* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint*, HRESULT>)_lpVtbl[135])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_backEndQFE"/>
+    public HRESULT get_backEndQFE(uint* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint*, HRESULT>)_lpVtbl[136])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_wasInlined"/>
+    public HRESULT get_wasInlined(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BOOL*, HRESULT>)_lpVtbl[137])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_strictGSCheck"/>
+    public HRESULT get_strictGSCheck(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BOOL*, HRESULT>)_lpVtbl[138])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isCxxReturnUdt"/>
+    public HRESULT get_isCxxReturnUdt(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BOOL*, HRESULT>)_lpVtbl[139])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isConstructorVirtualBase"/>
+    public HRESULT get_isConstructorVirtualBase(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BOOL*, HRESULT>)_lpVtbl[140])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_RValueReference"/>
+    public HRESULT get_RValueReference(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BOOL*, HRESULT>)_lpVtbl[141])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_unmodifiedType"/>
+    public HRESULT get_unmodifiedType(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, IDiaSymbol**, HRESULT>)_lpVtbl[142])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_framePointerPresent"/>
+    public HRESULT get_framePointerPresent(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BOOL*, HRESULT>)_lpVtbl[143])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isSafeBuffers"/>
+    public HRESULT get_isSafeBuffers(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BOOL*, HRESULT>)_lpVtbl[144])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_intrinsic"/>
+    public HRESULT get_intrinsic(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BOOL*, HRESULT>)_lpVtbl[145])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_sealed"/>
+    public HRESULT get_sealed(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BOOL*, HRESULT>)_lpVtbl[146])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hfaFloat"/>
+    public HRESULT get_hfaFloat(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BOOL*, HRESULT>)_lpVtbl[147])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hfaDouble"/>
+    public HRESULT get_hfaDouble(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BOOL*, HRESULT>)_lpVtbl[148])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_liveRangeStartAddressSection"/>
+    public HRESULT get_liveRangeStartAddressSection(uint* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint*, HRESULT>)_lpVtbl[149])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_liveRangeStartAddressOffset"/>
+    public HRESULT get_liveRangeStartAddressOffset(uint* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint*, HRESULT>)_lpVtbl[150])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_liveRangeStartRelativeVirtualAddress"/>
+    public HRESULT get_liveRangeStartRelativeVirtualAddress(uint* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint*, HRESULT>)_lpVtbl[151])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_countLiveRanges"/>
+    public HRESULT get_countLiveRanges(uint* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint*, HRESULT>)_lpVtbl[152])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_liveRangeLength"/>
+    public HRESULT get_liveRangeLength(ulong* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, ulong*, HRESULT>)_lpVtbl[153])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_offsetInUdt"/>
+    public HRESULT get_offsetInUdt(uint* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint*, HRESULT>)_lpVtbl[154])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_paramBasePointerRegisterId"/>
+    public HRESULT get_paramBasePointerRegisterId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint*, HRESULT>)_lpVtbl[155])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_localBasePointerRegisterId"/>
+    public HRESULT get_localBasePointerRegisterId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint*, HRESULT>)_lpVtbl[156])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isLocationControlFlowDependent"/>
+    public HRESULT get_isLocationControlFlowDependent(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BOOL*, HRESULT>)_lpVtbl[157])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_stride"/>
+    public HRESULT get_stride(uint* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint*, HRESULT>)_lpVtbl[158])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_numberOfRows"/>
+    public HRESULT get_numberOfRows(uint* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint*, HRESULT>)_lpVtbl[159])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_numberOfColumns"/>
+    public HRESULT get_numberOfColumns(uint* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint*, HRESULT>)_lpVtbl[160])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isMatrixRowMajor"/>
+    public HRESULT get_isMatrixRowMajor(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BOOL*, HRESULT>)_lpVtbl[161])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_numericProperties"/>
+    public HRESULT get_numericProperties(uint cnt, uint* pcnt, uint* pProperties)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint, uint*, uint*, HRESULT>)_lpVtbl[162])(pThis, cnt, pcnt, pProperties);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_modifierValues"/>
+    public HRESULT get_modifierValues(uint cnt, uint* pcnt, ushort* pModifiers)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint, uint*, ushort*, HRESULT>)_lpVtbl[163])(pThis, cnt, pcnt, pModifiers);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isReturnValue"/>
+    public HRESULT get_isReturnValue(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BOOL*, HRESULT>)_lpVtbl[164])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isOptimizedAway"/>
+    public HRESULT get_isOptimizedAway(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BOOL*, HRESULT>)_lpVtbl[165])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_builtInKind"/>
+    public HRESULT get_builtInKind(uint* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint*, HRESULT>)_lpVtbl[166])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_registerType"/>
+    public HRESULT get_registerType(uint* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint*, HRESULT>)_lpVtbl[167])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_baseDataSlot"/>
+    public HRESULT get_baseDataSlot(uint* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint*, HRESULT>)_lpVtbl[168])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_baseDataOffset"/>
+    public HRESULT get_baseDataOffset(uint* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint*, HRESULT>)_lpVtbl[169])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_textureSlot"/>
+    public HRESULT get_textureSlot(uint* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint*, HRESULT>)_lpVtbl[170])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_samplerSlot"/>
+    public HRESULT get_samplerSlot(uint* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint*, HRESULT>)_lpVtbl[171])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_uavSlot"/>
+    public HRESULT get_uavSlot(uint* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint*, HRESULT>)_lpVtbl[172])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_sizeInUdt"/>
+    public HRESULT get_sizeInUdt(uint* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint*, HRESULT>)_lpVtbl[173])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_memorySpaceKind"/>
+    public HRESULT get_memorySpaceKind(uint* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint*, HRESULT>)_lpVtbl[174])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_unmodifiedTypeId"/>
+    public HRESULT get_unmodifiedTypeId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint*, HRESULT>)_lpVtbl[175])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_subTypeId"/>
+    public HRESULT get_subTypeId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint*, HRESULT>)_lpVtbl[176])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_subType"/>
+    public HRESULT get_subType(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, IDiaSymbol**, HRESULT>)_lpVtbl[177])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_numberOfModifiers"/>
+    public HRESULT get_numberOfModifiers(uint* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint*, HRESULT>)_lpVtbl[178])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_numberOfRegisterIndices"/>
+    public HRESULT get_numberOfRegisterIndices(uint* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint*, HRESULT>)_lpVtbl[179])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isHLSLData"/>
+    public HRESULT get_isHLSLData(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BOOL*, HRESULT>)_lpVtbl[180])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isPointerToDataMember"/>
+    public HRESULT get_isPointerToDataMember(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BOOL*, HRESULT>)_lpVtbl[181])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isPointerToMemberFunction"/>
+    public HRESULT get_isPointerToMemberFunction(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BOOL*, HRESULT>)_lpVtbl[182])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isSingleInheritance"/>
+    public HRESULT get_isSingleInheritance(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BOOL*, HRESULT>)_lpVtbl[183])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isMultipleInheritance"/>
+    public HRESULT get_isMultipleInheritance(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BOOL*, HRESULT>)_lpVtbl[184])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isVirtualInheritance"/>
+    public HRESULT get_isVirtualInheritance(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BOOL*, HRESULT>)_lpVtbl[185])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_restrictedType"/>
+    public HRESULT get_restrictedType(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BOOL*, HRESULT>)_lpVtbl[186])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isPointerBasedOnSymbolValue"/>
+    public HRESULT get_isPointerBasedOnSymbolValue(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BOOL*, HRESULT>)_lpVtbl[187])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_baseSymbol"/>
+    public HRESULT get_baseSymbol(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, IDiaSymbol**, HRESULT>)_lpVtbl[188])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_baseSymbolId"/>
+    public HRESULT get_baseSymbolId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint*, HRESULT>)_lpVtbl[189])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_objectFileName"/>
+    public HRESULT get_objectFileName(BSTR* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BSTR*, HRESULT>)_lpVtbl[190])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isAcceleratorGroupSharedLocal"/>
+    public HRESULT get_isAcceleratorGroupSharedLocal(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BOOL*, HRESULT>)_lpVtbl[191])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isAcceleratorPointerTagLiveRange"/>
+    public HRESULT get_isAcceleratorPointerTagLiveRange(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BOOL*, HRESULT>)_lpVtbl[192])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isAcceleratorStubFunction"/>
+    public HRESULT get_isAcceleratorStubFunction(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BOOL*, HRESULT>)_lpVtbl[193])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_numberOfAcceleratorPointerTags"/>
+    public HRESULT get_numberOfAcceleratorPointerTags(uint* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint*, HRESULT>)_lpVtbl[194])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isSdl"/>
+    public HRESULT get_isSdl(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BOOL*, HRESULT>)_lpVtbl[195])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isWinRTPointer"/>
+    public HRESULT get_isWinRTPointer(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BOOL*, HRESULT>)_lpVtbl[196])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isRefUdt"/>
+    public HRESULT get_isRefUdt(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BOOL*, HRESULT>)_lpVtbl[197])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isValueUdt"/>
+    public HRESULT get_isValueUdt(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BOOL*, HRESULT>)_lpVtbl[198])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isInterfaceUdt"/>
+    public HRESULT get_isInterfaceUdt(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BOOL*, HRESULT>)_lpVtbl[199])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findInlineFramesByAddr"/>
+    public HRESULT findInlineFramesByAddr(uint isect, uint offset, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[200])(pThis, isect, offset, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findInlineFramesByRVA"/>
+    public HRESULT findInlineFramesByRVA(uint rva, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[201])(pThis, rva, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findInlineFramesByVA"/>
+    public HRESULT findInlineFramesByVA(ulong va, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, ulong, IDiaEnumSymbols**, HRESULT>)_lpVtbl[202])(pThis, va, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findInlineeLines"/>
+    public HRESULT findInlineeLines(IDiaEnumLineNumbers** ppResult)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, IDiaEnumLineNumbers**, HRESULT>)_lpVtbl[203])(pThis, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findInlineeLinesByAddr"/>
+    public HRESULT findInlineeLinesByAddr(uint isect, uint offset, uint length, IDiaEnumLineNumbers** ppResult)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint, uint, uint, IDiaEnumLineNumbers**, HRESULT>)_lpVtbl[204])(pThis, isect, offset, length, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findInlineeLinesByRVA"/>
+    public HRESULT findInlineeLinesByRVA(uint rva, uint length, IDiaEnumLineNumbers** ppResult)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint, uint, IDiaEnumLineNumbers**, HRESULT>)_lpVtbl[205])(pThis, rva, length, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findInlineeLinesByVA"/>
+    public HRESULT findInlineeLinesByVA(ulong va, uint length, IDiaEnumLineNumbers** ppResult)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, ulong, uint, IDiaEnumLineNumbers**, HRESULT>)_lpVtbl[206])(pThis, va, length, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findSymbolsForAcceleratorPointerTag"/>
+    public HRESULT findSymbolsForAcceleratorPointerTag(uint tagValue, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[207])(pThis, tagValue, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findSymbolsByRVAForAcceleratorPointerTag"/>
+    public HRESULT findSymbolsByRVAForAcceleratorPointerTag(uint tagValue, uint rva, IDiaEnumSymbols** ppResult)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint, uint, IDiaEnumSymbols**, HRESULT>)_lpVtbl[208])(pThis, tagValue, rva, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_acceleratorPointerTags"/>
+    public HRESULT get_acceleratorPointerTags(uint cnt, uint* pcnt, uint* pPointerTags)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint, uint*, uint*, HRESULT>)_lpVtbl[209])(pThis, cnt, pcnt, pPointerTags);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.getSrcLineOnTypeDefn"/>
+    public HRESULT getSrcLineOnTypeDefn(IDiaLineNumber** ppResult)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, IDiaLineNumber**, HRESULT>)_lpVtbl[210])(pThis, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isPGO"/>
+    public HRESULT get_isPGO(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BOOL*, HRESULT>)_lpVtbl[211])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasValidPGOCounts"/>
+    public HRESULT get_hasValidPGOCounts(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BOOL*, HRESULT>)_lpVtbl[212])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_isOptimizedForSpeed"/>
+    public HRESULT get_isOptimizedForSpeed(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BOOL*, HRESULT>)_lpVtbl[213])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_PGOEntryCount"/>
+    public HRESULT get_PGOEntryCount(uint* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint*, HRESULT>)_lpVtbl[214])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_PGOEdgeCount"/>
+    public HRESULT get_PGOEdgeCount(uint* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint*, HRESULT>)_lpVtbl[215])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_PGODynamicInstructionCount"/>
+    public HRESULT get_PGODynamicInstructionCount(ulong* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, ulong*, HRESULT>)_lpVtbl[216])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_staticSize"/>
+    public HRESULT get_staticSize(uint* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint*, HRESULT>)_lpVtbl[217])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_finalLiveStaticSize"/>
+    public HRESULT get_finalLiveStaticSize(uint* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint*, HRESULT>)_lpVtbl[218])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_phaseName"/>
+    public HRESULT get_phaseName(BSTR* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BSTR*, HRESULT>)_lpVtbl[219])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_hasControlFlowCheck"/>
+    public HRESULT get_hasControlFlowCheck(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BOOL*, HRESULT>)_lpVtbl[220])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_constantExport"/>
+    public HRESULT get_constantExport(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BOOL*, HRESULT>)_lpVtbl[221])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_dataExport"/>
+    public HRESULT get_dataExport(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BOOL*, HRESULT>)_lpVtbl[222])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_privateExport"/>
+    public HRESULT get_privateExport(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BOOL*, HRESULT>)_lpVtbl[223])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_noNameExport"/>
+    public HRESULT get_noNameExport(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BOOL*, HRESULT>)_lpVtbl[224])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_exportHasExplicitlyAssignedOrdinal"/>
+    public HRESULT get_exportHasExplicitlyAssignedOrdinal(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BOOL*, HRESULT>)_lpVtbl[225])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_exportIsForwarder"/>
+    public HRESULT get_exportIsForwarder(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BOOL*, HRESULT>)_lpVtbl[226])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_ordinal"/>
+    public HRESULT get_ordinal(uint* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint*, HRESULT>)_lpVtbl[227])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_frameSize"/>
+    public HRESULT get_frameSize(uint* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint*, HRESULT>)_lpVtbl[228])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_exceptionHandlerAddressSection"/>
+    public HRESULT get_exceptionHandlerAddressSection(uint* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint*, HRESULT>)_lpVtbl[229])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_exceptionHandlerAddressOffset"/>
+    public HRESULT get_exceptionHandlerAddressOffset(uint* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint*, HRESULT>)_lpVtbl[230])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_exceptionHandlerRelativeVirtualAddress"/>
+    public HRESULT get_exceptionHandlerRelativeVirtualAddress(uint* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint*, HRESULT>)_lpVtbl[231])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_exceptionHandlerVirtualAddress"/>
+    public HRESULT get_exceptionHandlerVirtualAddress(ulong* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, ulong*, HRESULT>)_lpVtbl[232])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.findInputAssemblyFile"/>
+    public HRESULT findInputAssemblyFile(IDiaInputAssemblyFile** ppResult)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, IDiaInputAssemblyFile**, HRESULT>)_lpVtbl[233])(pThis, ppResult);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_characteristics"/>
+    public HRESULT get_characteristics(uint* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint*, HRESULT>)_lpVtbl[234])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_coffGroup"/>
+    public HRESULT get_coffGroup(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, IDiaSymbol**, HRESULT>)_lpVtbl[235])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_bindID"/>
+    public HRESULT get_bindID(uint* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint*, HRESULT>)_lpVtbl[236])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_bindSpace"/>
+    public HRESULT get_bindSpace(uint* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint*, HRESULT>)_lpVtbl[237])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol.Interface.get_bindSlot"/>
+    public HRESULT get_bindSlot(uint* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint*, HRESULT>)_lpVtbl[238])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol2.Interface.get_isObjCClass"/>
+    public HRESULT get_isObjCClass(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BOOL*, HRESULT>)_lpVtbl[239])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol2.Interface.get_isObjCCategory"/>
+    public HRESULT get_isObjCCategory(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BOOL*, HRESULT>)_lpVtbl[240])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol2.Interface.get_isObjCProtocol"/>
+    public HRESULT get_isObjCProtocol(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BOOL*, HRESULT>)_lpVtbl[241])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol3.Interface.get_inlinee"/>
+    public HRESULT get_inlinee(IDiaSymbol** pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, IDiaSymbol**, HRESULT>)_lpVtbl[242])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol3.Interface.get_inlineeId"/>
+    public HRESULT get_inlineeId(uint* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint*, HRESULT>)_lpVtbl[243])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol4.Interface.get_noexcept"/>
+    public HRESULT get_noexcept(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BOOL*, HRESULT>)_lpVtbl[244])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol5.Interface.get_hasAbsoluteAddress"/>
+    public HRESULT get_hasAbsoluteAddress(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BOOL*, HRESULT>)_lpVtbl[245])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol6.Interface.get_isStaticMemberFunc"/>
+    public HRESULT get_isStaticMemberFunc(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BOOL*, HRESULT>)_lpVtbl[246])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol7.Interface.get_isSignRet"/>
+    public HRESULT get_isSignRet(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BOOL*, HRESULT>)_lpVtbl[247])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol8.Interface.get_coroutineKind"/>
+    public HRESULT get_coroutineKind(uint* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint*, HRESULT>)_lpVtbl[248])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol8.Interface.get_associatedSymbolKind"/>
+    public HRESULT get_associatedSymbolKind(uint* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint*, HRESULT>)_lpVtbl[249])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol8.Interface.get_associatedSymbolSection"/>
+    public HRESULT get_associatedSymbolSection(uint* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint*, HRESULT>)_lpVtbl[250])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol8.Interface.get_associatedSymbolOffset"/>
+    public HRESULT get_associatedSymbolOffset(uint* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint*, HRESULT>)_lpVtbl[251])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol8.Interface.get_associatedSymbolRva"/>
+    public HRESULT get_associatedSymbolRva(uint* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint*, HRESULT>)_lpVtbl[252])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="IDiaSymbol8.Interface.get_associatedSymbolAddr"/>
+    public HRESULT get_associatedSymbolAddr(ulong* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, ulong*, HRESULT>)_lpVtbl[253])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_framePadSize"/>
+    public HRESULT get_framePadSize(uint* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint*, HRESULT>)_lpVtbl[254])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_framePadOffset"/>
+    public HRESULT get_framePadOffset(uint* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, uint*, HRESULT>)_lpVtbl[255])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_isRTCs"/>
+    public HRESULT get_isRTCs(BOOL* pRetVal)
+    {
+        fixed (IDiaSymbol9* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaSymbol9*, BOOL*, HRESULT>)_lpVtbl[256])(pThis, pRetVal);
+    }
+
+    /// <summary>
+    ///  Extends IDiaSymbol8 with stack frame padding and runtime check properties.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/visualstudio/debugger/debug-interface-access/idiasymbol9">
+    ///    Official documentation.
+    ///   </see>
+    ///  </para>
+    /// </remarks>
+    [ComImport]
+    [Guid("A89E5969-92A1-4F8A-B704-00121C37ABBB")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    public unsafe interface Interface : IDiaSymbol8.Interface
+    {
+        /// <summary>
+        ///  Stack frame pad size.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_framePadSize(uint* pRetVal);
+
+        /// <summary>
+        ///  Stack frame pad offset.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_framePadOffset(uint* pRetVal);
+
+        /// <summary>
+        ///  Compiled with runtime stack checks.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_isRTCs(BOOL* pRetVal);
+    }
+}

--- a/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaTable.cs
+++ b/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/IDiaTable.cs
@@ -1,0 +1,202 @@
+﻿// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Runtime.InteropServices;
+
+// For some reason the XML comment refs for IUnknown can't be resolved on .NET Framework without
+// explicitly using the fully qualified name, which falls afoul of the simplify warning.
+using ComIUnknown = Windows.Win32.System.Com.IUnknown;
+
+namespace Microsoft.VisualStudio.Debugging.DebugInterfaceAccess;
+
+/// <inheritdoc cref="Interface"/>
+public unsafe struct IDiaTable : IComIID
+{
+    /// <inheritdoc cref="IComIID.Guid"/>
+#pragma warning disable IDE1006 // Naming Styles
+    public static readonly Guid IID_Guid = new(0x4A59FB77, 0xABAC, 0x469B, 0xA3, 0x0B, 0x9E, 0xCC, 0x85, 0xBF, 0xEF, 0x14);
+#pragma warning restore IDE1006
+
+#if NETFRAMEWORK
+    readonly ref readonly Guid IComIID.Guid => ref IID_Guid;
+#else
+    static ref readonly Guid IComIID.Guid
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get
+        {
+            ReadOnlySpan<byte> data =
+            [
+                0x77, 0xFB, 0x59, 0x4A,
+                0xAC, 0xAB,
+                0x9B, 0x46,
+                0xA3, 0x0B, 0x9E, 0xCC, 0x85, 0xBF, 0xEF, 0x14
+            ];
+
+            return ref Unsafe.As<byte, Guid>(ref MemoryMarshal.GetReference(data));
+        }
+    }
+#endif
+
+    private readonly void** _lpVtbl;
+
+    /// <inheritdoc cref="ComIUnknown.QueryInterface(Guid*, void**)"/>
+    public HRESULT QueryInterface(Guid* riid, void** ppvObject)
+    {
+        fixed (IDiaTable* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaTable*, Guid*, void**, HRESULT>)_lpVtbl[0])(pThis, riid, ppvObject);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.AddRef"/>
+    public uint AddRef()
+    {
+        fixed (IDiaTable* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaTable*, uint>)_lpVtbl[1])(pThis);
+    }
+
+    /// <inheritdoc cref="ComIUnknown.Release"/>
+    public uint Release()
+    {
+        fixed (IDiaTable* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaTable*, uint>)_lpVtbl[2])(pThis);
+    }
+
+    /// <inheritdoc cref="Interface.Next"/>
+    public HRESULT Next(uint celt, IUnknown** rgelt, uint* pceltFetched)
+    {
+        fixed (IDiaTable* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaTable*, uint, IUnknown**, uint*, HRESULT>)_lpVtbl[3])(pThis, celt, rgelt, pceltFetched);
+    }
+
+    /// <inheritdoc cref="Interface.Skip"/>
+    public HRESULT Skip(uint celt)
+    {
+        fixed (IDiaTable* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaTable*, uint, HRESULT>)_lpVtbl[4])(pThis, celt);
+    }
+
+    /// <inheritdoc cref="Interface.Reset"/>
+    public HRESULT Reset()
+    {
+        fixed (IDiaTable* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaTable*, HRESULT>)_lpVtbl[5])(pThis);
+    }
+
+    /// <inheritdoc cref="Interface.Clone"/>
+    public HRESULT Clone(IEnumUnknown** ppenum)
+    {
+        fixed (IDiaTable* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaTable*, IEnumUnknown**, HRESULT>)_lpVtbl[6])(pThis, ppenum);
+    }
+
+    /// <inheritdoc cref="Interface.get__NewEnum"/>
+    public HRESULT get__NewEnum(IUnknown** pRetVal)
+    {
+        fixed (IDiaTable* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaTable*, IUnknown**, HRESULT>)_lpVtbl[7])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_name"/>
+    public HRESULT get_name(BSTR* pRetVal)
+    {
+        fixed (IDiaTable* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaTable*, BSTR*, HRESULT>)_lpVtbl[8])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.get_Count"/>
+    public HRESULT get_Count(int* pRetVal)
+    {
+        fixed (IDiaTable* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaTable*, int*, HRESULT>)_lpVtbl[9])(pThis, pRetVal);
+    }
+
+    /// <inheritdoc cref="Interface.Item"/>
+    public HRESULT Item(uint index, IUnknown** element)
+    {
+        fixed (IDiaTable* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IDiaTable*, uint, IUnknown**, HRESULT>)_lpVtbl[10])(pThis, index, element);
+    }
+
+    /// <summary>
+    ///  Provides access to one of the various tables contained in the DIA data source.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/visualstudio/debugger/debug-interface-access/idiatable">
+    ///    Official documentation.
+    ///   </see>
+    ///  </para>
+    /// </remarks>
+    [ComImport]
+    [Guid("4A59FB77-ABAC-469B-A30B-9ECC85BFEF14")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    public unsafe interface Interface
+    {
+        /// <summary>
+        ///  Retrieves the next item or items in the enumeration sequence.
+        /// </summary>
+        /// <param name="celt">The number of items to retrieve.</param>
+        /// <param name="rgelt">Pointer to a variable that receives the requested object.</param>
+        /// <param name="pceltFetched">Pointer to a variable that receives the number of items actually retrieved.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT Next(uint celt, IUnknown** rgelt, uint* pceltFetched);
+
+        /// <summary>
+        ///  Skips a specified number of items in the enumeration sequence.
+        /// </summary>
+        /// <param name="celt">The number of items to retrieve.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT Skip(uint celt);
+
+        /// <summary>
+        ///  Resets the enumeration sequence to the beginning.
+        /// </summary>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT Reset();
+
+        /// <summary>
+        ///  Creates an enumerator that contains the same enumeration state as the current enumerator.
+        /// </summary>
+        /// <param name="ppenum">Pointer to a variable that receives the cloned enumerator.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT Clone(IEnumUnknown** ppenum);
+
+        /// <summary>
+        ///  Retrieves a version of this enumerator as a COM <c>IEnumVARIANT</c> enumerator.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get__NewEnum(IUnknown** pRetVal);
+
+        /// <summary>
+        ///  Table name.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_name(BSTR* pRetVal);
+
+        /// <summary>
+        ///  Number of table entries.
+        /// </summary>
+        /// <param name="pRetVal">Pointer to a variable that receives the value.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT get_Count(int* pRetVal);
+
+        /// <summary>
+        ///  Returns the table element for the given index.
+        /// </summary>
+        /// <param name="index">The zero-based index of the item to retrieve.</param>
+        /// <param name="element">Pointer to a variable that receives the requested object.</param>
+        /// <returns>Standard <see cref="HRESULT"/> indicating success or failure.</returns>
+        [PreserveSig]
+        HRESULT Item(uint index, IUnknown** element);
+    }
+}

--- a/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/MemoryTypeEnum.cs
+++ b/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/MemoryTypeEnum.cs
@@ -1,0 +1,26 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace Microsoft.VisualStudio.Debugging.DebugInterfaceAccess;
+
+/// <summary>
+///  Specifies the kind of memory to read during a stack walk.
+/// </summary>
+public enum MemoryTypeEnum
+{
+    /// <summary>Read-only code memory.</summary>
+    MemTypeCode = 0,
+
+    /// <summary>Read-only data or stack memory.</summary>
+    MemTypeData = 1,
+
+    /// <summary>Read-only stack memory.</summary>
+    MemTypeStack = 2,
+
+    /// <summary>Read-only memory for code generated on the heap by the runtime.</summary>
+    MemTypeCodeOnHeap = 3,
+
+    /// <summary>Any of the available memory types.</summary>
+    MemTypeAny = -1
+}

--- a/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/SymTagEnum.cs
+++ b/vsinterop/Microsoft/VisualStudio/Debugging/DebugInterfaceAccess/SymTagEnum.cs
@@ -1,0 +1,153 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace Microsoft.VisualStudio.Debugging.DebugInterfaceAccess;
+
+/// <summary>
+///  Identifies the kind of a symbol (its tag).
+/// </summary>
+/// <remarks>
+///  <para>
+///   <see href="https://learn.microsoft.com/visualstudio/debugger/debug-interface-access/symtagenum">
+///    Official documentation.
+///   </see>
+///  </para>
+/// </remarks>
+public enum SymTagEnum
+{
+    /// <summary>No symbol.</summary>
+    SymTagNull,
+
+    /// <summary>An executable (.exe or .dll) file.</summary>
+    SymTagExe,
+
+    /// <summary>A compiland (the result of compiling a single source file).</summary>
+    SymTagCompiland,
+
+    /// <summary>Details about a compiland.</summary>
+    SymTagCompilandDetails,
+
+    /// <summary>The environment of a compiland.</summary>
+    SymTagCompilandEnv,
+
+    /// <summary>A function.</summary>
+    SymTagFunction,
+
+    /// <summary>A lexical block of code.</summary>
+    SymTagBlock,
+
+    /// <summary>Data.</summary>
+    SymTagData,
+
+    /// <summary>An annotation.</summary>
+    SymTagAnnotation,
+
+    /// <summary>A label.</summary>
+    SymTagLabel,
+
+    /// <summary>A public symbol.</summary>
+    SymTagPublicSymbol,
+
+    /// <summary>A user-defined type (UDT).</summary>
+    SymTagUDT,
+
+    /// <summary>An enumeration.</summary>
+    SymTagEnum,
+
+    /// <summary>A function signature type.</summary>
+    SymTagFunctionType,
+
+    /// <summary>A pointer type.</summary>
+    SymTagPointerType,
+
+    /// <summary>An array type.</summary>
+    SymTagArrayType,
+
+    /// <summary>A base (intrinsic) type.</summary>
+    SymTagBaseType,
+
+    /// <summary>A typedef.</summary>
+    SymTagTypedef,
+
+    /// <summary>A base class.</summary>
+    SymTagBaseClass,
+
+    /// <summary>A friend.</summary>
+    SymTagFriend,
+
+    /// <summary>A function argument type.</summary>
+    SymTagFunctionArgType,
+
+    /// <summary>The start of a function's debug range.</summary>
+    SymTagFuncDebugStart,
+
+    /// <summary>The end of a function's debug range.</summary>
+    SymTagFuncDebugEnd,
+
+    /// <summary>A namespace introduced by a using directive.</summary>
+    SymTagUsingNamespace,
+
+    /// <summary>The shape of a virtual table.</summary>
+    SymTagVTableShape,
+
+    /// <summary>A virtual table.</summary>
+    SymTagVTable,
+
+    /// <summary>A custom symbol.</summary>
+    SymTagCustom,
+
+    /// <summary>A thunk.</summary>
+    SymTagThunk,
+
+    /// <summary>A custom type.</summary>
+    SymTagCustomType,
+
+    /// <summary>A managed type.</summary>
+    SymTagManagedType,
+
+    /// <summary>A FORTRAN multi-dimensional array dimension.</summary>
+    SymTagDimension,
+
+    /// <summary>A call site.</summary>
+    SymTagCallSite,
+
+    /// <summary>An inline site.</summary>
+    SymTagInlineSite,
+
+    /// <summary>A base interface.</summary>
+    SymTagBaseInterface,
+
+    /// <summary>A vector type.</summary>
+    SymTagVectorType,
+
+    /// <summary>A matrix type.</summary>
+    SymTagMatrixType,
+
+    /// <summary>An HLSL type.</summary>
+    SymTagHLSLType,
+
+    /// <summary>A caller.</summary>
+    SymTagCaller,
+
+    /// <summary>A callee.</summary>
+    SymTagCallee,
+
+    /// <summary>An export.</summary>
+    SymTagExport,
+
+    /// <summary>A heap allocation site.</summary>
+    SymTagHeapAllocationSite,
+
+    /// <summary>A COFF group.</summary>
+    SymTagCoffGroup,
+
+    /// <summary>An inlinee.</summary>
+    SymTagInlinee,
+
+    /// <summary>A case of a tagged union UDT type.</summary>
+    SymTagTaggedUnionCase,
+
+    /// <summary>The number of valid symbol tags.</summary>
+    SymTagMax
+}

--- a/vsinterop/NativeMethods.txt
+++ b/vsinterop/NativeMethods.txt
@@ -1,0 +1,3 @@
+IEnumUnknown
+IEnumSTATPROPSTG
+PROPSPEC

--- a/vsinterop/Windows/Win32/System/Com/IEnumUnknown.cs
+++ b/vsinterop/Windows/Win32/System/Com/IEnumUnknown.cs
@@ -1,0 +1,24 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+// CsWin32 attaches the IComIID interface (with a static-abstract Guid) to generated COM structs
+// only on .NET 7 and later. On .NET Framework we ship this instance-based partial so the generated
+// type can be used through ComScope<T> and IID.Get<T>(), mirroring Madowaku's per-struct polyfills.
+#if NETFRAMEWORK
+
+namespace Windows.Win32.System.Com;
+
+/// <summary>
+///  Enumerates a sequence of COM objects.
+/// </summary>
+public partial struct IEnumUnknown : IComIID
+{
+    readonly ref readonly Guid IComIID.Guid
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => ref Unsafe.AsRef(in IID_Guid);
+    }
+}
+
+#endif

--- a/vsinterop/Windows/Win32/System/Com/StructuredStorage/IEnumSTATPROPSTG.cs
+++ b/vsinterop/Windows/Win32/System/Com/StructuredStorage/IEnumSTATPROPSTG.cs
@@ -1,0 +1,24 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+// CsWin32 attaches the IComIID interface (with a static-abstract Guid) to generated COM structs
+// only on .NET 7 and later. On .NET Framework we ship this instance-based partial so the generated
+// type can be used through ComScope<T> and IID.Get<T>(), mirroring Madowaku's per-struct polyfills.
+#if NETFRAMEWORK
+
+namespace Windows.Win32.System.Com.StructuredStorage;
+
+/// <summary>
+///  Enumerates an array of <c>STATPROPSTG</c> structures describing the properties in a property set.
+/// </summary>
+public partial struct IEnumSTATPROPSTG : IComIID
+{
+    readonly ref readonly Guid IComIID.Guid
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => ref Unsafe.AsRef(in IID_Guid);
+    }
+}
+
+#endif


### PR DESCRIPTION
## Summary

Adds struct-based COM wrappers for the **Debug Interface Access (DIA) SDK** in the new `Microsoft.VisualStudio.Debugging.DebugInterfaceAccess` namespace, following the same pattern as the existing VS Setup interfaces: an `IComIID` struct with a nested `[ComImport] Interface`, a dual `NETFRAMEWORK`/static IID implementation, and `delegate* unmanaged[Stdcall]` vtable calls.

All 54 interfaces from `dia2` are covered, plus the supporting enums (`SymTagEnum`, `MemoryTypeEnum`, `CV_CPU_TYPE_e`) and structs (`DiaAddressMapEntry`, `DiaTagValue`). Vtable indices were verified against `dia2.h` for every interface.

## Details

- **Header-sourced documentation.** Member summaries come from the DIA IDL helpstrings, parameter docs from the SAL annotations (`[in]`/`[out, retval]`/`[size_is]`) in `dia2.h`, and the `IDiaSymbol` boolean flags are enriched from the `csymrow.h` field comments in the DIA implementation sources.
- **Real COM types via CsWin32.** `IEnumUnknown`, `PROPSPEC`, and `IEnumSTATPROPSTG` (the types not shipped by Madowaku) are generated through CsWin32 (`NativeMethods.txt`) and aggregate onto Madowaku's existing `Windows.Win32` types. Per-struct `IComIID` polyfills are added under `vsinterop/Windows/...` for the `net472` path, where CsWin32 does not emit the static-abstract IID.
- **`CLASSID` class** with the `DiaSource`, `DiaSourceAlt`, and `DiaStackWalker` CLSIDs (verified from `dia2.h`).
- **Tests.** Reference the [Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles](https://www.nuget.org/packages/Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles) package for the native `msdia140.dll` binaries, copy the architecture-specific binaries next to the test assembly, and load the correct one directly via Madowaku's `ComClassFactory`. The tests exercise the full create → `loadDataFromPdb` → `openSession` → global scope / compiland / table pipeline against the test assembly's own PDB.

## Validation

- Library builds clean (0 warnings / 0 errors) on `net10.0-windows`, `net10.0`, and `net472`.
- 11/11 tests pass on both `net10.0-windows` and `net472`.